### PR TITLE
Extend restart options

### DIFF
--- a/config_src/coupled_driver/ocean_model_MOM.F90
+++ b/config_src/coupled_driver/ocean_model_MOM.F90
@@ -28,7 +28,7 @@ use MOM_error_handler, only : MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave
 use MOM_file_parser, only : get_param, log_version, close_param_file, param_file_type
 use MOM_forcing_type, only : forcing, forcing_diagnostics, mech_forcing_diags, forcing_accumulate
-use MOM_get_input, only : Get_MOM_Input, directories
+use MOM_get_input, only : directories
 use MOM_grid, only : ocean_grid_type
 use MOM_io, only : close_file, file_exists, read_data, write_version_number
 use MOM_restart, only : save_restart
@@ -189,7 +189,7 @@ contains
 
 !> ocean_model_init initializes the ocean model, including registering fields
 !! for restarts and reading restart files if appropriate.
-subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
+subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, input_restart_file)
   type(ocean_public_type), target, &
                        intent(inout) :: Ocean_sfc !< A structure containing various
                                 !! publicly visible ocean surface properties after initialization,
@@ -205,6 +205,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
                                               !! in the calculation of additional gas or other
                                               !! tracer fluxes, and can be used to spawn related
                                               !! internal variables in the ice model.
+  character(len=*), optional, intent(in) :: input_restart_file !< If present, name of restart file to read
 
 !   This subroutine initializes both the ocean state and the ocean surface type.
 ! Because of the way that indicies and domains are handled, Ocean_sfc must have
@@ -241,7 +242,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn)
 
   OS%Time = Time_in
   call initialize_MOM(OS%Time, param_file, OS%dirs, OS%MOM_CSp, Time_in, &
-      offline_tracer_mode=offline_tracer_mode)
+      offline_tracer_mode=offline_tracer_mode, input_restart_file=input_restart_file)
   OS%grid => OS%MOM_CSp%G ; OS%GV => OS%MOM_CSp%GV
   OS%C_p = OS%MOM_CSp%tv%C_p
   OS%fluxes%C_p = OS%MOM_CSp%tv%C_p

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1475,7 +1475,7 @@ subroutine step_offline(fluxes, state, Time_start, time_interval, CS)
 end subroutine step_offline
 
 !> This subroutine initializes MOM.
-subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mode)
+subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mode, input_restart_file)
   type(time_type), target,   intent(inout) :: Time        !< model time, set in this routine
   type(param_file_type),     intent(out)   :: param_file  !< structure indicating paramater file to parse
   type(directories),         intent(out)   :: dirs        !< structure with directory paths
@@ -1483,6 +1483,7 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
   type(time_type), optional, intent(in)    :: Time_in     !< time passed to MOM_initialize_state when
                                                           !! model is not being started from a restart file
   logical,         optional, intent(out)   :: offline_tracer_mode !< True if tracers are being run offline
+  character(len=*),optional, intent(in)    :: input_restart_file !< If present, name of restart file to read
 
   ! local
   type(ocean_grid_type),  pointer :: G => NULL() ! A pointer to a structure with metrics and related
@@ -1552,7 +1553,9 @@ subroutine initialize_MOM(Time, param_file, dirs, CS, Time_in, offline_tracer_mo
 
   Start_time = Time ; if (present(Time_in)) Start_time = Time_in
 
-  call Get_MOM_Input(param_file, dirs)
+  ! Read paths and filenames from namelist and store in "dirs".
+  ! Also open the parsed input parameter file(s) and setup param_file.
+  call get_MOM_input(param_file, dirs, default_input_filename=input_restart_file)
 
   verbosity = 2 ; call read_param(param_file, "VERBOSITY", verbosity)
   call MOM_set_verbosity(verbosity)

--- a/src/framework/MOM_get_input.F90
+++ b/src/framework/MOM_get_input.F90
@@ -30,11 +30,14 @@ contains
 
 !> Get the names of the I/O directories and initialization file.
 !! Also calls the subroutine that opens run-time parameter files.
-subroutine get_MOM_input(param_file, dirs, check_params)
+subroutine get_MOM_input(param_file, dirs, check_params, default_input_filename)
   type(param_file_type), optional, intent(out) :: param_file   !< A structure to parse for run-time parameters.
   type(directories),     optional, intent(out) :: dirs         !< Container for paths and parameter file names.
   logical,               optional, intent(in)  :: check_params !< If present and False will stop error checking for
                                                                !! run-time parameters.
+  character(len=*),      optional, intent(in)  :: default_input_filename !< If present, is the value assumed for
+                                                               !! input_filename if input_filename is not listed
+                                                               !! in the namelist MOM_input_nml.
   ! Local variables
   integer, parameter :: npf = 5 ! Maximum number of parameter files
   character(len=240) :: &
@@ -56,6 +59,7 @@ subroutine get_MOM_input(param_file, dirs, check_params)
   restart_input_dir = ' '
   restart_output_dir = ' '
   input_filename  = ' '
+  if (present(default_input_filename)) input_filename = trim(default_input_filename)
 
   ! Open namelist
   if (file_exists('input.nml')) then

--- a/src/framework/MOM_get_input.F90
+++ b/src/framework/MOM_get_input.F90
@@ -1,16 +1,11 @@
+!> \brief Reads the only Fortran name list needed to boot-strap the model.
+!!
+!! The name list parameters indicate which directories to use for
+!! certain types of input and output, and which files to look in for
+!! the full parsable input parameter file(s).
 module MOM_get_input
 
 ! This file is part of MOM6. See LICENSE.md for the license.
-
-!********+*********+*********+*********+*********+*********+*********+**
-!*                                                                     *
-!*  By Robert Hallberg, April 2013                                     *
-!*                                                                     *
-!*    The subroutine in this file reads the MOM6 namelist input, which *
-!*  indicates which directories to use for certain types of input and  *
-!*  output, and where to look for the full parsable input file(s).     *
-!*                                                                     *
-!********+*********+*********+*********+*********+*********+*********+**
 
 use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser, only : open_param_file, param_file_type
@@ -19,30 +14,28 @@ use MOM_io, only : open_namelist_file, check_nml_error
 
 implicit none ; private
 
-public Get_MOM_Input
+public get_MOM_input
 
-! This structure is to simplify communication with the calling code.
-
+!> Container for paths and parameter file names.
 type, public :: directories
   character(len=240) :: &
-    restart_input_dir = ' ',& ! The directory to read restart and input files.
-    restart_output_dir = ' ',&! The directory into which to write restart files.
-    output_directory = ' ', & ! The directory to use to write the model output.
-    input_filename  = ' '     ! A string that indicates the input files or how
-                              ! the run segment should be started.
+    restart_input_dir = ' ',& !< The directory to read restart and input files.
+    restart_output_dir = ' ',&!< The directory into which to write restart files.
+    output_directory = ' ', & !< The directory to use to write the model output.
+    input_filename  = ' '     !< A string that indicates the input files or how
+                              !! the run segment should be started.
 end type directories
 
 contains
 
-subroutine Get_MOM_Input(param_file, dirs, check_params)
-  type(param_file_type), optional, intent(out) :: param_file !< A structure to parse for run-time parameters
-  type(directories),     optional, intent(out) :: dirs
-  logical,               optional, intent(in)  :: check_params
-
-!    See if the run is to be started from saved conditions, and get  !
-!  the names of the I/O directories and initialization file.  This   !
-!  subroutine also calls the subroutine that allows run-time changes !
-!  in parameters.                                                    !
+!> Get the names of the I/O directories and initialization file.
+!! Also calls the subroutine that opens run-time parameter files.
+subroutine get_MOM_input(param_file, dirs, check_params)
+  type(param_file_type), optional, intent(out) :: param_file   !< A structure to parse for run-time parameters.
+  type(directories),     optional, intent(out) :: dirs         !< Container for paths and parameter file names.
+  logical,               optional, intent(in)  :: check_params !< If present and False will stop error checking for
+                                                               !! run-time parameters.
+  ! Local variables
   integer, parameter :: npf = 5 ! Maximum number of parameter files
   character(len=240) :: &
     parameter_filename(npf) = ' ', & ! List of files containing parameters.
@@ -57,18 +50,21 @@ subroutine Get_MOM_Input(param_file, dirs, check_params)
   namelist /MOM_input_nml/ output_directory, input_filename, parameter_filename, &
                            restart_input_dir, restart_output_dir
 
+  ! Open namelist
   if (file_exists('input.nml')) then
     unit = open_namelist_file(file='input.nml')
   else
     call MOM_error(FATAL,'Required namelist file input.nml does not exist.')
   endif
 
+  ! Read namelist parameters
   ierr=1 ; do while (ierr /= 0)
     read(unit, nml=MOM_input_nml, iostat=io, end=10)
     ierr = check_nml_error(io, 'MOM_input_nml')
   enddo
 10 call close_file(unit)
 
+  ! Store parameters in container
   if (present(dirs)) then
     dirs%output_directory = slasher(ensembler(output_directory))
     dirs%restart_output_dir = slasher(ensembler(restart_output_dir))
@@ -76,6 +72,7 @@ subroutine Get_MOM_Input(param_file, dirs, check_params)
     dirs%input_filename = ensembler(input_filename)
   endif
 
+  ! Open run-time parameter file(s)
   if (present(param_file)) then
     output_dir = slasher(ensembler(output_directory))
     valid_param_files = 0
@@ -90,6 +87,6 @@ subroutine Get_MOM_Input(param_file, dirs, check_params)
          "least 1 valid entry in input_filename in MOM_input_nml in input.nml.")
   endif
 
-end subroutine Get_MOM_Input
+end subroutine get_MOM_input
 
 end module MOM_get_input

--- a/src/framework/MOM_get_input.F90
+++ b/src/framework/MOM_get_input.F90
@@ -38,17 +38,24 @@ subroutine get_MOM_input(param_file, dirs, check_params)
   ! Local variables
   integer, parameter :: npf = 5 ! Maximum number of parameter files
   character(len=240) :: &
-    parameter_filename(npf) = ' ', & ! List of files containing parameters.
-    output_directory = ' ', &   ! Directory to use to write the model output.
-    restart_input_dir = ' ', &  ! Directory for reading restart and input files.
-    restart_output_dir = ' ', & ! Directory into which to write restart files.
-    input_filename  = ' '       ! A string that indicates the input files or how
-                                ! the run segment should be started.
+    parameter_filename(npf), & ! List of files containing parameters.
+    output_directory,        & ! Directory to use to write the model output.
+    restart_input_dir,       & ! Directory for reading restart and input files.
+    restart_output_dir,      & ! Directory into which to write restart files.
+    input_filename             ! A string that indicates the input files or how
+                               ! the run segment should be started.
   character(len=240) :: output_dir
   integer :: unit, io, ierr, valid_param_files
 
   namelist /MOM_input_nml/ output_directory, input_filename, parameter_filename, &
                            restart_input_dir, restart_output_dir
+
+  ! Default values in case parameter is not set in file input.nml
+  parameter_filename(:) = ' '
+  output_directory = ' '
+  restart_input_dir = ' '
+  restart_output_dir = ' '
+  input_filename  = ' '
 
   ! Open namelist
   if (file_exists('input.nml')) then

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -889,7 +889,7 @@ subroutine restore_state(filename, directory, day, G, CS)
 !                 restart_init.
 
   character(len=200) :: filepath  ! The path (dir/file) to the file being opened.
-  character(len=80) :: fname      ! The name of the current file.
+  character(len=200) :: fname     ! The name of the current file.
   character(len=8)  :: suffix     ! A suffix (like "_2") that is added to any
                                   ! additional restart files.
   character(len=256) :: mesg      ! A message for warnings.


### PR DESCRIPTION
Allows coupled driver to specify the restart file via an subroutine argument:
- Some of the changes in this commit are temporary; once the mct_driver   is no longer using ocean_model_MOM.F90, some of the optional arguments   can be removed.
- NCAR's MCT driver specifics the absolute path of a restart file   with a generated name (dates). This commit allows the driver to   override the namelist parameter input_filename.
- To use, set restart_input_dir='/' in input.nml since leaving   restart_input_dir blank automatically replaces it with './'

This involves three commits:
- Most relevant is adcroft/MOM6@aa62808 which allows coupler to provide a filename for the input restart
- adcroft/MOM6@07d0f36 fixes an initialization problem that might break adcroft/MOM6@aa62808
- adcroft/MOM6@a96c4dd documents the code changed before adcroft/MOM6@aa62808

