### PR TITLE
apply oda tracer increments only if da is active

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1153,7 +1153,9 @@ subroutine step_MOM_thermo(CS, G, GV, u, v, h, tv, fluxes, dtdia, &
 
   call enable_averaging(dtdia, Time_end_thermo, CS%diag)
 
-  call apply_oda_tracer_increments(dtdia,G,tv,h,CS%odaCS)
+  if (associated(CS%odaCS)) then
+    call apply_oda_tracer_increments(dtdia,G,tv,h,CS%odaCS)
+  endif
 
   if (update_BBL) then
     !   Calculate the BBL properties and store them inside visc (u,h).


### PR DESCRIPTION
Without this change, CESM+MOM6 crashes in debug mode.