### PR TITLE
 Adds option to read initial temp and salt from separate files

### DIFF
--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -15,6 +15,11 @@ module ocn_comp_mct
    use seq_cdata_mod
    use mct_mod
 
+  ! From MOM6
+  use ocean_model_mod, only: ocean_state_type, ocean_public_type
+  use ocean_model_mod, only: ocean_model_init
+  use MOM_time_manager, only: time_type, set_date, set_calendar_type, THIRTY_DAY_MONTHS
+  use MOM_domains, only: MOM_infra_init
 !
 ! !PUBLIC MEMBER FUNCTIONS:
   implicit none
@@ -34,6 +39,8 @@ module ocn_comp_mct
 
 !
 ! !PRIVATE MODULE VARIABLES
+ type(ocean_state_type), pointer  :: ocn_state => NULL()   ! Private state of ocean
+ type(ocean_public_type), pointer :: ocn_surface => NULL() ! Public surface state of ocean
 
 !=======================================================================
 
@@ -52,10 +59,10 @@ contains
 !
 ! !INPUT/OUTPUT PARAMETERS:
 
-    type(ESMF_Clock)            , intent(inout) :: EClock
-    type(seq_cdata)             , intent(inout) :: cdata_o
-    type(mct_aVect)             , intent(inout) :: x2o_o, o2x_o
-    character(len=*), optional  , intent(in)    :: NLFilename ! Namelist filename
+  type(ESMF_Clock)            , intent(inout) :: EClock
+  type(seq_cdata)             , intent(inout) :: cdata_o
+  type(mct_aVect)             , intent(inout) :: x2o_o, o2x_o
+  character(len=*), optional  , intent(in)    :: NLFilename ! Namelist filename
 !
 ! !REVISION HISTORY:
 ! Author: Mariana Vertenstein
@@ -65,7 +72,28 @@ contains
 !  local variables
 !
 !-----------------------------------------------------------------------
+  type(time_type)     :: time_init ! Start time of coupled model's calendar
+  type(time_type)     :: time_in   ! Start time for ocean model at initialization
+  type(ESMF_time)     :: current_time
+  integer             :: year, month, day, hour, minute, seconds, rc
+  character(len=128)  :: errMsg
+  integer             :: mpicom
 
+  mpicom = cdata_o%mpicom
+
+  call MOM_infra_init(mpicom)
+
+  call ESMF_ClockGet(EClock, currTime=current_time, rc=rc) 
+
+  call ESMF_TimeGet(current_time, yy=year, mm=month, dd=day, h=hour, m=minute, s=seconds, rc=rc)
+
+  call set_calendar_type(THIRTY_DAY_MONTHS)
+
+  time_init = set_date(year, month, day, hour, minute, seconds, err_msg=errMsg)
+
+  allocate(ocn_surface)
+
+  !call ocean_model_init(ocn_surface, ocn_state, time_init, time_in)
 
 !-----------------------------------------------------------------------
 !EOC

--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -1,0 +1,140 @@
+module ocn_comp_mct
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!BOP
+! !MODULE: ocn_comp_mct
+! !INTERFACE:
+
+! !DESCRIPTION:
+!  This is the main driver for the MOM6 in CIME
+!
+! !REVISION HISTORY:
+!
+! !USES:
+   use esmf
+   use seq_cdata_mod
+   use mct_mod
+
+!
+! !PUBLIC MEMBER FUNCTIONS:
+  implicit none
+  public :: ocn_init_mct
+  public :: ocn_run_mct
+  public :: ocn_final_mct
+  private                              ! By default make data private
+
+!
+! ! PUBLIC DATA:
+!
+! !REVISION HISTORY:
+! Author: Mariana Vertenstein
+!
+!EOP
+! !PRIVATE MODULE FUNCTIONS:
+
+!
+! !PRIVATE MODULE VARIABLES
+
+!=======================================================================
+
+contains
+
+!***********************************************************************
+!BOP
+!
+! !IROUTINE: ocn_init_mct
+!
+! !INTERFACE:
+  subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
+!
+! !DESCRIPTION:
+! Initialize POP 
+!
+! !INPUT/OUTPUT PARAMETERS:
+
+    type(ESMF_Clock)            , intent(inout) :: EClock
+    type(seq_cdata)             , intent(inout) :: cdata_o
+    type(mct_aVect)             , intent(inout) :: x2o_o, o2x_o
+    character(len=*), optional  , intent(in)    :: NLFilename ! Namelist filename
+!
+! !REVISION HISTORY:
+! Author: Mariana Vertenstein
+!EOP
+!-----------------------------------------------------------------------
+!
+!  local variables
+!
+!-----------------------------------------------------------------------
+
+
+!-----------------------------------------------------------------------
+!EOC
+
+ end subroutine ocn_init_mct
+
+!***********************************************************************
+!BOP
+!
+! !IROUTINE: ocn_run_mct
+!
+! !INTERFACE:
+  subroutine ocn_run_mct( EClock, cdata_o, x2o_o, o2x_o)
+!
+! !DESCRIPTION:
+! Run POP for a coupling interval
+!
+! !INPUT/OUTPUT PARAMETERS:
+    type(ESMF_Clock)            , intent(inout) :: EClock
+    type(seq_cdata)             , intent(inout) :: cdata_o
+    type(mct_aVect)             , intent(inout) :: x2o_o
+    type(mct_aVect)             , intent(inout) :: o2x_o
+
+!
+! !REVISION HISTORY:
+! Author: Mariana Vertenstein
+!EOP
+!-----------------------------------------------------------------------
+!
+!  local variables
+!
+!-----------------------------------------------------------------------
+
+!-----------------------------------------------------------------------
+!EOC
+
+  end subroutine ocn_run_mct
+
+!***********************************************************************
+!BOP
+!
+! !IROUTINE: ocn_final_mct
+!
+! !INTERFACE:
+  subroutine ocn_final_mct( EClock, cdata_o, x2o_o, o2x_o)
+!
+! !DESCRIPTION:
+! Finalize POP
+!
+! !USES:
+! !ARGUMENTS:
+    type(ESMF_Clock)            , intent(inout) :: EClock
+    type(seq_cdata)             , intent(inout) :: cdata_o
+    type(mct_aVect)             , intent(inout) :: x2o_o
+    type(mct_aVect)             , intent(inout) :: o2x_o
+!
+! !REVISION HISTORY:
+! Author: Fei Liu
+!EOP
+!BOC
+!-----------------------------------------------------------------------
+!
+!  local variables
+!
+!-----------------------------------------------------------------------
+
+  end subroutine ocn_final_mct
+
+
+end module ocn_comp_mct
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1053,17 +1053,6 @@ subroutine add_shelf_flux(G, CS, state, fluxes)
       endif
 
 
-      ! Add frazil formation diagnosed by the ocean model (J m-2) in the
-      ! form of surface layer evaporation (kg m-2 s-1). Update lprec in the
-      ! control structure for diagnostic purposes.
-
-      if (associated(state%frazil)) then
-        fraz = state%frazil(i,j) / CS%time_step / CS%Lat_fusion
-        if (associated(fluxes%evap)) fluxes%evap(i,j) = fluxes%evap(i,j) - fraz
-        CS%lprec(i,j)=CS%lprec(i,j) - fraz
-        state%frazil(i,j) = 0.0
-      endif
-
       if (associated(fluxes%sens)) fluxes%sens(i,j) = -frac_area*CS%t_flux(i,j)*CS%flux_factor
       if (associated(fluxes%salt_flux)) fluxes%salt_flux(i,j) = frac_area * CS%salt_flux(i,j)*CS%flux_factor
       if (associated(fluxes%p_surf)) fluxes%p_surf(i,j) = frac_area * CS%g_Earth * CS%mass_shelf(i,j)

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -1648,6 +1648,10 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, dirs)
 
   character(len=200) :: filename   ! The name of an input file containing temperature
                                    ! and salinity in z-space; also used for  ice shelf area.
+  character(len=200) :: tfilename  ! The name of an input file containing only temperature
+                                   ! in z-space.
+  character(len=200) :: sfilename  ! The name of an input file containing only salinity
+                                   ! in z-space.
   character(len=200) :: inputdir ! The directory where NetCDF input files are.
   character(len=200) :: mesg, area_varname, ice_shelf_file
 
@@ -1745,15 +1749,24 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, dirs)
 
   call get_param(PF, mod, "TEMP_SALT_Z_INIT_FILE",filename, &
                  "The name of the z-space input file used to initialize \n"//&
-                 "the layer thicknesses, temperatures and salinities.", &
-                 default="temp_salt_z.nc")
+                 "temperatures (T) and salinities (S). If T and S are not \n" //&
+                 "in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE \n" //&
+                 "must be set.",default="temp_salt_z.nc")
+  call get_param(PF, mod, "TEMP_Z_INIT_FILE",tfilename, &
+                 "The name of the z-space input file used to initialize \n"//&
+                 "temperatures, only.", default=trim(filename))
+  call get_param(PF, mod, "SALT_Z_INIT_FILE",sfilename, &
+                 "The name of the z-space input file used to initialize \n"//&
+                 "temperatures, only.", default=trim(filename))
   filename = trim(inputdir)//trim(filename)
+  tfilename = trim(inputdir)//trim(tfilename)
+  sfilename = trim(inputdir)//trim(sfilename)
   call get_param(PF, mod, "Z_INIT_FILE_PTEMP_VAR", potemp_var, &
                  "The name of the potential temperature variable in \n"//&
-                 "TEMP_SALT_Z_INIT_FILE.", default="ptemp")
+                 "TEMP_Z_INIT_FILE.", default="ptemp")
   call get_param(PF, mod, "Z_INIT_FILE_SALT_VAR", salin_var, &
                  "The name of the salinity variable in \n"//&
-                 "TEMP_SALT_Z_INIT_FILE.", default="salt")
+                 "SALT_Z_INIT_FILE.", default="salt")
   call get_param(PF, mod, "Z_INIT_HOMOGENIZE", homogenize, &
                  "If True, then horizontally homogenize the interpolated \n"//&
                  "initial conditions.", default=.false.)
@@ -1792,10 +1805,10 @@ subroutine MOM_temp_salt_initialize_from_Z(h, tv, G, GV, PF, dirs)
 !   value at the northernmost/southernmost latitude.
 
 
-  call horiz_interp_and_extrap_tracer(filename, potemp_var,1.0,1, &
+  call horiz_interp_and_extrap_tracer(tfilename, potemp_var,1.0,1, &
        G, temp_z, mask_z, z_in, z_edges_in, missing_value_temp, reentrant_x, tripolar_n, homogenize)
 
-  call horiz_interp_and_extrap_tracer(filename, salin_var,1.0,1, &
+  call horiz_interp_and_extrap_tracer(sfilename, salin_var,1.0,1, &
        G, salt_z, mask_z, z_in, z_edges_in, missing_value_salt, reentrant_x, tripolar_n, homogenize)
 
   kd = size(z_in,1)


### PR DESCRIPTION
- This commit adds the option to read initial temperature and salinity fields from separate z-space input files. Before, both T and S had to be in the same file. The input parameter `TEMP_SALT_Z_INIT_FILE` is
 kept, so previous configurations do not to be changed. Two new parameters are introduced:  `TEMP_Z_INIT_FILE` and `SALT_Z_INIT_FILE`.
- Answers should not change.