### PR TITLE
Fix option to use MatchTechnique = 'MatchBoth' in KPP

### DIFF
--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1,5 +1,5 @@
 !> Provides the K-Profile Parameterization (KPP) of Large et al., 1994, via CVMix.
-module MOM_KPP
+module MOM_CVMix_KPP
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
@@ -186,11 +186,11 @@ logical function KPP_init(paramFile, G, diag, Time, CS, passive, Waves)
 
   ! Local variables
 #include "version_variable.h"
-  character(len=40) :: mdl = 'MOM_KPP' ! name of this module
+  character(len=40) :: mdl = 'MOM_CVMix_KPP' ! name of this module
   character(len=20) :: string          ! local temporary string
   logical :: CS_IS_ONE=.false.         ! Logical for setting Cs based on Non-local
 
-  if (associated(CS)) call MOM_error(FATAL, 'MOM_KPP, KPP_init: '// &
+  if (associated(CS)) call MOM_error(FATAL, 'MOM_CVMix_KPP, KPP_init: '// &
            'Control structure has already been initialized')
   allocate(CS)
 
@@ -848,7 +848,7 @@ subroutine KPP_calculate(CS, G, GV, h, Temp, Salt, u, v, EOS, uStar, &
           enddo
         else
            !This shouldn't be reached.
-           !call MOM_error(WARNING,"Unexpected behavior in MOM_KPP, see error in Vt2")
+           !call MOM_error(WARNING,"Unexpected behavior in MOM_CVMix_KPP, see error in Vt2")
            LangEnhVT2(:) = 1.0
         endif
       else
@@ -925,7 +925,7 @@ subroutine KPP_calculate(CS, G, GV, h, Temp, Salt, u, v, EOS, uStar, &
            LangEnhK = min(2.25, 1. + 1./WAVES%LangNum(i,j))
         else
            !This shouldn't be reached.
-           !call MOM_error(WARNING,"Unexpected behavior in MOM_KPP, see error in LT_K_ENHANCEMENT")
+           !call MOM_error(WARNING,"Unexpected behavior in MOM_CVMix_KPP, see error in LT_K_ENHANCEMENT")
            LangEnhK = 1.0
         endif
         do k=1,G%ke
@@ -1372,7 +1372,7 @@ subroutine KPP_compute_BLD(CS, G, GV, h, Temp, Salt, u, v, EOS, uStar, buoyFlux,
           enddo
         else
            !This shouldn't be reached.
-           !call MOM_error(WARNING,"Unexpected behavior in MOM_KPP, see error in Vt2")
+           !call MOM_error(WARNING,"Unexpected behavior in MOM_CVMix_KPP, see error in Vt2")
            LangEnhVT2(:) = 1.0
         endif
       else
@@ -1426,7 +1426,7 @@ subroutine KPP_compute_BLD(CS, G, GV, h, Temp, Salt, u, v, EOS, uStar, buoyFlux,
 
 ! Following "correction" step has been found to be unnecessary.
 ! Code should be removed after further testing.
-! BGR: 03/15/2018-> Restructured code (Vt2 changed to compute from call in MOM_KPP now)
+! BGR: 03/15/2018-> Restructured code (Vt2 changed to compute from call in MOM_CVMix_KPP now)
 !      I have not taken this restructuring into account here.
 !      Do we ever run with correctSurfLayerAvg?
 !      smg's suggested testing and removal is advised, in the meantime
@@ -1793,4 +1793,4 @@ end subroutine KPP_end
 !!
 !! \sa
 !! kpp_calculate(), kpp_applynonlocaltransport()
-end module MOM_KPP
+end module MOM_CVMix_KPP

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -932,10 +932,10 @@ subroutine KPP_calculate(CS, G, GV, h, Temp, Salt, u, v, EOS, uStar, &
 
       ! safety check, Kviscosity and Kdiffusivity must be >= 0
       do k=1, G%ke+1
-        if (Kviscosity(k) < 0. .or Kdiffusivity(k,1) < 0.) then
-          call MOM_error(FATAL,"KPP_calculate, after CVMix_coeffs_kpp: \n "// &
-                   "Negative vertical viscosity or diffusivity has been detected. \n" // &
-                   "This is likely related to the choice of MATCH_TECHNIQUE and INTERP_TYPE2. \n" //&
+        if (Kviscosity(k) < 0. .or. Kdiffusivity(k,1) < 0.) then
+          call MOM_error(FATAL,"KPP_calculate, after CVMix_coeffs_kpp: "// &
+                   "Negative vertical viscosity or diffusivity has been detected. " // &
+                   "This is likely related to the choice of MATCH_TECHNIQUE and INTERP_TYPE2." //&
                    "You might consider using the default options for these parameters." )
         endif
       enddo

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -50,9 +50,9 @@ use MOM_interface_heights,   only : find_eta
 use MOM_internal_tides,      only : propagate_int_tide
 use MOM_internal_tides,      only : internal_tides_init, internal_tides_end, int_tide_CS
 use MOM_kappa_shear,         only : kappa_shear_is_used
-use MOM_KPP,                 only : KPP_CS, KPP_init, KPP_compute_BLD, KPP_calculate
-use MOM_KPP,                 only : KPP_end, KPP_get_BLD
-use MOM_KPP,                 only : KPP_NonLocalTransport_temp, KPP_NonLocalTransport_saln
+use MOM_CVMix_KPP,           only : KPP_CS, KPP_init, KPP_compute_BLD, KPP_calculate
+use MOM_CVMix_KPP,           only : KPP_end, KPP_get_BLD
+use MOM_CVMix_KPP,           only : KPP_NonLocalTransport_temp, KPP_NonLocalTransport_saln
 use MOM_opacity,             only : opacity_init, set_opacity, opacity_end, opacity_CS
 use MOM_regularize_layers,   only : regularize_layers, regularize_layers_init, regularize_layers_CS
 use MOM_set_diffusivity,     only : set_diffusivity, set_BBL_TKE

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -552,8 +552,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
 
   call cpu_clock_begin(id_clock_set_diffusivity)
   ! Sets: Kd, Kd_int, visc%Kd_extra_T, visc%Kd_extra_S
-  ! Also changes: visc%Kd_shear, visc%TKE_turb (not clear that TKE_turb is used as input ????
-  ! And sets visc%Kv_shear
+  ! Also changes: visc%Kd_shear, visc%Kv_slow and visc%TKE_turb (not clear that TKE_turb is used as input ????
   call set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, CS%optics, visc, dt, G, GV, CS%set_diff_CSp, Kd, Kd_int)
   call cpu_clock_end(id_clock_set_diffusivity)
   if (showCallTree) call callTree_waypoint("done with set_diffusivity (diabatic)")
@@ -591,6 +590,11 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
 
   if (CS%useKPP) then
     call cpu_clock_begin(id_clock_kpp)
+    ! total vertical viscosity in the interior
+    do k=1,nz+1 ; do j=js,je ; do i=is,ie
+      visc%Kv_shear(i,j,k) = visc%Kv_shear(i,j,k) + visc%Kv_slow(i,j,k)
+    enddo ; enddo ; enddo
+
     ! KPP needs the surface buoyancy flux but does not update state variables.
     ! We could make this call higher up to avoid a repeat unpacking of the surface fluxes.
     ! Sets: CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux
@@ -599,9 +603,6 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     call calculateBuoyancyFlux2d(G, GV, fluxes, CS%optics, h, tv%T, tv%S, tv, &
                                  CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux)
     ! The KPP scheme calculates boundary layer diffusivities and non-local transport.
-    ! MOM6 implementation of KPP matches the boundary layer to zero interior diffusivity,
-    ! since the matching to nonzero interior diffusivity can be problematic.
-    ! Changes: Kd_int. Sets: KPP_NLTheat, KPP_NLTscalar
 
     call KPP_compute_BLD(CS%KPP_CSp, G, GV, h, tv%T, tv%S, u, v, tv%eqn_of_state, &
       fluxes%ustar, CS%KPP_buoy_flux)
@@ -609,35 +610,11 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     call KPP_calculate(CS%KPP_CSp, G, GV, h, tv%T, tv%S, u, v, tv%eqn_of_state, &
       fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, Kd_salt, visc%Kv_shear, CS%KPP_NLTheat, &
       CS%KPP_NLTscalar, Waves=Waves)
-!$OMP parallel default(none) shared(is,ie,js,je,nz,Kd_salt,Kd_int,visc,CS,G,Kd_heat,Hml)
 
     if (associated(Hml)) then
       call KPP_get_BLD(CS%KPP_CSp, Hml(:,:), G)
       call pass_var(Hml, G%domain, halo=1)
     endif
-
-! GMM, I believe the following can be deleted???
-    if (.not. CS%KPPisPassive) then
-!$OMP do
-      do k=1,nz+1 ; do j=js,je ; do i=is,ie
-        Kd_int(i,j,k) = min( Kd_salt(i,j,k),  Kd_heat(i,j,k) )
-      enddo ; enddo ; enddo
-      if (associated(visc%Kd_extra_S)) then
-!$OMP do
-        do k=1,nz+1 ; do j=js,je ; do i=is,ie
-          visc%Kd_extra_S(i,j,k) = Kd_salt(i,j,k) - Kd_int(i,j,k)
-        enddo ; enddo ; enddo
-      endif
-      if (associated(visc%Kd_extra_T)) then
-!$OMP do
-        do k=1,nz+1 ; do j=js,je ; do i=is,ie
-          visc%Kd_extra_T(i,j,k) = Kd_heat(i,j,k) - Kd_int(i,j,k)
-        enddo ; enddo ; enddo
-      endif
-    endif ! not passive
-
-!$OMP end parallel
-!!!!!!! delete above ?? !!!!!!!!!!!!!
 
     call cpu_clock_end(id_clock_kpp)
     if (showCallTree) call callTree_waypoint("done with KPP_calculate (diabatic)")
@@ -675,14 +652,8 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     endif
   endif ! endif for KPP
 
-  ! GMM, this is the "old" method for applying differential diffusion.
-  ! TODO\ the following will not work with KPP. We need to add a FATAL
-  ! error to avoid that.
-
+  ! This is the "old" method for applying differential diffusion.
   ! Changes: tv%T, tv%S
-  ! If using matching within the KPP scheme, then this step needs to provide
-  ! a diffusivity and happen before KPP.  But generally in MOM, we do not match
-  ! KPP boundary layer to interior, so this diffusivity can be computed when convenient.
   if (associated(visc%Kd_extra_T) .and. associated(visc%Kd_extra_S) .and. associated(tv%T) .and. .not. &
      CS%use_CVMix_ddiff) then
 
@@ -716,7 +687,11 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
     do k=1,nz+1 ; do j=js,je ; do i=is,ie
       Kd_heat(i,j,k) = Kd_heat(i,j,k) + CS%CVMix_conv_csp%kd_conv(i,j,k)
       Kd_salt(i,j,k) = Kd_salt(i,j,k) + CS%CVMix_conv_csp%kd_conv(i,j,k)
-      visc%Kv_slow(i,j,k) = visc%Kv_slow(i,j,k) + CS%CVMix_conv_csp%kv_conv(i,j,k)
+      if (CS%useKPP) then
+        visc%Kv_shear(i,j,k) = visc%Kv_shear(i,j,k) + CS%CVMix_conv_csp%kv_conv(i,j,k)
+      else
+        visc%Kv_slow(i,j,k) = visc%Kv_slow(i,j,k) + CS%CVMix_conv_csp%kv_conv(i,j,k)
+      endif
     enddo ; enddo ; enddo
 !$OMP end parallel
   endif
@@ -1553,7 +1528,7 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
       fluxes%ustar, CS%KPP_buoy_flux)
 
     call KPP_calculate(CS%KPP_CSp, G, GV, h, tv%T, tv%S, u, v, tv%eqn_of_state, &
-      fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, Kd_salt, visc%Kv_shear, CS%KPP_NLTheat, &
+      fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, Kd_salt, visc%Kv_slow, CS%KPP_NLTheat, &
       CS%KPP_NLTscalar, Waves=Waves)
 !$OMP parallel default(none) shared(is,ie,js,je,nz,Kd_salt,Kd_int,visc,CS,G,Kd_heat,Hml)
 
@@ -3096,6 +3071,12 @@ subroutine diabatic_driver_init(Time, G, GV, param_file, useALEalgorithm, diag, 
     allocate( CS%KPP_buoy_flux(isd:ied,jsd:jed,nz+1) ) ; CS%KPP_buoy_flux(:,:,:) = 0.
     allocate( CS%KPP_temp_flux(isd:ied,jsd:jed) )      ; CS%KPP_temp_flux(:,:)   = 0.
     allocate( CS%KPP_salt_flux(isd:ied,jsd:jed) )      ; CS%KPP_salt_flux(:,:)   = 0.
+  endif
+
+  if (CS%useKPP .and. differentialDiffusion) then
+    call MOM_error(FATAL, 'diabatic_driver_init: '// &
+           'DOUBLE_DIFFUSION (old method) does not work with KPP. Please'//&
+           'set DOUBLE_DIFFUSION=False and USE_CVMIX_DDIFF=True.')
   endif
 
   call get_param(param_file, mod, "SALT_REJECT_BELOW_ML", CS%salt_reject_below_ML, &

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -590,7 +590,7 @@ subroutine diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, &
 
   if (CS%useKPP) then
     call cpu_clock_begin(id_clock_kpp)
-    ! total vertical viscosity in the interior
+    ! total vertical viscosity in the interior is represented via visc%Kv_shear
     do k=1,nz+1 ; do j=js,je ; do i=is,ie
       visc%Kv_shear(i,j,k) = visc%Kv_shear(i,j,k) + visc%Kv_slow(i,j,k)
     enddo ; enddo ; enddo

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1608,9 +1608,6 @@ subroutine legacy_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_en
 
   ! Differential diffusion done here.
   ! Changes: tv%T, tv%S
-  ! If using matching within the KPP scheme, then this step needs to provide
-  ! a diffusivity and happen before KPP.  But generally in MOM, we do not match
-  ! KPP boundary layer to interior, so this diffusivity can be computed when convenient.
   if (associated(visc%Kd_extra_T) .and. associated(visc%Kd_extra_S) .and. associated(tv%T)) then
     call cpu_clock_begin(id_clock_differential_diff)
 

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -180,13 +180,12 @@ contains
 !! 1) Shear-driven mixing: two options, Jackson et at. and KPP interior;
 !! 2) Background mixing via CVMix (Bryan-Lewis profile) or the scheme described by
 !! Harrison & Hallberg, JPO 2008;
-!! 3) Double-diffusion aplpied via CVMix;
+!! 3) Double-diffusion, old method and new method via CVMix;
 !! 4) Tidal mixing: many options available, see MOM_tidal_mixing.F90;
 !! In addition, this subroutine has the option to set the interior vertical
-!! viscosity associated with processes 2-4 listed above, which is stored in
+!! viscosity associated with processes 1,2 and 4 listed above, which is stored in
 !! visc%Kv_slow. Vertical viscosity due to shear-driven mixing is passed via
 !! visc%Kv_shear
-!! GMM, TODO: add contribution from tidal mixing into visc%Kv_slow
 subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
                            G, GV, CS, Kd, Kd_int)
   type(ocean_grid_type),     intent(in)    :: G    !< The ocean's grid structure.

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1834,7 +1834,7 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
   real    :: omega_frac_dflt
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz, i, j, n
   logical :: use_kappa_shear, adiabatic, use_omega
-  logical :: use_CVMix_ddiff, differential_diffusion
+  logical :: use_CVMix_ddiff, differential_diffusion, use_KPP
   type(OBC_segment_type), pointer :: segment  ! pointer to OBC segment type
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
@@ -2000,9 +2000,9 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
                  do_not_log=.true., default=.false.)
 
   if (use_KPP .and. visc%add_Kv_slow) call MOM_error(FATAL,"set_visc_init: "//&
-         "When USE_KPP=True, ADD_KV_SLOW must be false. Otherwise vertical \n"//&
-         "vertical visc. due to slow processes will be double counted. Please set \n"//&
-         "ADD_KV_SLOW=False".)
+         "When USE_KPP=True, ADD_KV_SLOW must be false. Otherwise vertical "//&
+         "viscosity due to slow processes will be double counted. Please set "//&
+         "ADD_KV_SLOW=False.")
 
   call get_param(param_file, mdl, "KV_BBL_MIN", CS%KV_BBL_min, &
                  "The minimum viscosities in the bottom boundary layer.", &

--- a/src/parameterizations/vertical/MOM_set_viscosity.F90
+++ b/src/parameterizations/vertical/MOM_set_viscosity.F90
@@ -1994,6 +1994,16 @@ subroutine set_visc_init(Time, G, GV, param_file, diag, visc, CS, OBC)
                  "be removed in the future since this option should always be true.", &
                   default=.false.)
 
+  call get_param(param_file, mdl, "USE_KPP", use_KPP, &
+                 "If true, turns on the [CVMix] KPP scheme of Large et al., 1994,\n"// &
+                 "to calculate diffusivities and non-local transport in the OBL.",     &
+                 do_not_log=.true., default=.false.)
+
+  if (use_KPP .and. visc%add_Kv_slow) call MOM_error(FATAL,"set_visc_init: "//&
+         "When USE_KPP=True, ADD_KV_SLOW must be false. Otherwise vertical \n"//&
+         "vertical visc. due to slow processes will be double counted. Please set \n"//&
+         "ADD_KV_SLOW=False".)
+
   call get_param(param_file, mdl, "KV_BBL_MIN", CS%KV_BBL_min, &
                  "The minimum viscosities in the bottom boundary layer.", &
                  units="m2 s-1", default=Kv_background)


### PR DESCRIPTION
This PR adds a set of changes that allow MatchTechnique to be set to "MatchBoth" without getting negative viscosity and diffusivity. This was achieved by introducing new input params and setting the default KPP options to be consistent with what is done in POP. 

Additional changes:
* Rename MOM_KPP.F90 -> MOM_CVMix_KPP.F90
* Update MOM_CVMix_shear
* Add FATAL error if USE_KPP=True and ADD_KV_SLOW=True

This PR solves issue #69  

TODO:
MOM_CVMix_shear must be improved, see #70 

