### PR TITLE
Adds missing parameter and fixes a bug

### DIFF
--- a/config_src/mct_driver/ocn_cap_methods.F90
+++ b/config_src/mct_driver/ocn_cap_methods.F90
@@ -82,8 +82,8 @@ contains
         ! surface pressure
         ice_ocean_boundary%p(i,j) = x2o(ind%x2o_Sa_pslv,k) * GRID%mask2dT(ig,jg)
 
-        ! salt flux
-        ice_ocean_boundary%salt_flux(i,j) = x2o(ind%x2o_Fioi_salt,k) * GRID%mask2dT(ig,jg)
+        ! salt flux (minus sign needed here -GMM)
+        ice_ocean_boundary%salt_flux(i,j) = -x2o(ind%x2o_Fioi_salt,k) * GRID%mask2dT(ig,jg)
 
         ! 1) visible, direct shortwave  (W/m2)
         ! 2) visible, diffuse shortwave (W/m2)


### PR DESCRIPTION
* Add option to use the wrong sign for adjusting net fresh-water.

* Fixes a bug in MOM_surface_forcing.F90 that occurred when IOB
was re-introduced.