### PR TITLE
comment out call ocn_domain_mct for 3d to avoid uninitialized vars

### DIFF
--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -580,7 +580,7 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
 
   if (debug .and. root_pe().eq.pe_here()) print *, "calling ocn_domain_mct"
   call ocn_domain_mct(lsize, MOM_MCT_gsmap, MOM_MCT_dom)
-  call ocn_domain_mct(lsize*km, MOM_MCT_gsmap3d, MOM_MCT_dom3d) !TODO: this is not used
+  !call ocn_domain_mct(lsize*km, MOM_MCT_gsmap3d, MOM_MCT_dom3d) !TODO: this is not used
 
   ! Inialize mct attribute vectors
 


### PR DESCRIPTION
Call to ocn_domain_mct for 3D domain is unnecessary and causing the model to fail on hobart due to uninitialized variables for 3D import/export. 
Note: A comprehensive cleanup of ocn_comp_mct.F90 is to come.