### PR TITLE
finalize FMS diag_manager module when MOM6 finalizes

### DIFF
--- a/config_src/nuopc_driver/MOM_ocean_model.F90
+++ b/config_src/nuopc_driver/MOM_ocean_model.F90
@@ -773,7 +773,7 @@ subroutine ocean_model_end(Ocean_sfc, Ocean_state, Time, write_restart)
   if (write_restart) then
      call ocean_model_save_restart(Ocean_state, Time)
   end if
-  call diag_mediator_end(Time, Ocean_state%diag)
+  call diag_mediator_end(Time, Ocean_state%diag, end_diag_manager=.true.)
   call MOM_end(Ocean_state%MOM_CSp)
   if (Ocean_state%use_ice_shelf) call ice_shelf_end(Ocean_state%Ice_shelf_CSp)
 


### PR DESCRIPTION
Finalize FMS diagnostics module during MOM6 finalization. Otherwise, diagnostics buffers won't be flushed and MOM6 will not write the final set of outputs.