### PR TITLE
Merge in unified MOM6 cap

### DIFF
--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -404,9 +404,9 @@ module mom_cap_mod
 
   use, intrinsic :: iso_fortran_env, only: output_unit
 
-  use ESMF                      
-  use NUOPC                     
-  use NUOPC_Model, &            
+  use ESMF
+  use NUOPC
+  use NUOPC_Model, &
     model_routine_SS           => SetServices, &
     model_label_Advance        => label_Advance, &
     model_label_DataInitialize => label_DataInitialize, &
@@ -456,7 +456,7 @@ module mom_cap_mod
   logical              :: grid_attach_area = .false.
   character(len=128)   :: scalar_field_name
   integer              :: scalar_field_count
-  integer              :: scalar_field_idx_grid_nx 
+  integer              :: scalar_field_idx_grid_nx
   integer              :: scalar_field_idx_grid_ny
   character(len=*),parameter :: u_file_u = &
        __FILE__
@@ -578,23 +578,23 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
-    
+         return
+
     write_diagnostics = .false.
     call NUOPC_CompAttributeGet(gcomp, name="DumpFields", value=value, &
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
+         return
     if (isPresent .and. isSet) write_diagnostics=(trim(value)=="true")
-    
+
     write(logmsg,*) write_diagnostics
     call ESMF_LogWrite('mom_cap:DumpFields = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
+         return
 
     profile_memory = .false.
     call NUOPC_CompAttributeGet(gcomp, name="ProfileMemory", value=value, &
@@ -602,14 +602,14 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
+         return
     if (isPresent .and. isSet) profile_memory=(trim(value)=="true")
     write(logmsg,*) profile_memory
     call ESMF_LogWrite('mom_cap:ProfileMemory = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
+         return
 
     grid_attach_area = .false.
     call NUOPC_CompAttributeGet(gcomp, name="GridAttachArea", value=value, &
@@ -617,14 +617,14 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
+         return
     if (isPresent .and. isSet) grid_attach_area=(trim(value)=="true")
     write(logmsg,*) grid_attach_area
     call ESMF_LogWrite('mom_cap:GridAttachArea = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
+         return
 
     scalar_field_name = ""
     call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldName", value=value, &
@@ -632,14 +632,14 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
-    if (isPresent .and. isSet) then 
+         return
+    if (isPresent .and. isSet) then
        scalar_field_name = trim(value)
        call ESMF_LogWrite('mom_cap:ScalarFieldName = '//trim(scalar_field_name), ESMF_LOGMSG_INFO, rc=rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return  
+            return
     endif
 
     scalar_field_count = 0
@@ -648,7 +648,7 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
+         return
     if (isPresent .and. isSet) then
        read(value, '(i)', iostat=iostat) scalar_field_count
        if (iostat /= 0) then
@@ -662,7 +662,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return  
+            return
     endif
 
     scalar_field_idx_grid_nx = 0
@@ -671,7 +671,7 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
+         return
     if (isPresent .and. isSet) then
        read(value, '(i)', iostat=iostat) scalar_field_idx_grid_nx
        if (iostat /= 0) then
@@ -685,7 +685,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return  
+            return
     endif
 
     scalar_field_idx_grid_ny = 0
@@ -694,7 +694,7 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
+         return
     if (isPresent .and. isSet) then
        read(value, '(i)', iostat=iostat) scalar_field_idx_grid_ny
        if (iostat /= 0) then
@@ -708,16 +708,16 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return  
+            return
     endif
 
-    call NUOPC_CompAttributeAdd(gcomp, & 
+    call NUOPC_CompAttributeAdd(gcomp, &
          attrList=(/'RestartFileToRead', 'RestartFileToWrite'/), rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return  
-      
+         return
+
   end subroutine
 
   !===============================================================================
@@ -774,7 +774,7 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return         
+         return
 
     allocate(Ice_ocean_boundary)
     !allocate(ocean_state) ! ocean_model_init allocate this pointer
@@ -827,11 +827,11 @@ contains
 
     ! rsd need to figure out how to get this without share code
     !call shr_nuopc_get_component_instance(gcomp, inst_suffix, inst_index)
-    !inst_name = "OCN"//trim(inst_suffix) 
+    !inst_name = "OCN"//trim(inst_suffix)
 
     ! reset shr logging to my log file
     if (is_root_pe()) then
-       call NUOPC_CompAttributeGet(gcomp, name="diro", value=diro, & 
+       call NUOPC_CompAttributeGet(gcomp, name="diro", value=diro, &
             isPresent=isPresentDiro, rc=rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
@@ -842,7 +842,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return 
+            return
        if (isPresentDiro .and. isPresentLogfile) then
           open(newunit=logunit,file=trim(diro)//"/"//trim(logfile))
        else
@@ -853,7 +853,7 @@ contains
     endif
 
     starttype = ""
-    call NUOPC_CompAttributeGet(gcomp, name='start_type', value=cvalue, & 
+    call NUOPC_CompAttributeGet(gcomp, name='start_type', value=cvalue, &
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
@@ -867,7 +867,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return         
+            return
     endif
 
     runtype = ""
@@ -881,7 +881,7 @@ contains
        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
             msg=subname//": unknown starttype - "//trim(starttype), &
             line=__LINE__, file=__FILE__, rcToReturn=rc)
-       return 
+       return
     endif
 
     if (len_trim(runtype) > 0) then
@@ -889,9 +889,9 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return         
+            return
     endif
-    
+
     restartfile = ""
     if (runtype == "initial") then
        ! startup (new run) - 'n' is needed below if we don't specify input_filename in input.nml
@@ -914,36 +914,36 @@ contains
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
                line=__LINE__, &
                file=__FILE__)) &
-               return         
+               return
        endif
-       
+
        call NUOPC_CompAttributeGet(gcomp, name='RestartFileToRead', &
             value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return  
+            return
        if (isPresent .and. isSet) then
           restartfile = trim(cvalue)
           call ESMF_LogWrite('mom_cap: RestartFileToRead = '//trim(restartfile), ESMF_LOGMSG_INFO, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
                line=__LINE__, &
                file=__FILE__)) &
-               return         
+               return
        else
-          call ESMF_LogWrite('mom_cap: restart requested but no RestartFileToRead attribute provided - will use input.nml', & 
+          call ESMF_LogWrite('mom_cap: restart requested but no RestartFileToRead attribute provided - will use input.nml', &
                ESMF_LOGMSG_WARNING, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
                line=__LINE__, &
                file=__FILE__)) &
-               return                   
+               return
        endif
 
     end if
- 
+
     ocean_public%is_ocean_pe = .true.
     if (len_trim(restartfile) > 0) then
-       call ocean_model_init(ocean_public, ocean_state, Time, Time, & 
+       call ocean_model_init(ocean_public, ocean_state, Time, Time, &
             input_restart_file=trim(restartfile))
     else
        call ocean_model_init(ocean_public, ocean_state, Time, Time)
@@ -1008,7 +1008,7 @@ contains
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_lwdn"     , "will provide")
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_swndr"    , "will provide") ! -> mean_net_sw_ir_dif_flx
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_swvdr"    , "will provide") ! -> mean_net_sw_vis_dir_flx
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_swndf"    , "will provide") ! -> mean_net_sw_ir_dir_flx 
+    call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_swndf"    , "will provide") ! -> mean_net_sw_ir_dir_flx
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_swvdf"    , "will provide") ! -> mean_net_sw_vis_dif_flx
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_taux"     , "will provide") ! -> mean_zonal_moment_flx
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_tauy"     , "will provide") ! -> mean_merid_moment_flx
@@ -1020,7 +1020,7 @@ contains
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"     , "will provide")
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"     , "will provide")
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Sa_pslv"       , "will provide") ! -> inst_pres_height_surface
-    
+
     ! EMC fields not used
     ! call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_runoff_rate"           , "will provide") ! for CESM rofl + rofi
     ! call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_lw_flx"            , "will provide") ! for CESM lwup + lwdn
@@ -1037,7 +1037,7 @@ contains
     ! call fld_list_add(fldsToOcn_num, fldsToOcn, "Si_ifrac"      , "will provide")
     ! call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_melth"    , "will provide")
     ! call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_meltw"    , "will provide")
-    ! call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_prec"     , "will provide") 
+    ! call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_prec"     , "will provide")
     ! call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_bcphidry" , "will provide")
     ! call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_bcphodry" , "will provide")
     ! call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_bcphiwet" , "will provide")
@@ -1105,7 +1105,7 @@ contains
     call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_v"          , "will provide") ! -> ocn_current_merid
     call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_dhdx"       , "will provide") ! not in EMC
     call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_dhdy"       , "will provide") ! not in EMC
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_bldepth"    , "will provide") ! not in EMC 
+    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_bldepth"    , "will provide") ! not in EMC
     call fld_list_add(fldsFrOcn_num, fldsFrOcn, "Fioo_q"        , "will provide") ! not in EMC
 
     ! EMC fields not used
@@ -1115,7 +1115,7 @@ contains
     ! Optional CESM fields currently not used
     ! call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_fswpen"     , "will provide") ! not in EMC
     ! if (flds_co2c) then
-    !    call fld_list_add(fldsToOcn_num, fldsFrOcn, "Faoo_fco2_ocn" , "will provide") 
+    !    call fld_list_add(fldsToOcn_num, fldsFrOcn, "Faoo_fco2_ocn" , "will provide")
     ! end if
 
 
@@ -1303,7 +1303,7 @@ contains
          line=__LINE__, &
          file=__FILE__)) &
          return  ! bail out
-    
+
     !---------------------------------
     ! number of tiles per PET, assumed to be 1, and number of pes (tiles) total
     !---------------------------------
@@ -1324,7 +1324,7 @@ contains
          line=__LINE__, &
          file=__FILE__)) &
          return
-    
+
     !---------------------------------
     ! get start and end indices of each tile and their PET
     !---------------------------------
@@ -1339,10 +1339,10 @@ contains
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
                line=__LINE__, &
                file=__FILE__)) &
-               return       
+               return
        enddo
     end if
-    
+
 
     !---------------------------------
     ! create delayout and distgrid
@@ -1425,7 +1425,7 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return       
+         return
     call ESMF_DistGridGet(distgrid=distgrid, localDE=0, seqIndexList=indexList, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
@@ -1437,9 +1437,9 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return       
+         return
     deallocate(IndexList)
-    
+
     !---------------------------------
     ! create grid
     !---------------------------------
@@ -1730,7 +1730,7 @@ contains
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
-       
+
        call State_SetScalar(dble(nyg),scalar_field_idx_grid_ny, exportState, localPet, &
             scalar_field_name, scalar_field_count, rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -1783,7 +1783,7 @@ contains
     !     line=__LINE__, &
     !     file=__FILE__)) &
     !     return  ! bail out
-    
+
   end subroutine InitializeRealize
 
   !===============================================================================
@@ -2081,7 +2081,7 @@ contains
         mzmf(i,j) = ocean_grid%cos_rot(i1,j1)*dataPtr_mzmf(i,j) &
                   - ocean_grid%sin_rot(i1,j1)*dataPtr_mmmf(i,j)
         mmmf(i,j) = ocean_grid%cos_rot(i1,j1)*dataPtr_mmmf(i,j) &
-                  + ocean_grid%sin_rot(i1,j1)*dataPtr_mzmf(i,j) 
+                  + ocean_grid%sin_rot(i1,j1)*dataPtr_mzmf(i,j)
       enddo
     enddo
     dataPtr_mzmf = mzmf
@@ -2177,26 +2177,26 @@ contains
     deallocate(ocz, ocm)
 
 #endif
-    
+
     ! If restart alarm is ringing - write restart file
     call ESMF_ClockGetAlarm(clock, alarmname='alarm_restart', alarm=alarm, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
          return  ! bail out
-    
+
     if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
-       
+
        call ESMF_AlarmRingerOff(alarm, rc=rc )
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
-       
+
        ! call into system specific method to get desired restart filename
        restartname = ""
        call ESMF_MethodExecute(gcomp, label="GetRestartFileToWrite", &
@@ -2230,7 +2230,7 @@ contains
                   return  ! bail out
           endif
        endif
-       
+
        if (len_trim(restartname) == 0) then
           ! none provided, so use a default restart filename
           call ESMF_ClockGetNextTime(clock, MyTime, rc=rc)
@@ -2244,7 +2244,7 @@ contains
                line=__LINE__, &
                file=__FILE__)) &
                return  ! bail out
-          write(restartname,'(A,".mom6.r.",I4.4,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2)') & 
+          write(restartname,'(A,".mom6.r.",I4.4,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2)') &
                "ocn", year, month, day, hour, minute, seconds
           call ESMF_LogWrite("mom_cap: Using default restart filename:  "//trim(restartname), ESMF_LOGMSG_INFO, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -2252,15 +2252,15 @@ contains
                file=__FILE__)) &
                return  ! bail out
        endif
-       
+
        ! write restart file(s)
        call ocean_model_restart(ocean_state, restartname=restartname)
-       
+
        if (is_root_pe()) then
           write(logunit,*) subname//' writing restart file ',trim(restartname)
        end if
     endif
-    
+
     if (write_diagnostics) then
        call NUOPC_Write(exportState, fileNamePrefix='field_ocn_export_', &
             timeslice=export_slice, relaxedFlag=.true., rc=rc)
@@ -2270,9 +2270,9 @@ contains
             return  ! bail out
        export_slice = export_slice + 1
     endif
-    
+
     if(profile_memory) call ESMF_VMLogMemInfo("Leaving MOM Model_ADVANCE: ")
-    
+
   end subroutine ModelAdvance
 
   !===============================================================================
@@ -2354,9 +2354,9 @@ contains
       return  ! bail out
 
     if (first_time) then
-       !--------------------------------                                                                                 
+       !--------------------------------
        ! set restart alarm
-       !--------------------------------                                                                                 
+       !--------------------------------
 
        ! defaults
        restart_n = 0
@@ -2390,7 +2390,7 @@ contains
        else
           restart_option = "none"
        endif
-       
+
        call AlarmInit(mclock, &
             alarm   = restart_alarm,         &
             option  = trim(restart_option),  &
@@ -2402,21 +2402,21 @@ contains
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
-       
+
        call ESMF_AlarmSet(restart_alarm, clock=mclock, rc=rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
        first_time = .false.
-      
-       call ESMF_LogWrite(subname//" Set restart option = "//restart_option, & 
+
+       call ESMF_LogWrite(subname//" Set restart option = "//restart_option, &
             ESMF_LOGMSG_INFO, rc=rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
-       
+
     end if
 
     !--------------------------------
@@ -2537,7 +2537,7 @@ contains
     integer,           intent(in)     :: scalar_id
     type(ESMF_State),  intent(inout)  :: State
     integer,           intent(in)     :: mytask
-    character(len=*),  intent(in)     :: scalar_name   
+    character(len=*),  intent(in)     :: scalar_name
     integer,           intent(in)     :: scalar_count
     integer,           intent(inout)  :: rc
 
@@ -2635,14 +2635,14 @@ contains
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
-          
+
           ! initialize to zero
           call ESMF_FieldGet(field, farrayPtr=fldptr, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
             return  ! bail out
-          fldptr = 0.0 
+          fldptr = 0.0
 
         endif
 

--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -3,6 +3,7 @@ module mom_cap_methods
   use ESMF,                only: ESMF_time, ESMF_ClockGet, ESMF_TimeGet, ESMF_State, ESMF_Clock
   use ESMF,                only: ESMF_KIND_R8, ESMF_Field, ESMF_SUCCESS, ESMF_LogFoundError
   use ESMF,                only: ESMF_LOGERR_PASSTHRU, ESMF_StateGet, ESMF_FieldGet
+  use ESMF,                only: ESMF_LogSetError, ESMF_RC_MEM_ALLOCATE
   use MOM_ocean_model,     only: ocean_public_type, ocean_state_type
   use MOM_surface_forcing, only: ice_ocean_boundary_type
   use MOM_grid,            only: ocean_grid_type
@@ -15,8 +16,10 @@ module mom_cap_methods
   private
 
   ! Public member functions
+#ifdef CESMCOUPLED
   public :: mom_export
   public :: mom_import
+#endif
   public :: mom_import_nems
 
   integer            :: rc,dbrc
@@ -27,6 +30,7 @@ module mom_cap_methods
 contains
 !-----------------------------------------------------------------------
 
+#ifdef CESMCOUPLED
   !> Maps outgoing ocean data to ESMF State
   !! See \ref section_mom_export for a summary of the data
   !! that is transferred from MOM6 to MCT.
@@ -468,7 +472,7 @@ contains
     end if
 
   end subroutine mom_import
-
+#endif
   !-----------------------------------------------------------------------------
 
   subroutine mom_import_nems(ocean_public, grid, importState, ice_ocean_boundary, rc)

--- a/config_src/nuopc_driver/mom_cap_time.F90
+++ b/config_src/nuopc_driver/mom_cap_time.F90
@@ -1,0 +1,425 @@
+!
+! This was originally share code in CIME, but required CIME as a
+! dependency to build the MOM cap.  The options here for setting
+! a restart alarm are useful for all caps, so a second step is to
+! determine if/how these could be offered more generally in a 
+! shared library.  For now we really want the MOM cap to only 
+! depend on MOM and ESMF/NUOPC.
+!
+module mom_cap_time 
+
+  ! !USES:
+  use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_Calendar, ESMF_Alarm 
+  use ESMF                  , only : ESMF_TimeGet, ESMF_TimeSet
+  use ESMF                  , only : ESMF_TimeInterval, ESMF_TimeIntervalSet
+  use ESMF                  , only : ESMF_ClockGet, ESMF_AlarmCreate 
+  use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
+  use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
+  use ESMF                  , only : ESMF_RC_ARG_BAD
+  use ESMF                  , only : operator(<), operator(/=), operator(+), operator(-), operator(*) , operator(>=)
+  use ESMF                  , only : operator(<=), operator(>), operator(==)
+
+  implicit none
+  private    ! default private
+
+  public  :: AlarmInit  ! initialize an alarm
+
+  private :: TimeInit
+  private :: date2ymd
+
+  ! Clock and alarm options
+  character(len=*), private, parameter :: &
+       optNONE           = "none"      , &
+       optNever          = "never"     , &
+       optNSteps         = "nsteps"    , &
+       optNStep          = "nstep"     , &
+       optNSeconds       = "nseconds"  , &
+       optNSecond        = "nsecond"   , &
+       optNMinutes       = "nminutes"  , &
+       optNMinute        = "nminute"   , &
+       optNHours         = "nhours"    , &
+       optNHour          = "nhour"     , &
+       optNDays          = "ndays"     , &
+       optNDay           = "nday"      , &
+       optNMonths        = "nmonths"   , &
+       optNMonth         = "nmonth"    , &
+       optNYears         = "nyears"    , &
+       optNYear          = "nyear"     , &
+       optMonthly        = "monthly"   , &
+       optYearly         = "yearly"    , &
+       optDate           = "date"      , &
+       optIfdays0        = "ifdays0"   , &
+       optGLCCouplingPeriod = "glc_coupling_period"
+
+  ! Module data
+  integer, parameter          :: SecPerDay = 86400 ! Seconds per day
+  character(len=*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine AlarmInit( clock, alarm, option, &
+       opt_n, opt_ymd, opt_tod, RefTime, alarmname, rc)
+
+    ! !DESCRIPTION: Setup an alarm in a clock
+    ! Notes: The ringtime sent to AlarmCreate MUST be the next alarm
+    ! time.  If you send an arbitrary but proper ringtime from the
+    ! past and the ring interval, the alarm will always go off on the
+    ! next clock advance and this will cause serious problems.  Even
+    ! if it makes sense to initialize an alarm with some reference
+    ! time and the alarm interval, that reference time has to be
+    ! advance forward to be >= the current time.  In the logic below
+    ! we set an appropriate "NextAlarm" and then we make sure to
+    ! advance it properly based on the ring interval.
+
+    ! input/output variables
+    type(ESMF_Clock)            , intent(inout) :: clock     ! clock
+    type(ESMF_Alarm)            , intent(inout) :: alarm     ! alarm
+    character(len=*)            , intent(in)    :: option    ! alarm option
+    integer          , optional , intent(in)    :: opt_n     ! alarm freq
+    integer          , optional , intent(in)    :: opt_ymd   ! alarm ymd
+    integer          , optional , intent(in)    :: opt_tod   ! alarm tod (sec)
+    type(ESMF_Time)  , optional , intent(in)    :: RefTime   ! ref time
+    character(len=*) , optional , intent(in)    :: alarmname ! alarm name
+    integer                     , intent(inout) :: rc        ! Return code
+
+    ! local variables
+    type(ESMF_Calendar)     :: cal                ! calendar
+    integer                 :: lymd             ! local ymd
+    integer                 :: ltod             ! local tod
+    integer                 :: cyy,cmm,cdd,csec ! time info
+    integer                 :: nyy,nmm,ndd,nsec ! time info
+    character(len=64)       :: lalarmname       ! local alarm name
+    logical                 :: update_nextalarm ! update next alarm
+    type(ESMF_Time)         :: CurrTime         ! Current Time
+    type(ESMF_Time)         :: NextAlarm        ! Next restart alarm time
+    type(ESMF_TimeInterval) :: AlarmInterval    ! Alarm interval
+    character(len=*), parameter :: subname = '(AlarmInit): '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    lalarmname = 'alarm_unknown'
+    if (present(alarmname)) lalarmname = trim(alarmname)
+    ltod = 0
+    if (present(opt_tod)) ltod = opt_tod
+    lymd = -1
+    if (present(opt_ymd)) lymd = opt_ymd
+
+    ! verify parameters
+    if (trim(option) == optNSteps    .or. trim(option) == optNStep   .or. &
+        trim(option) == optNSeconds  .or. trim(option) == optNSecond .or. &
+        trim(option) == optNMinutes  .or. trim(option) == optNMinute .or. &
+        trim(option) == optNHours    .or. trim(option) == optNHour   .or. &
+        trim(option) == optNDays     .or. trim(option) == optNDay    .or. &
+        trim(option) == optNMonths   .or. trim(option) == optNMonth  .or. &
+        trim(option) == optNYears    .or. trim(option) == optNYear   .or. &
+        trim(option) == optIfdays0) then
+       if (.not. present(opt_n)) then
+          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+               msg=subname//trim(option)//' requires opt_n', &
+               line=__LINE__, &
+               file=__FILE__, rcToReturn=rc)
+          return          
+       end if
+       if (opt_n <= 0) then
+          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+               msg=subname//trim(option)//' invalid opt_n', &
+               line=__LINE__, &
+               file=__FILE__, rcToReturn=rc)
+          return          
+       end if
+    endif
+
+    call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  
+    
+    call ESMF_TimeGet(CurrTime, yy=cyy, mm=cmm, dd=cdd, s=csec, rc=rc )
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+         line=__LINE__, &
+         file=__FILE__)) &
+         return      
+
+    call ESMF_TimeGet(CurrTime, yy=nyy, mm=nmm, dd=ndd, s=nsec, rc=rc )
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+         line=__LINE__, &
+         file=__FILE__)) &
+         return      
+
+    ! initial guess of next alarm, this will be updated below 
+    if (present(RefTime)) then
+       NextAlarm = RefTime
+    else
+       NextAlarm = CurrTime
+    endif
+
+    ! Determine calendar
+    call ESMF_ClockGet(clock, calendar=cal, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+         line=__LINE__, &
+         file=__FILE__)) &
+         return      
+    
+    ! Determine inputs for call to create alarm
+    selectcase (trim(option))
+
+    case (optNONE, optNever)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return          
+       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       update_nextalarm  = .false.
+
+    case (optDate)
+       if (.not. present(opt_ymd)) then
+          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+               msg=subname//trim(option)//' requires opt_ymd', &
+               line=__LINE__, &
+               file=__FILE__, rcToReturn=rc)
+          return          
+       end if
+       if (lymd < 0 .or. ltod < 0) then
+          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+               msg=subname//trim(option)//'opt_ymd, opt_tod invalid', &
+               line=__LINE__, &
+               file=__FILE__, rcToReturn=rc)
+          return          
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       call TimeInit(NextAlarm, lymd, cal, tod=ltod, desc="optDate", rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       update_nextalarm  = .false.
+
+    case (optIfdays0)
+       if (.not. present(opt_ymd)) then
+          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+               msg=subname//trim(option)//' requires opt_ymd', &
+               line=__LINE__, &
+               file=__FILE__, rcToReturn=rc)
+          return          
+       end if
+       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return             
+       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=opt_n, s=0, calendar=cal, rc=rc )
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       update_nextalarm  = .true.
+
+    case (optNSteps, optNStep)
+       call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNSeconds, optNSecond)
+       call ESMF_TimeIntervalSet(AlarmInterval, s=1, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNMinutes, optNMinute)
+       call ESMF_TimeIntervalSet(AlarmInterval, s=60, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNHours, optNHour)
+       call ESMF_TimeIntervalSet(AlarmInterval, s=3600, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNDays, optNDay)
+       call ESMF_TimeIntervalSet(AlarmInterval, d=1, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optNMonths, optNMonth)
+       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optMonthly)
+       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=1, s=0, calendar=cal, rc=rc )
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       update_nextalarm  = .true.
+
+    case (optNYears, optNYear)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       AlarmInterval = AlarmInterval * opt_n
+       update_nextalarm  = .true.
+
+    case (optYearly)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return      
+       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=1, dd=1, s=0, calendar=cal, rc=rc )
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__)) &
+            return             
+       update_nextalarm  = .true.
+       
+    case default
+       call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+            msg=subname//' unknown option: '//trim(option), &
+            line=__LINE__, &
+            file=__FILE__, rcToReturn=rc)
+       return          
+
+    end select
+
+    ! --------------------------------------------------------------------------------
+    ! --- AlarmInterval and NextAlarm should be set ---
+    ! --------------------------------------------------------------------------------
+
+    ! --- advance Next Alarm so it won't ring on first timestep for
+    ! --- most options above. go back one alarminterval just to be careful
+
+    if (update_nextalarm) then
+       NextAlarm = NextAlarm - AlarmInterval
+       do while (NextAlarm <= CurrTime)
+          NextAlarm = NextAlarm + AlarmInterval
+       enddo
+    endif
+
+    alarm = ESMF_AlarmCreate( name=lalarmname, clock=clock, ringTime=NextAlarm, ringInterval=AlarmInterval, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+         line=__LINE__, &
+         file=__FILE__)) &
+         return                 
+        
+  end subroutine AlarmInit
+
+  !===============================================================================
+
+  subroutine TimeInit( Time, ymd, cal, tod, desc, logunit, rc)
+
+    !  Create the ESMF_Time object corresponding to the given input time, given in
+    !  YMD (Year Month Day) and TOD (Time-of-day) format.
+    !  Set the time by an integer as YYYYMMDD and integer seconds in the day
+
+    ! input/output parameters:
+    type(ESMF_Time)     , intent(inout)         :: Time ! ESMF time
+    integer             , intent(in)            :: ymd  ! year, month, day YYYYMMDD
+    type(ESMF_Calendar) , intent(in)            :: cal  ! ESMF calendar
+    integer             , intent(in),  optional :: tod  ! time of day in seconds
+    character(len=*)    , intent(in),  optional :: desc ! description of time to set
+    integer             , intent(in),  optional :: logunit
+    integer             , intent(out), optional :: rc
+
+    ! local varaibles
+    integer                     :: yr, mon, day ! Year, month, day as integers
+    integer                     :: ltod         ! local tod
+    character(len=256)          :: ldesc        ! local desc
+    character(len=*), parameter :: subname = '(TimeInit) '
+    !-------------------------------------------------------------------------------
+
+    ltod = 0
+    if (present(tod)) ltod = tod
+    ldesc = ''
+    if (present(desc)) ldesc = desc
+
+    if ( (ymd < 0) .or. (ltod < 0) .or. (ltod > SecPerDay) )then
+       if (present(logunit)) then
+          write(logunit,*) subname//': ERROR yymmdd is a negative number or '// &
+               'time-of-day out of bounds', ymd, ltod
+       end if
+       call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+            msg=subname//' yymmdd is negative or time-of-day out of bounds ', &
+            line=__LINE__, &
+            file=__FILE__, rcToReturn=rc)
+       return
+    end if
+
+    call date2ymd (ymd,yr,mon,day)
+    
+    call ESMF_TimeSet( Time, yy=yr, mm=mon, dd=day, s=ltod, calendar=cal, rc=rc )
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+         line=__LINE__, &
+         file=__FILE__)) &
+         return      
+
+  end subroutine TimeInit
+  
+  !===============================================================================
+
+  subroutine date2ymd (date, year, month, day)
+
+    ! input/output variables
+    integer, intent(in)  :: date             ! coded-date (yyyymmdd)
+    integer, intent(out) :: year,month,day   ! calendar year,month,day
+
+    ! local variables
+    integer :: tdate   ! temporary date
+    character(*),parameter :: subName = "(date2ymd)"
+    !-------------------------------------------------------------------------------
+
+    tdate = abs(date)
+    year = int(tdate/10000)
+    if (date < 0) then
+       year = -year
+    end if
+    month = int( mod(tdate,10000)/  100)
+    day = mod(tdate,  100)
+
+  end subroutine date2ymd
+  
+end module

--- a/config_src/nuopc_driver/mom_cap_time.F90
+++ b/config_src/nuopc_driver/mom_cap_time.F90
@@ -2,17 +2,17 @@
 ! This was originally share code in CIME, but required CIME as a
 ! dependency to build the MOM cap.  The options here for setting
 ! a restart alarm are useful for all caps, so a second step is to
-! determine if/how these could be offered more generally in a 
-! shared library.  For now we really want the MOM cap to only 
+! determine if/how these could be offered more generally in a
+! shared library.  For now we really want the MOM cap to only
 ! depend on MOM and ESMF/NUOPC.
 !
-module mom_cap_time 
+module mom_cap_time
 
   ! !USES:
-  use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_Calendar, ESMF_Alarm 
+  use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_Calendar, ESMF_Alarm
   use ESMF                  , only : ESMF_TimeGet, ESMF_TimeSet
   use ESMF                  , only : ESMF_TimeInterval, ESMF_TimeIntervalSet
-  use ESMF                  , only : ESMF_ClockGet, ESMF_AlarmCreate 
+  use ESMF                  , only : ESMF_ClockGet, ESMF_AlarmCreate
   use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
   use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
   use ESMF                  , only : ESMF_RC_ARG_BAD
@@ -122,14 +122,14 @@ contains
                msg=subname//trim(option)//' requires opt_n', &
                line=__LINE__, &
                file=__FILE__, rcToReturn=rc)
-          return          
+          return
        end if
        if (opt_n <= 0) then
           call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
                msg=subname//trim(option)//' invalid opt_n', &
                line=__LINE__, &
                file=__FILE__, rcToReturn=rc)
-          return          
+          return
        end if
     endif
 
@@ -137,21 +137,21 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, &
       file=__FILE__)) &
-      return  
-    
+      return
+
     call ESMF_TimeGet(CurrTime, yy=cyy, mm=cmm, dd=cdd, s=csec, rc=rc )
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return      
+         return
 
     call ESMF_TimeGet(CurrTime, yy=nyy, mm=nmm, dd=ndd, s=nsec, rc=rc )
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return      
+         return
 
-    ! initial guess of next alarm, this will be updated below 
+    ! initial guess of next alarm, this will be updated below
     if (present(RefTime)) then
        NextAlarm = RefTime
     else
@@ -163,8 +163,8 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return      
-    
+         return
+
     ! Determine inputs for call to create alarm
     selectcase (trim(option))
 
@@ -173,12 +173,12 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return          
+            return
        call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        update_nextalarm  = .false.
 
     case (optDate)
@@ -187,25 +187,25 @@ contains
                msg=subname//trim(option)//' requires opt_ymd', &
                line=__LINE__, &
                file=__FILE__, rcToReturn=rc)
-          return          
+          return
        end if
        if (lymd < 0 .or. ltod < 0) then
           call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
                msg=subname//trim(option)//'opt_ymd, opt_tod invalid', &
                line=__LINE__, &
                file=__FILE__, rcToReturn=rc)
-          return          
+          return
        end if
        call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        call TimeInit(NextAlarm, lymd, cal, tod=ltod, desc="optDate", rc=rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        update_nextalarm  = .false.
 
     case (optIfdays0)
@@ -214,18 +214,18 @@ contains
                msg=subname//trim(option)//' requires opt_ymd', &
                line=__LINE__, &
                file=__FILE__, rcToReturn=rc)
-          return          
+          return
        end if
        call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return             
+            return
        call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=opt_n, s=0, calendar=cal, rc=rc )
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        update_nextalarm  = .true.
 
     case (optNSteps, optNStep)
@@ -233,7 +233,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        AlarmInterval = AlarmInterval * opt_n
        update_nextalarm  = .true.
 
@@ -242,7 +242,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        AlarmInterval = AlarmInterval * opt_n
        update_nextalarm  = .true.
 
@@ -251,7 +251,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        AlarmInterval = AlarmInterval * opt_n
        update_nextalarm  = .true.
 
@@ -260,7 +260,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        AlarmInterval = AlarmInterval * opt_n
        update_nextalarm  = .true.
 
@@ -269,7 +269,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        AlarmInterval = AlarmInterval * opt_n
        update_nextalarm  = .true.
 
@@ -278,7 +278,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        AlarmInterval = AlarmInterval * opt_n
        update_nextalarm  = .true.
 
@@ -287,12 +287,12 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=1, s=0, calendar=cal, rc=rc )
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        update_nextalarm  = .true.
 
     case (optNYears, optNYear)
@@ -300,7 +300,7 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        AlarmInterval = AlarmInterval * opt_n
        update_nextalarm  = .true.
 
@@ -309,20 +309,20 @@ contains
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return      
+            return
        call ESMF_TimeSet( NextAlarm, yy=cyy, mm=1, dd=1, s=0, calendar=cal, rc=rc )
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
             line=__LINE__, &
             file=__FILE__)) &
-            return             
+            return
        update_nextalarm  = .true.
-       
+
     case default
        call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
             msg=subname//' unknown option: '//trim(option), &
             line=__LINE__, &
             file=__FILE__, rcToReturn=rc)
-       return          
+       return
 
     end select
 
@@ -344,8 +344,8 @@ contains
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return                 
-        
+         return
+
   end subroutine AlarmInit
 
   !===============================================================================
@@ -390,15 +390,15 @@ contains
     end if
 
     call date2ymd (ymd,yr,mon,day)
-    
+
     call ESMF_TimeSet( Time, yy=yr, mm=mon, dd=day, s=ltod, calendar=cal, rc=rc )
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
          line=__LINE__, &
          file=__FILE__)) &
-         return      
+         return
 
   end subroutine TimeInit
-  
+
   !===============================================================================
 
   subroutine date2ymd (date, year, month, day)
@@ -421,5 +421,5 @@ contains
     day = mod(tdate,  100)
 
   end subroutine date2ymd
-  
+
 end module


### PR DESCRIPTION
This represents join work with EMC to unify the MOM6 caps used in CESM and NEMS.  There are still a few remaining #ifdefs that will need to be handled in a follow up PR.  This PR unifies how restarts work by allowing each system to attach custom ESMF methods for defining the restart filename to read and write.  Also added is a new mom_cap _time.F90 module for determining when to write restart files.  This code is largely copied from CESM share code, but this was necessary to eliminate the dependency on that code so that MOM6 can compile without it.  The new cap was tested at EMC in NEMS are shown to be working.

This PR requires a CIME PR:
https://github.com/ESMCI/cmeps-cime/pull/50
