### PR TITLE
Add seaice_melt and seaice_melt_heat

### DIFF
--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -204,6 +204,8 @@
 !! --------------------------|------------|-----------------|---------------------------------------|-------------------
 !! inst_pres_height_surface  | Pa         | p               | pressure of overlying sea ice and atmosphere
 !! mass_of_overlying_sea_ice | kg         | mi              | mass of overlying sea ice          | |
+!! seaice_melt_heat          | W m-2      | seaice_melt_heat| sea ice and snow melt heat flux    | |
+!! seaice_melt               | kg m-2 s-1 | seaice_melt     | water flux due to sea ice and snow melting    | |
 !! mean_calving_heat_flx     | W m-2      | calving_hflx    | heat flux, relative to 0C, of frozen land water into ocean
 !! mean_calving_rate         | kg m-2 s-1 | calving         | mass flux of frozen runoff         | |
 !! mean_evap_rate            | kg m-2 s-1 | q_flux          | specific humidity flux             |
@@ -961,6 +963,8 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
              Ice_ocean_boundary% sw_flux_nir_dif (isc:iec,jsc:jec), &
              Ice_ocean_boundary% lprec (isc:iec,jsc:jec),           &
              Ice_ocean_boundary% fprec (isc:iec,jsc:jec),           &
+             Ice_ocean_boundary% seaice_melt_heat (isc:iec,jsc:jec),&
+             Ice_ocean_boundary% seaice_melt (isc:iec,jsc:jec),     &
              Ice_ocean_boundary% mi (isc:iec,jsc:jec),              &
              Ice_ocean_boundary% p (isc:iec,jsc:jec),               &
              Ice_ocean_boundary% runoff (isc:iec,jsc:jec),          &
@@ -982,6 +986,8 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   Ice_ocean_boundary%sw_flux_nir_dif = 0.0
   Ice_ocean_boundary%lprec           = 0.0
   Ice_ocean_boundary%fprec           = 0.0
+  Ice_ocean_boundary%seaice_melt     = 0.0
+  Ice_ocean_boundary%seaice_melt_heat= 0.0
   Ice_ocean_boundary%mi              = 0.0
   Ice_ocean_boundary%p               = 0.0
   Ice_ocean_boundary%runoff          = 0.0
@@ -1031,8 +1037,8 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   call fld_list_add(fldsToOcn_num, fldsToOcn, "inst_pres_height_surface"   , "will provide")
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"                  , "will provide") !-> liquid runoff
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"                  , "will provide") !-> ice runoff
-  !call fld_list_add(fldsToOcn_num, fldsToOcn, "seaice_melt_water"          , "will provide")
-  !call fld_list_add(fldsToOcn_num, fldsToOcn, "seaice_melt_heat"           , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_fresh_water_to_ocean_rate", "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "net_heat_flx_to_ocn"        , "will provide")
 
  !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_runoff_rate"           , "will provide")
  !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_calving_rate"          , "will provide")

--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -294,6 +294,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
      !----
      ! salt flux from ice
      !----
+     ice_ocean_boundary%salt_flux(:,:) = 0._ESMF_KIND_R8
      call state_getimport(importState, 'mean_salt_rate',  &
           isc, iec, jsc, jec, ice_ocean_boundary%salt_flux,rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -304,22 +305,24 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
      ! !----
      ! ! snow&ice melt heat flux  (W/m^2)
      ! !----
-     ! call state_getimport(importState, 'seaice_melt_heat',  &
-     !      isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_heat,rc=rc)
-     ! if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-     !      line=__LINE__, &
-     !      file=__FILE__)) &
-     !      return  ! bail out
+     ice_ocean_boundary%seaice_melt_heat(:,:) = 0._ESMF_KIND_R8
+     call state_getimport(importState, 'net_heat_flx_to_ocn',  &
+           isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_heat,rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
 
-     ! !----
-     ! ! snow&ice melt water flux  (W/m^2)
-     ! !----
-     ! call state_getimport(importState, 'seaice_melt_water',  &
-     !      isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_water,rc=rc)
-     ! if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-     !      line=__LINE__, &
-     !      file=__FILE__)) &
-     !      return  ! bail out
+      ! !----
+      ! ! snow&ice melt water flux  (W/m^2)
+      ! !----
+      ice_ocean_boundary%seaice_melt(:,:) = 0._ESMF_KIND_R8
+      call state_getimport(importState, 'mean_fresh_water_to_ocean_rate',  &
+           isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt,rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
 
      !----
      ! mass of overlying ice
@@ -373,7 +376,6 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
 
   rc = ESMF_SUCCESS
 
-  ! Use Adcroft's rule of reciprocals; it does the right thing here.
   call ESMF_ClockGet( clock, timeStep=timeStep, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__, &
@@ -386,6 +388,7 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
     file=__FILE__)) &
     return  ! bail out
 
+  ! Use Adcroft's rule of reciprocals; it does the right thing here.
   if (real(dt_int) > 0.0) then
      inv_dt_int = 1.0 / real(dt_int)
   else


### PR DESCRIPTION
This commit adds two fluxes in the nuopc cap that were previously missing. The MOM (coupler)
definition of these terms is **seaice_melt** (meltw) and **seaice_melt_heat** (melth).

TODO:
Currently, the alias names for these terms in the fd.yaml file are
**mean_fresh_water_to_ocean_rate** and **net_heat_flx_to_ocn**. We need to change these
to more meaningful names and this will require changes in CICE.