### PR TITLE
Introduces additional fluxes used in the CESM framework

### DIFF
--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -489,9 +489,12 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, CS, &
       !   Bob thinks this is trying ensure the net fresh-water of the ocean + sea-ice system
       ! is constant.
       !   To do this correctly we will need a sea-ice melt field added to IOB. -AJA
-      if (associated(fluxes%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
-          net_FW(i,j) = net_FW(i,j) + G%areaT(i,j) * &
-          (fluxes%salt_flux(i,j) / CS%ice_salt_concentration)
+      ! GMM: as stated above, the following is wrong. CIME deals with volume/mass and
+      ! heat from sea ice/snow via meltw and melth, respectively.
+      !!if (associated(fluxes%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
+      !    net_FW(i,j) = net_FW(i,j) + G%areaT(i,j) * &
+      !    (fluxes%salt_flux(i,j) / CS%ice_salt_concentration)
+
       net_FW2(i,j) = net_FW(i,j)/G%areaT(i,j)
     enddo; enddo
 

--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -491,9 +491,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, CS, &
       !   To do this correctly we will need a sea-ice melt field added to IOB. -AJA
       ! GMM: as stated above, the following is wrong. CIME deals with volume/mass and
       ! heat from sea ice/snow via meltw and melth, respectively.
-      !!if (associated(fluxes%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
-      !    net_FW(i,j) = net_FW(i,j) + G%areaT(i,j) * &
-      !    (fluxes%salt_flux(i,j) / CS%ice_salt_concentration)
+      if (associated(fluxes%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
+          net_FW(i,j) = net_FW(i,j) + G%areaT(i,j) * &
+          (fluxes%salt_flux(i,j) / CS%ice_salt_concentration)
 
       net_FW2(i,j) = net_FW(i,j)/G%areaT(i,j)
     enddo; enddo

--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -158,6 +158,7 @@ type, public :: ice_ocean_boundary_type
   real, pointer, dimension(:,:) :: v_flux          =>NULL() !< j-direction wind stress (Pa)
   real, pointer, dimension(:,:) :: t_flux          =>NULL() !< sensible heat flux (W/m2)
   real, pointer, dimension(:,:) :: melth           =>NULL() !< sea ice and snow melt heat flux (W/m2)
+  real, pointer, dimension(:,:) :: meltw           =>NULL() !< water flux due to sea ice and snow melting (kg/m2/s)
   real, pointer, dimension(:,:) :: q_flux          =>NULL() !< specific humidity flux (kg/m2/s)
   real, pointer, dimension(:,:) :: salt_flux       =>NULL() !< salt flux (kg/m2/s)
   real, pointer, dimension(:,:) :: lw_flux         =>NULL() !< long wave radiation (W/m2)
@@ -445,6 +446,10 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, CS, &
     ! sea ice and snow melt heat flux (W/m2)
     if (associated(fluxes%melth)) &
       fluxes%melth(i,j) = G%mask2dT(i,j) * IOB%melth(i-i0,j-j0)
+
+    ! water flux due to sea ice and snow melt (kg/m2/s)
+    if (associated(fluxes%meltw)) &
+      fluxes%meltw(i,j) = G%mask2dT(i,j) * IOB%meltw(i-i0,j-j0)
 
     ! latent heat flux (W/m^2)
     if (associated(fluxes%latent)) &
@@ -776,6 +781,7 @@ subroutine IOB_allocate(IOB, isc, iec, jsc, jec)
              IOB% v_flux (isc:iec,jsc:jec),          &
              IOB% t_flux (isc:iec,jsc:jec),          &
              IOB% melth (isc:iec,jsc:jec),          &
+             IOB% meltw (isc:iec,jsc:jec),          &
              IOB% q_flux (isc:iec,jsc:jec),          &
              IOB% salt_flux (isc:iec,jsc:jec),       &
              IOB% lw_flux (isc:iec,jsc:jec),         &
@@ -801,6 +807,7 @@ subroutine IOB_allocate(IOB, isc, iec, jsc, jec)
   IOB%v_flux          = 0.0
   IOB%t_flux          = 0.0
   IOB%melth           = 0.0
+  IOB%meltw           = 0.0
   IOB%q_flux          = 0.0
   IOB%salt_flux       = 0.0
   IOB%lw_flux         = 0.0
@@ -1316,6 +1323,7 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
   write(outunit,100) 'iobt%v_flux         ', mpp_chksum( iobt%v_flux         )
   write(outunit,100) 'iobt%t_flux         ', mpp_chksum( iobt%t_flux         )
   write(outunit,100) 'iobt%melth          ', mpp_chksum( iobt%melth          )
+  write(outunit,100) 'iobt%meltw          ', mpp_chksum( iobt%meltw          )
   write(outunit,100) 'iobt%q_flux         ', mpp_chksum( iobt%q_flux         )
   write(outunit,100) 'iobt%rofl_flux      ', mpp_chksum( iobt%rofl_flux      )
   write(outunit,100) 'iobt%rofi_flux      ', mpp_chksum( iobt%rofi_flux      )

--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -480,7 +480,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, CS, &
   ! adjust the NET fresh-water flux to zero, if flagged
   if (CS%adjust_net_fresh_water_to_zero) then
     do j=js,je ; do i=is,ie
-      net_FW(i,j) = (((fluxes%lprec(i,j)   + fluxes%fprec(i,j)) + &
+      net_FW(i,j) = (((fluxes%lprec(i,j)   + fluxes%fprec(i,j) + fluxes%meltw(i,j)) + &
           (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j))) + &
           (fluxes%evap(i,j)    + fluxes%vprec(i,j)) ) * G%areaT(i,j)
       !   The following contribution appears to be calculating the volume flux of sea-ice

--- a/config_src/mct_driver/ocn_cap_methods.F90
+++ b/config_src/mct_driver/ocn_cap_methods.F90
@@ -76,6 +76,9 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
       ! snow&ice melt heat flux  (W/m^2)
       ice_ocean_boundary%melth(i,j) = x2o(ind%x2o_Fioi_melth,k)
 
+      ! water flux from snow&ice melt (kg/m2/s)
+      ice_ocean_boundary%meltw(i,j) = x2o(ind%x2o_Fioi_meltw,k)
+
       ! liquid runoff
       ice_ocean_boundary%rofl_flux(i,j) = x2o(ind%x2o_Foxx_rofl,k) * GRID%mask2dT(ig,jg)
 
@@ -120,6 +123,7 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
         write(logunit,F01)'import: day, secs, j, i, q_flux          = ',day,secs,j,i,ice_ocean_boundary%q_flux(i,j)
         write(logunit,F01)'import: day, secs, j, i, t_flux          = ',day,secs,j,i,ice_ocean_boundary%t_flux(i,j)
         write(logunit,F01)'import: day, secs, j, i, melth           = ',day,secs,j,i,ice_ocean_boundary%melth(i,j)
+        write(logunit,F01)'import: day, secs, j, i, meltw           = ',day,secs,j,i,ice_ocean_boundary%meltw(i,j)
         write(logunit,F01)'import: day, secs, j, i, latent_flux     = ',&
                           day,secs,j,i,ice_ocean_boundary%latent_flux(i,j)
         write(logunit,F01)'import: day, secs, j, i, runoff          = ',&

--- a/config_src/mct_driver/ocn_cap_methods.F90
+++ b/config_src/mct_driver/ocn_cap_methods.F90
@@ -33,7 +33,7 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
   real(kind=8), optional        , intent(in)    :: c1, c2, c3, c4     !< Coeffs. used in the shortwave decomposition
 
   ! Local variables
-  integer         :: i, j, ig, jg, isc, iec, jsc, jec  ! Grid indices
+  integer         :: i, j, isc, iec, jsc, jec  ! Grid indices
   integer         :: k
   integer         :: day, secs, rc
   type(ESMF_time) :: currTime
@@ -44,9 +44,7 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
 
   k = 0
   do j = jsc, jec
-    jg = j + grid%jsc - jsc
     do i = isc, iec
-      ig = i + grid%jsc - isc
       k = k + 1 ! Increment position within gindex
 
       ! taux
@@ -80,16 +78,16 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
       ice_ocean_boundary%meltw(i,j) = x2o(ind%x2o_Fioi_meltw,k)
 
       ! liquid runoff
-      ice_ocean_boundary%rofl_flux(i,j) = x2o(ind%x2o_Foxx_rofl,k) * GRID%mask2dT(ig,jg)
+      ice_ocean_boundary%rofl_flux(i,j) = x2o(ind%x2o_Foxx_rofl,k) * GRID%mask2dT(i,j)
 
       ! ice runoff
-      ice_ocean_boundary%rofi_flux(i,j) = x2o(ind%x2o_Foxx_rofi,k) * GRID%mask2dT(ig,jg)
+      ice_ocean_boundary%rofi_flux(i,j) = x2o(ind%x2o_Foxx_rofi,k) * GRID%mask2dT(i,j)
 
       ! surface pressure
-      ice_ocean_boundary%p(i,j) = x2o(ind%x2o_Sa_pslv,k) * GRID%mask2dT(ig,jg)
+      ice_ocean_boundary%p(i,j) = x2o(ind%x2o_Sa_pslv,k) * GRID%mask2dT(i,j)
 
       ! salt flux (minus sign needed here -GMM)
-      ice_ocean_boundary%salt_flux(i,j) = -x2o(ind%x2o_Fioi_salt,k) * GRID%mask2dT(ig,jg)
+      ice_ocean_boundary%salt_flux(i,j) = -x2o(ind%x2o_Fioi_salt,k) * GRID%mask2dT(i,j)
 
       ! 1) visible, direct shortwave  (W/m2)
       ! 2) visible, diffuse shortwave (W/m2)
@@ -97,15 +95,15 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
       ! 4) near-IR, diffuse shortwave (W/m2)
       if (present(c1) .and. present(c2) .and. present(c3) .and. present(c4)) then
         ! Use runtime coefficients to decompose net short-wave heat flux into 4 components
-        ice_ocean_boundary%sw_flux_vis_dir(i,j) = x2o(ind%x2o_Foxx_swnet,k) * c1 * GRID%mask2dT(ig,jg)
-        ice_ocean_boundary%sw_flux_vis_dif(i,j) = x2o(ind%x2o_Foxx_swnet,k) * c2 * GRID%mask2dT(ig,jg)
-        ice_ocean_boundary%sw_flux_nir_dir(i,j) = x2o(ind%x2o_Foxx_swnet,k) * c3 * GRID%mask2dT(ig,jg)
-        ice_ocean_boundary%sw_flux_nir_dif(i,j) = x2o(ind%x2o_Foxx_swnet,k) * c4 * GRID%mask2dT(ig,jg)
+        ice_ocean_boundary%sw_flux_vis_dir(i,j) = x2o(ind%x2o_Foxx_swnet,k) * c1 * GRID%mask2dT(i,j)
+        ice_ocean_boundary%sw_flux_vis_dif(i,j) = x2o(ind%x2o_Foxx_swnet,k) * c2 * GRID%mask2dT(i,j)
+        ice_ocean_boundary%sw_flux_nir_dir(i,j) = x2o(ind%x2o_Foxx_swnet,k) * c3 * GRID%mask2dT(i,j)
+        ice_ocean_boundary%sw_flux_nir_dif(i,j) = x2o(ind%x2o_Foxx_swnet,k) * c4 * GRID%mask2dT(i,j)
       else
-        ice_ocean_boundary%sw_flux_vis_dir(i,j) = x2o(ind%x2o_Faxa_swvdr,k) * GRID%mask2dT(ig,jg)
-        ice_ocean_boundary%sw_flux_vis_dif(i,j) = x2o(ind%x2o_Faxa_swvdf,k) * GRID%mask2dT(ig,jg)
-        ice_ocean_boundary%sw_flux_nir_dir(i,j) = x2o(ind%x2o_Faxa_swndr,k) * GRID%mask2dT(ig,jg)
-        ice_ocean_boundary%sw_flux_nir_dif(i,j) = x2o(ind%x2o_Faxa_swndf,k) * GRID%mask2dT(ig,jg)
+        ice_ocean_boundary%sw_flux_vis_dir(i,j) = x2o(ind%x2o_Faxa_swvdr,k) * GRID%mask2dT(i,j)
+        ice_ocean_boundary%sw_flux_vis_dif(i,j) = x2o(ind%x2o_Faxa_swvdf,k) * GRID%mask2dT(i,j)
+        ice_ocean_boundary%sw_flux_nir_dir(i,j) = x2o(ind%x2o_Faxa_swndr,k) * GRID%mask2dT(i,j)
+        ice_ocean_boundary%sw_flux_nir_dif(i,j) = x2o(ind%x2o_Faxa_swndf,k) * GRID%mask2dT(i,j)
       endif
     enddo
   enddo

--- a/config_src/mct_driver/ocn_cap_methods.F90
+++ b/config_src/mct_driver/ocn_cap_methods.F90
@@ -65,13 +65,13 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
       ice_ocean_boundary%lw_flux(i,j) = (x2o(ind%x2o_Faxa_lwdn,k) + x2o(ind%x2o_Foxx_lwup,k))
 
       ! specific humitidy flux
-      ice_ocean_boundary%q_flux(i,j) = x2o(ind%x2o_Foxx_evap,k) !???TODO: should this be a minus sign
+      ice_ocean_boundary%q_flux(i,j) = x2o(ind%x2o_Foxx_evap,k)
 
       ! sensible heat flux (W/m2)
-      ice_ocean_boundary%t_flux(i,j) = x2o(ind%x2o_Foxx_sen,k)  !???TODO: should this be a minus sign
+      ice_ocean_boundary%t_flux(i,j) = x2o(ind%x2o_Foxx_sen,k)
 
       ! latent heat flux (W/m^2)
-      ice_ocean_boundary%latent_flux(i,j) = x2o(ind%x2o_Foxx_lat,k) !???TODO: should this be a minus sign
+      ice_ocean_boundary%latent_flux(i,j) = x2o(ind%x2o_Foxx_lat,k)
 
       ! snow&ice melt heat flux  (W/m^2)
       ice_ocean_boundary%melth(i,j) = x2o(ind%x2o_Fioi_melth,k)

--- a/config_src/mct_driver/ocn_cap_methods.F90
+++ b/config_src/mct_driver/ocn_cap_methods.F90
@@ -73,6 +73,9 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
       ! latent heat flux (W/m^2)
       ice_ocean_boundary%latent_flux(i,j) = x2o(ind%x2o_Foxx_lat,k) !???TODO: should this be a minus sign
 
+      ! snow&ice melt heat flux  (W/m^2)
+      ice_ocean_boundary%melth(i,j) = x2o(ind%x2o_Fioi_melth,k)
+
       ! liquid runoff
       ice_ocean_boundary%rofl_flux(i,j) = x2o(ind%x2o_Foxx_rofl,k) * GRID%mask2dT(ig,jg)
 
@@ -116,6 +119,7 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
         write(logunit,F01)'import: day, secs, j, i, lwrad           = ',day,secs,j,i,ice_ocean_boundary%lw_flux(i,j)
         write(logunit,F01)'import: day, secs, j, i, q_flux          = ',day,secs,j,i,ice_ocean_boundary%q_flux(i,j)
         write(logunit,F01)'import: day, secs, j, i, t_flux          = ',day,secs,j,i,ice_ocean_boundary%t_flux(i,j)
+        write(logunit,F01)'import: day, secs, j, i, melth           = ',day,secs,j,i,ice_ocean_boundary%melth(i,j)
         write(logunit,F01)'import: day, secs, j, i, latent_flux     = ',&
                           day,secs,j,i,ice_ocean_boundary%latent_flux(i,j)
         write(logunit,F01)'import: day, secs, j, i, runoff          = ',&

--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -773,8 +773,6 @@ end subroutine ocean_model_init_sfc
 !! mi, mass of ice (kg/m2)
 !!
 !! Variables in the coupler that are **NOT** used in MOM6 (i.e., no corresponding field in fluxes):
-!! x2o_Fioi_melth, heat flux from snow & ice melt (W/m2)
-!! x2o_Fioi_meltw, snow melt flux (kg/m2/s)
 !! x2o_Si_ifrac, fractional ice wrt ocean
 !! x2o_So_duu10n, 10m wind speed squared (m^2/s^2)
 !! x2o_Sa_co2prog, bottom atm level prognostic CO2

--- a/config_src/mct_driver/ocn_cpl_indices.F90
+++ b/config_src/mct_driver/ocn_cpl_indices.F90
@@ -41,7 +41,7 @@ module ocn_cpl_indices
     integer :: x2o_Faxa_swndr    !< near-IR, direct shortwave (W/m2)
     integer :: x2o_Faxa_swndf    !< near-IR, direct shortwave (W/m2)
     integer :: x2o_Fioi_melth    !< Heat flux from snow & ice melt (W/m2)
-    integer :: x2o_Fioi_meltw    !< Snow melt flux (kg/m2/s)
+    integer :: x2o_Fioi_meltw    !< Water flux from sea ice and snow melt (kg/m2/s)
     integer :: x2o_Fioi_bcpho    !< Black Carbon hydrophobic release from sea ice component
     integer :: x2o_Fioi_bcphi    !< Black Carbon hydrophilic release from sea ice component
     integer :: x2o_Fioi_flxdst   !< Dust release from sea ice component

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -2103,7 +2103,7 @@ subroutine get_net_mass_forcing(fluxes, G, net_mass_src)
     net_mass_src(i,j) = net_mass_src(i,j) + fluxes%evap(i,j)
   enddo ; enddo ; endif
   if (associated(fluxes%meltw)) then ; do j=js,je ; do i=is,ie
-      forces%net_mass_src(i,j) = forces%net_mass_src(i,j) + fluxes%meltw(i,j)
+    net_mass_src(i,j) = net_mass_src(i,j) + fluxes%meltw(i,j)
   enddo ; enddo ; endif
 
 end subroutine get_net_mass_forcing

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -2123,7 +2123,6 @@ subroutine forcing_diagnostics(fluxes, sfc_state, dt, G, diag, handles)
         if (associated(fluxes%lrunoff))     res(i,j) = res(i,j)+fluxes%lrunoff(i,j)
         if (associated(fluxes%frunoff))     res(i,j) = res(i,j)+fluxes%frunoff(i,j)
         if (associated(fluxes%vprec))       res(i,j) = res(i,j)+fluxes%vprec(i,j)
-        ! GMM, not sure if meltw is needed here. If so, the name prcme is misleading.
         if (associated(fluxes%meltw))       res(i,j) = res(i,j)+fluxes%meltw(i,j)
       enddo ; enddo
       call post_data(handles%id_prcme, res, diag)

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -952,12 +952,20 @@ subroutine accumulate_net_input(fluxes, sfc_state, dt, G, CS)
     endif
   endif
 
+  if (associated(fluxes%meltw)) then ; do j=js,je ; do i=is,ie
+    FW_in(i,j) = FW_in(i,j) + dt * G%areaT(i,j) * fluxes%meltw(i,j)
+  enddo ; enddo ; endif
+
   salt_in(:,:) = 0.0 ; heat_in(:,:) = 0.0
   if (CS%use_temperature) then
 
     if (associated(fluxes%sw)) then ; do j=js,je ; do i=is,ie
       heat_in(i,j) = heat_in(i,j) + dt*G%areaT(i,j) * (fluxes%sw(i,j) + &
              (fluxes%lw(i,j) + (fluxes%latent(i,j) + fluxes%sens(i,j))))
+    enddo ; enddo ; endif
+
+    if (associated(fluxes%melth)) then ; do j=js,je ; do i=is,ie
+       heat_in(i,j) = heat_in(i,j) + dt*G%areaT(i,j) * fluxes%melth(i,j)
     enddo ; enddo ; endif
 
     ! smg: new code

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -1337,7 +1337,10 @@ subroutine diabatic_aux_init(Time, G, GV, param_file, diag, CS, useALEalgorithm,
       call get_param(param_file, mod, "RIVERMIX_DEPTH", CS%rivermix_depth, &
                  "The depth to which rivers are mixed if DO_RIVERMIX is \n"//&
                  "defined.", units="m", default=0.0)
-  else ; CS%do_rivermix = .false. ; CS%rivermix_depth = 0.0 ; endif
+  else
+    CS%do_rivermix = .false. ; CS%rivermix_depth = 0.0 ; CS%ignore_fluxes_over_land = .false.
+  endif
+
   if (GV%nkml == 0) then
     call get_param(param_file, mod, "USE_RIVER_HEAT_CONTENT", CS%use_river_heat_content, &
                    "If true, use the fluxes%runoff_Hflx field to set the \n"//&


### PR DESCRIPTION
The main goal of this PR is to add fluxes that were missing in MOM6 and are needed in CESM. These fluxes are:

1) **melth** = sea ice and snow melt heat flux (W/m2);

2) **meltw** = water flux due to sea ice and snow melting (kg/m2/s).

PS: an additional term for the heat content associated with meltw, called **heat_content_meltw**, is also added here. This term is applied following similar terms (e.g., lprec).
The new terms have been accounted for in the corresponding diagnostic terms (netMassInOut, netMassOut, net_heat, net_mass_src etc., see `src/core/MOM_forcing_type.F90`).  Fluxes of water, heat, and salt crossing the surface are consistent with corresponding changes in the ocean interior. These fluxes have been validated for C and G compsets and the following notebooks document these analysis:

* [C-compset](https://gist.github.com/gustavo-marques/270019b965e406f22f2a2eb86a628b26)
* [G-compset](https://gist.github.com/gustavo-marques/08dc1de673d505ad183af0b7b16ab6f0)

Mass, salt and heat (Mass Err, Salin Err, Temp Err in ocean.stats ) are conserved for C and G compsets.

Options to save different diagnostics of the added terms via MOM6 have been added.

The documentation within the MCT cap has been updated.  

This PR **changes NCAR's answers** since new terms have been added. However, **it does not** change answers for MOM6-examples, based on the [latest dev/master](https://github.com/NOAA-GFDL/MOM6/tree/dev/master).