### PR TITLE
Move pointer assignment outside of loop

### DIFF
--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -599,13 +599,14 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS)
         forces%p_surf(i,j) = forces%p_surf_full(i,j)
       endif
 
-      if (CS%use_limited_P_SSH) then
-        forces%p_surf_SSH => forces%p_surf
-      else
-        forces%p_surf_SSH => forces%p_surf_full
-      endif
-    end if
+    endif
   end do; end do
+
+  if (CS%use_limited_P_SSH) then
+    forces%p_surf_SSH => forces%p_surf
+  else
+    forces%p_surf_SSH => forces%p_surf_full
+  endif
 
   ! GMM, CIME uses AGRID. All the BGRID_NE code can be cleaned later
   wind_stagger = AGRID

--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -600,7 +600,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS)
       endif
 
     endif
-  end do; end do
+  enddo; enddo
 
   if (CS%use_limited_P_SSH) then
     forces%p_surf_SSH => forces%p_surf


### PR DESCRIPTION
@mvertens correctly noticed that pointer assignments were happening inside a loop, which is incorrect. This PR moves these lines outside of the loop.

Answers are b4b, but just a C compset was tested.