### PR TITLE
Rename meltw to seaice_melt and melth to seaice_melt_heat 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
 # Merges MOM6 with dev/gfdl. Changes directory to test directory, if it exists.
 before_script:
   - MOM6_SRC=$CI_PROJECT_DIR
-  - CACHE_DIR=/lustre/f1/oar.gfdl.ogrp-account/runner/cache/
+  - echo Cache directory set to ${CACHE_DIR:=/lustre/f2/scratch/oar.gfdl.ogrp-account/runner/cache/}
   - git pull --no-edit https://github.com/NOAA-GFDL/MOM6.git dev/gfdl && git submodule init && git submodule update
   - pwd ; ls
 

--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -151,33 +151,33 @@ end type surface_forcing_CS
 ! the elements, units, and conventions that exactly conform to the use for
 ! MOM-based coupled models.
 type, public :: ice_ocean_boundary_type
-  real, pointer, dimension(:,:) :: latent_flux     =>NULL() !< latent flux (W/m2)
-  real, pointer, dimension(:,:) :: rofl_flux       =>NULL() !< liquid runoff (kg/m2/s)
-  real, pointer, dimension(:,:) :: rofi_flux       =>NULL() !< ice runoff (kg/m2/s)
-  real, pointer, dimension(:,:) :: u_flux          =>NULL() !< i-direction wind stress (Pa)
-  real, pointer, dimension(:,:) :: v_flux          =>NULL() !< j-direction wind stress (Pa)
-  real, pointer, dimension(:,:) :: t_flux          =>NULL() !< sensible heat flux (W/m2)
-  real, pointer, dimension(:,:) :: melth           =>NULL() !< sea ice and snow melt heat flux (W/m2)
-  real, pointer, dimension(:,:) :: meltw           =>NULL() !< water flux due to sea ice and snow melting (kg/m2/s)
-  real, pointer, dimension(:,:) :: q_flux          =>NULL() !< specific humidity flux (kg/m2/s)
-  real, pointer, dimension(:,:) :: salt_flux       =>NULL() !< salt flux (kg/m2/s)
-  real, pointer, dimension(:,:) :: lw_flux         =>NULL() !< long wave radiation (W/m2)
-  real, pointer, dimension(:,:) :: sw_flux_vis_dir =>NULL() !< direct visible sw radiation (W/m2)
-  real, pointer, dimension(:,:) :: sw_flux_vis_dif =>NULL() !< diffuse visible sw radiation (W/m2)
-  real, pointer, dimension(:,:) :: sw_flux_nir_dir =>NULL() !< direct Near InfraRed sw radiation (W/m2)
-  real, pointer, dimension(:,:) :: sw_flux_nir_dif =>NULL() !< diffuse Near InfraRed sw radiation (W/m2)
-  real, pointer, dimension(:,:) :: lprec           =>NULL() !< mass flux of liquid precip (kg/m2/s)
-  real, pointer, dimension(:,:) :: fprec           =>NULL() !< mass flux of frozen precip (kg/m2/s)
-  real, pointer, dimension(:,:) :: calving         =>NULL() !< mass flux of frozen runoff (kg/m2/s)
-  real, pointer, dimension(:,:) :: ustar_berg      =>NULL() !< frictional velocity beneath icebergs (m/s)
-  real, pointer, dimension(:,:) :: area_berg       =>NULL() !< area covered by icebergs(m2/m2)
-  real, pointer, dimension(:,:) :: mass_berg       =>NULL() !< mass of icebergs(kg/m2)
-  real, pointer, dimension(:,:) :: runoff_hflx     =>NULL() !< heat content of liquid runoff (W/m2)
-  real, pointer, dimension(:,:) :: calving_hflx    =>NULL() !< heat content of frozen runoff (W/m2)
-  real, pointer, dimension(:,:) :: p               =>NULL() !< pressure of overlying ice and atmosphere
+  real, pointer, dimension(:,:) :: latent_flux      =>NULL() !< latent flux (W/m2)
+  real, pointer, dimension(:,:) :: rofl_flux        =>NULL() !< liquid runoff (kg/m2/s)
+  real, pointer, dimension(:,:) :: rofi_flux        =>NULL() !< ice runoff (kg/m2/s)
+  real, pointer, dimension(:,:) :: u_flux           =>NULL() !< i-direction wind stress (Pa)
+  real, pointer, dimension(:,:) :: v_flux           =>NULL() !< j-direction wind stress (Pa)
+  real, pointer, dimension(:,:) :: t_flux           =>NULL() !< sensible heat flux (W/m2)
+  real, pointer, dimension(:,:) :: seaice_melt_heat =>NULL() !< sea ice and snow melt heat flux (W/m2)
+  real, pointer, dimension(:,:) :: seaice_melt      =>NULL() !< water flux due to sea ice and snow melting (kg/m2/s)
+  real, pointer, dimension(:,:) :: q_flux           =>NULL() !< specific humidity flux (kg/m2/s)
+  real, pointer, dimension(:,:) :: salt_flux        =>NULL() !< salt flux (kg/m2/s)
+  real, pointer, dimension(:,:) :: lw_flux          =>NULL() !< long wave radiation (W/m2)
+  real, pointer, dimension(:,:) :: sw_flux_vis_dir  =>NULL() !< direct visible sw radiation (W/m2)
+  real, pointer, dimension(:,:) :: sw_flux_vis_dif  =>NULL() !< diffuse visible sw radiation (W/m2)
+  real, pointer, dimension(:,:) :: sw_flux_nir_dir  =>NULL() !< direct Near InfraRed sw radiation (W/m2)
+  real, pointer, dimension(:,:) :: sw_flux_nir_dif  =>NULL() !< diffuse Near InfraRed sw radiation (W/m2)
+  real, pointer, dimension(:,:) :: lprec            =>NULL() !< mass flux of liquid precip (kg/m2/s)
+  real, pointer, dimension(:,:) :: fprec            =>NULL() !< mass flux of frozen precip (kg/m2/s)
+  real, pointer, dimension(:,:) :: calving          =>NULL() !< mass flux of frozen runoff (kg/m2/s)
+  real, pointer, dimension(:,:) :: ustar_berg       =>NULL() !< frictional velocity beneath icebergs (m/s)
+  real, pointer, dimension(:,:) :: area_berg        =>NULL() !< area covered by icebergs(m2/m2)
+  real, pointer, dimension(:,:) :: mass_berg        =>NULL() !< mass of icebergs(kg/m2)
+  real, pointer, dimension(:,:) :: runoff_hflx      =>NULL() !< heat content of liquid runoff (W/m2)
+  real, pointer, dimension(:,:) :: calving_hflx     =>NULL() !< heat content of frozen runoff (W/m2)
+  real, pointer, dimension(:,:) :: p                =>NULL() !< pressure of overlying ice and atmosphere
                                                             !< on ocean surface (Pa)
-  real, pointer, dimension(:,:) :: mi              =>NULL() !< mass of ice (kg/m2)
-  real, pointer, dimension(:,:) :: ice_rigidity    =>NULL() !< rigidity of the sea ice, sea-ice and
+  real, pointer, dimension(:,:) :: mi               =>NULL() !< mass of ice (kg/m2)
+  real, pointer, dimension(:,:) :: ice_rigidity     =>NULL() !< rigidity of the sea ice, sea-ice and
                                                             !! ice-shelves, expressed as a coefficient
                                                             !! for divergence damping, as determined
                                                             !! outside of the ocean model in (m3/s)
@@ -445,12 +445,12 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, CS, &
       fluxes%sens(i,j) = G%mask2dT(i,j) * IOB%t_flux(i-i0,j-j0)
 
     ! sea ice and snow melt heat flux (W/m2)
-    if (associated(fluxes%melth)) &
-      fluxes%melth(i,j) = G%mask2dT(i,j) * IOB%melth(i-i0,j-j0)
+    if (associated(fluxes%seaice_melt_heat)) &
+      fluxes%seaice_melt_heat(i,j) = G%mask2dT(i,j) * IOB%seaice_melt_heat(i-i0,j-j0)
 
     ! water flux due to sea ice and snow melt (kg/m2/s)
-    if (associated(fluxes%meltw)) &
-      fluxes%meltw(i,j) = G%mask2dT(i,j) * IOB%meltw(i-i0,j-j0)
+    if (associated(fluxes%seaice_melt)) &
+      fluxes%seaice_melt(i,j) = G%mask2dT(i,j) * IOB%seaice_melt(i-i0,j-j0)
 
     ! latent heat flux (W/m^2)
     if (associated(fluxes%latent)) &
@@ -483,7 +483,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, CS, &
     sign_for_net_FW_bug = 1.
     if (CS%use_net_FW_adjustment_sign_bug) sign_for_net_FW_bug = -1.
     do j=js,je ; do i=is,ie
-      net_FW(i,j) = (((fluxes%lprec(i,j)   + fluxes%fprec(i,j) + fluxes%meltw(i,j)) + &
+      net_FW(i,j) = (((fluxes%lprec(i,j)   + fluxes%fprec(i,j) + fluxes%seaice_melt(i,j)) + &
           (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j))) + &
           (fluxes%evap(i,j)    + fluxes%vprec(i,j)) ) * G%areaT(i,j)
       !   The following contribution appears to be calculating the volume flux of sea-ice
@@ -493,7 +493,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, CS, &
       ! is constant.
       !   To do this correctly we will need a sea-ice melt field added to IOB. -AJA
       ! GMM: as stated above, the following is wrong. CIME deals with volume/mass and
-      ! heat from sea ice/snow via meltw and melth, respectively.
+      ! heat from sea ice/snow via seaice_melt and seaice_melt_heat, respectively.
       if (associated(fluxes%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
           net_FW(i,j) = net_FW(i,j) + G%areaT(i,j) * &
           (fluxes%salt_flux(i,j) / CS%ice_salt_concentration)
@@ -787,8 +787,8 @@ subroutine IOB_allocate(IOB, isc, iec, jsc, jec)
              IOB% u_flux (isc:iec,jsc:jec),          &
              IOB% v_flux (isc:iec,jsc:jec),          &
              IOB% t_flux (isc:iec,jsc:jec),          &
-             IOB% melth (isc:iec,jsc:jec),          &
-             IOB% meltw (isc:iec,jsc:jec),          &
+             IOB% seaice_melt_heat (isc:iec,jsc:jec),&
+             IOB% seaice_melt (isc:iec,jsc:jec),           &
              IOB% q_flux (isc:iec,jsc:jec),          &
              IOB% salt_flux (isc:iec,jsc:jec),       &
              IOB% lw_flux (isc:iec,jsc:jec),         &
@@ -807,31 +807,31 @@ subroutine IOB_allocate(IOB, isc, iec, jsc, jec)
              IOB% mi (isc:iec,jsc:jec),              &
              IOB% p (isc:iec,jsc:jec))
 
-  IOB%latent_flux     = 0.0
-  IOB%rofl_flux       = 0.0
-  IOB%rofi_flux       = 0.0
-  IOB%u_flux          = 0.0
-  IOB%v_flux          = 0.0
-  IOB%t_flux          = 0.0
-  IOB%melth           = 0.0
-  IOB%meltw           = 0.0
-  IOB%q_flux          = 0.0
-  IOB%salt_flux       = 0.0
-  IOB%lw_flux         = 0.0
-  IOB%sw_flux_vis_dir = 0.0
-  IOB%sw_flux_vis_dif = 0.0
-  IOB%sw_flux_nir_dir = 0.0
-  IOB%sw_flux_nir_dif = 0.0
-  IOB%lprec           = 0.0
-  IOB%fprec           = 0.0
-  IOB%ustar_berg      = 0.0
-  IOB%area_berg       = 0.0
-  IOB%mass_berg       = 0.0
-  IOB%calving         = 0.0
-  IOB%runoff_hflx     = 0.0
-  IOB%calving_hflx    = 0.0
-  IOB%mi              = 0.0
-  IOB%p               = 0.0
+  IOB%latent_flux      = 0.0
+  IOB%rofl_flux        = 0.0
+  IOB%rofi_flux        = 0.0
+  IOB%u_flux           = 0.0
+  IOB%v_flux           = 0.0
+  IOB%t_flux           = 0.0
+  IOB%seaice_melt_heat = 0.0
+  IOB%seaice_melt      = 0.0
+  IOB%q_flux           = 0.0
+  IOB%salt_flux        = 0.0
+  IOB%lw_flux          = 0.0
+  IOB%sw_flux_vis_dir  = 0.0
+  IOB%sw_flux_vis_dif  = 0.0
+  IOB%sw_flux_nir_dir  = 0.0
+  IOB%sw_flux_nir_dif  = 0.0
+  IOB%lprec            = 0.0
+  IOB%fprec            = 0.0
+  IOB%ustar_berg       = 0.0
+  IOB%area_berg        = 0.0
+  IOB%mass_berg        = 0.0
+  IOB%calving          = 0.0
+  IOB%runoff_hflx      = 0.0
+  IOB%calving_hflx     = 0.0
+  IOB%mi               = 0.0
+  IOB%p                = 0.0
 
 end subroutine IOB_allocate
 
@@ -1331,30 +1331,30 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
   outunit = stdout()
 
   write(outunit,*) "BEGIN CHECKSUM(ice_ocean_boundary_type):: ", id, timestep
-  write(outunit,100) 'iobt%u_flux         ', mpp_chksum( iobt%u_flux         )
-  write(outunit,100) 'iobt%v_flux         ', mpp_chksum( iobt%v_flux         )
-  write(outunit,100) 'iobt%t_flux         ', mpp_chksum( iobt%t_flux         )
-  write(outunit,100) 'iobt%melth          ', mpp_chksum( iobt%melth          )
-  write(outunit,100) 'iobt%meltw          ', mpp_chksum( iobt%meltw          )
-  write(outunit,100) 'iobt%q_flux         ', mpp_chksum( iobt%q_flux         )
-  write(outunit,100) 'iobt%rofl_flux      ', mpp_chksum( iobt%rofl_flux      )
-  write(outunit,100) 'iobt%rofi_flux      ', mpp_chksum( iobt%rofi_flux      )
-  write(outunit,100) 'iobt%salt_flux      ', mpp_chksum( iobt%salt_flux      )
-  write(outunit,100) 'iobt%lw_flux        ', mpp_chksum( iobt%lw_flux        )
-  write(outunit,100) 'iobt%sw_flux_vis_dir', mpp_chksum( iobt%sw_flux_vis_dir)
-  write(outunit,100) 'iobt%sw_flux_vis_dif', mpp_chksum( iobt%sw_flux_vis_dif)
-  write(outunit,100) 'iobt%sw_flux_nir_dir', mpp_chksum( iobt%sw_flux_nir_dir)
-  write(outunit,100) 'iobt%sw_flux_nir_dif', mpp_chksum( iobt%sw_flux_nir_dif)
-  write(outunit,100) 'iobt%lprec          ', mpp_chksum( iobt%lprec          )
-  write(outunit,100) 'iobt%fprec          ', mpp_chksum( iobt%fprec          )
-  write(outunit,100) 'iobt%calving        ', mpp_chksum( iobt%calving        )
-  write(outunit,100) 'iobt%p              ', mpp_chksum( iobt%p              )
+  write(outunit,100) 'iobt%u_flux          ', mpp_chksum( iobt%u_flux          )
+  write(outunit,100) 'iobt%v_flux          ', mpp_chksum( iobt%v_flux          )
+  write(outunit,100) 'iobt%t_flux          ', mpp_chksum( iobt%t_flux          )
+  write(outunit,100) 'iobt%seaice_melt_heat', mpp_chksum( iobt%seaice_melt_heat)
+  write(outunit,100) 'iobt%seaice_melt     ', mpp_chksum( iobt%seaice_melt     )
+  write(outunit,100) 'iobt%q_flux          ', mpp_chksum( iobt%q_flux          )
+  write(outunit,100) 'iobt%rofl_flux       ', mpp_chksum( iobt%rofl_flux       )
+  write(outunit,100) 'iobt%rofi_flux       ', mpp_chksum( iobt%rofi_flux       )
+  write(outunit,100) 'iobt%salt_flux       ', mpp_chksum( iobt%salt_flux       )
+  write(outunit,100) 'iobt%lw_flux         ', mpp_chksum( iobt%lw_flux         )
+  write(outunit,100) 'iobt%sw_flux_vis_dir ', mpp_chksum( iobt%sw_flux_vis_dir )
+  write(outunit,100) 'iobt%sw_flux_vis_dif ', mpp_chksum( iobt%sw_flux_vis_dif )
+  write(outunit,100) 'iobt%sw_flux_nir_dir ', mpp_chksum( iobt%sw_flux_nir_dir )
+  write(outunit,100) 'iobt%sw_flux_nir_dif ', mpp_chksum( iobt%sw_flux_nir_dif )
+  write(outunit,100) 'iobt%lprec           ', mpp_chksum( iobt%lprec           )
+  write(outunit,100) 'iobt%fprec           ', mpp_chksum( iobt%fprec           )
+  write(outunit,100) 'iobt%calving         ', mpp_chksum( iobt%calving         )
+  write(outunit,100) 'iobt%p               ', mpp_chksum( iobt%p               )
   if (associated(iobt%ustar_berg)) &
-    write(outunit,100) 'iobt%ustar_berg     ', mpp_chksum( iobt%ustar_berg )
+    write(outunit,100) 'iobt%ustar_berg    ', mpp_chksum( iobt%ustar_berg      )
   if (associated(iobt%area_berg)) &
-    write(outunit,100) 'iobt%area_berg      ', mpp_chksum( iobt%area_berg  )
+    write(outunit,100) 'iobt%area_berg     ', mpp_chksum( iobt%area_berg       )
   if (associated(iobt%mass_berg)) &
-    write(outunit,100) 'iobt%mass_berg      ', mpp_chksum( iobt%mass_berg  )
+    write(outunit,100) 'iobt%mass_berg     ', mpp_chksum( iobt%mass_berg       )
 100 FORMAT("   CHECKSUM::",A20," = ",Z20)
 
   call coupler_type_write_chksums(iobt%fluxes, outunit, 'iobt%')

--- a/config_src/mct_driver/ocn_cap_methods.F90
+++ b/config_src/mct_driver/ocn_cap_methods.F90
@@ -75,10 +75,10 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
       ice_ocean_boundary%latent_flux(i,j) = x2o(ind%x2o_Foxx_lat,k)
 
       ! snow&ice melt heat flux  (W/m^2)
-      ice_ocean_boundary%melth(i,j) = x2o(ind%x2o_Fioi_melth,k)
+      ice_ocean_boundary%seaice_melt_heat(i,j) = x2o(ind%x2o_Fioi_melth,k)
 
       ! water flux from snow&ice melt (kg/m2/s)
-      ice_ocean_boundary%meltw(i,j) = x2o(ind%x2o_Fioi_meltw,k)
+      ice_ocean_boundary%seaice_melt(i,j) = x2o(ind%x2o_Fioi_meltw,k)
 
       ! liquid runoff
       ice_ocean_boundary%rofl_flux(i,j) = x2o(ind%x2o_Foxx_rofl,k) * GRID%mask2dT(i,j)
@@ -117,14 +117,14 @@ subroutine ocn_import(x2o, ind, grid, ice_ocean_boundary, ocean_public, logunit,
 
     do j = GRID%jsc, GRID%jec
       do i = GRID%isc, GRID%iec
-        write(logunit,F01)'import: day, secs, j, i, u_flux          = ',day,secs,j,i,ice_ocean_boundary%u_flux(i,j)
-        write(logunit,F01)'import: day, secs, j, i, v_flux          = ',day,secs,j,i,ice_ocean_boundary%v_flux(i,j)
-        write(logunit,F01)'import: day, secs, j, i, lprec           = ',day,secs,j,i,ice_ocean_boundary%lprec(i,j)
-        write(logunit,F01)'import: day, secs, j, i, lwrad           = ',day,secs,j,i,ice_ocean_boundary%lw_flux(i,j)
-        write(logunit,F01)'import: day, secs, j, i, q_flux          = ',day,secs,j,i,ice_ocean_boundary%q_flux(i,j)
-        write(logunit,F01)'import: day, secs, j, i, t_flux          = ',day,secs,j,i,ice_ocean_boundary%t_flux(i,j)
-        write(logunit,F01)'import: day, secs, j, i, melth           = ',day,secs,j,i,ice_ocean_boundary%melth(i,j)
-        write(logunit,F01)'import: day, secs, j, i, meltw           = ',day,secs,j,i,ice_ocean_boundary%meltw(i,j)
+        write(logunit,F01)'import: day, secs, j, i, u_flux           = ',day,secs,j,i,ice_ocean_boundary%u_flux(i,j)
+        write(logunit,F01)'import: day, secs, j, i, v_flux           = ',day,secs,j,i,ice_ocean_boundary%v_flux(i,j)
+        write(logunit,F01)'import: day, secs, j, i, lprec            = ',day,secs,j,i,ice_ocean_boundary%lprec(i,j)
+        write(logunit,F01)'import: day, secs, j, i, lwrad            = ',day,secs,j,i,ice_ocean_boundary%lw_flux(i,j)
+        write(logunit,F01)'import: day, secs, j, i, q_flux           = ',day,secs,j,i,ice_ocean_boundary%q_flux(i,j)
+        write(logunit,F01)'import: day, secs, j, i, t_flux           = ',day,secs,j,i,ice_ocean_boundary%t_flux(i,j)
+        write(logunit,F01)'import: day, secs, j, i, seaice_melt_heat = ',day,secs,j,i,ice_ocean_boundary%seaice_melt_heat(i,j)
+        write(logunit,F01)'import: day, secs, j, i, seaice_melt      = ',day,secs,j,i,ice_ocean_boundary%seaice_melt(i,j)
         write(logunit,F01)'import: day, secs, j, i, latent_flux     = ',&
                           day,secs,j,i,ice_ocean_boundary%latent_flux(i,j)
         write(logunit,F01)'import: day, secs, j, i, runoff          = ',&

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1314,7 +1314,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
       cmor_long_name='Evaporation Where Ice Free Ocean over Sea Area Integrated')
 
   ! seaice_melt field requires updates to the sea ice model
-  handles%id_total_icemelt = register_scalar_field('ocean_model', 'total_icemelt', Time, diag, &
+  handles%id_total_seaice_melt = register_scalar_field('ocean_model', 'total_icemelt', Time, diag, &
       long_name='Area integrated sea ice melt (>0) or form (<0)', units='kg s-1',                      &
       standard_name='water_flux_into_sea_water_due_to_sea_ice_thermodynamics_area_integrated',         &
       cmor_field_name='total_fsitherm',                                                                &
@@ -1456,9 +1456,9 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
         diag%axesT1,Time,'Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)',&
         'W m-2')
 
-  handles%id_net_heat_surface = register_diag_field('ocean_model', 'net_heat_surface',diag%axesT1,  &
-        Time,'Surface ocean heat flux from SW+LW+lat+sens+mass transfer+frazil+restore+seaice_melt_heat', &
-        'or flux adjustments', 'W m-2',&
+  handles%id_net_heat_surface = register_diag_field('ocean_model', 'net_heat_surface',diag%axesT1, Time,  &
+        'Surface ocean heat flux from SW+LW+lat+sens+mass transfer+frazil+restore+seaice_melt_heat or flux adjustments',&
+        'W m-2',&
         standard_name='surface_downward_heat_flux_in_sea_water', cmor_field_name='hfds',            &
         cmor_standard_name='surface_downward_heat_flux_in_sea_water',           &
         cmor_long_name='Surface ocean heat flux from SW+LW+latent+sensible+masstransfer+frazil+seaice_melt_heat')
@@ -1692,7 +1692,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
 
   handles%id_net_heat_surface_ga = register_scalar_field('ocean_model',                       &
       'net_heat_surface_ga', Time, diag,                                                      &
-      long_name='Area averaged surface heat flux from SW+LW+lat+sens+mass+frazil+restore+seaice_melt_heat', &
+      long_name='Area averaged surface heat flux from SW+LW+lat+sens+mass+frazil+restore+seaice_melt_heat'&
       ' or flux adjustments',                                                                 &
       units='W m-2',                                                                          &
       cmor_field_name='ave_hfds',                                                             &

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1561,9 +1561,9 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
       units='W')
 
   handles%id_total_heat_content_icemelt = register_scalar_field('ocean_model',     &
-      'total_heat_content_icemelt', Time, diag,                                    &
-      long_name='Area integrated heat content (relative to 0C) of water flux due sea ice '&
-      'melting/freezing', units='W')
+      'total_heat_content_icemelt', Time, diag,long_name=                          &
+      'Area integrated heat content (relative to 0C) of water flux due sea ice melting/freezing', &
+      units='W')
 
   handles%id_total_heat_content_vprec = register_scalar_field('ocean_model',      &
       'total_heat_content_vprec', Time, diag,                                     &
@@ -1691,9 +1691,8 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
       units='W m-2')
 
   handles%id_net_heat_surface_ga = register_scalar_field('ocean_model',                       &
-      'net_heat_surface_ga', Time, diag,                                                      &
-      long_name='Area averaged surface heat flux from SW+LW+lat+sens+mass+frazil+restore+seaice_melt_heat'&
-      ' or flux adjustments',                                                                 &
+      'net_heat_surface_ga', Time, diag, long_name=                                                     &
+      'Area averaged surface heat flux from SW+LW+lat+sens+mass+frazil+restore+seaice_melt_heat or flux adjustments' &
       units='W m-2',                                                                          &
       cmor_field_name='ave_hfds',                                                             &
       cmor_standard_name='surface_downward_heat_flux_in_sea_water_area_averaged',             &

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -1692,7 +1692,7 @@ subroutine register_forcing_type_diags(Time, diag, use_temperature, handles, use
 
   handles%id_net_heat_surface_ga = register_scalar_field('ocean_model',                       &
       'net_heat_surface_ga', Time, diag, long_name=                                                     &
-      'Area averaged surface heat flux from SW+LW+lat+sens+mass+frazil+restore+seaice_melt_heat or flux adjustments' &
+      'Area averaged surface heat flux from SW+LW+lat+sens+mass+frazil+restore+seaice_melt_heat or flux adjustments', &
       units='W m-2',                                                                          &
       cmor_field_name='ave_hfds',                                                             &
       cmor_standard_name='surface_downward_heat_flux_in_sea_water_area_averaged',             &

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -952,8 +952,8 @@ subroutine accumulate_net_input(fluxes, sfc_state, dt, G, CS)
     endif
   endif
 
-  if (associated(fluxes%meltw)) then ; do j=js,je ; do i=is,ie
-    FW_in(i,j) = FW_in(i,j) + dt * G%areaT(i,j) * fluxes%meltw(i,j)
+  if (associated(fluxes%seaice_melt)) then ; do j=js,je ; do i=is,ie
+    FW_in(i,j) = FW_in(i,j) + dt * G%areaT(i,j) * fluxes%seaice_melt(i,j)
   enddo ; enddo ; endif
 
   salt_in(:,:) = 0.0 ; heat_in(:,:) = 0.0
@@ -964,8 +964,8 @@ subroutine accumulate_net_input(fluxes, sfc_state, dt, G, CS)
              (fluxes%lw(i,j) + (fluxes%latent(i,j) + fluxes%sens(i,j))))
     enddo ; enddo ; endif
 
-    if (associated(fluxes%melth)) then ; do j=js,je ; do i=is,ie
-       heat_in(i,j) = heat_in(i,j) + dt*G%areaT(i,j) * fluxes%melth(i,j)
+    if (associated(fluxes%seaice_melt_heat)) then ; do j=js,je ; do i=is,ie
+       heat_in(i,j) = heat_in(i,j) + dt*G%areaT(i,j) * fluxes%seaice_melt_heat(i,j)
     enddo ; enddo ; endif
 
     ! smg: new code


### PR DESCRIPTION
Following the last MOM6 dev meeting, I've pushed new commits to rename meltw and melth to seaice_melt and seaice_melt_heat, respectively. I've also renamed heat_content_meltw to heat_content_icemelt. All answers in MOM6-examples are b4b with respect to the latest dev/master (only Intel was checked). Noticed also a change in the .gitlab-ci.yml file.

Scripts used to check if fluxes of water, heat, and salt crossing the surface of the ocean are consistent with corresponding changes in the ocean interior will have to be modified following these changed.



