### PR TITLE
Fix ocn lag logic for continue_runs

### DIFF
--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -1847,8 +1847,11 @@ subroutine ModelAdvance(gcomp, rc)
     file=__FILE__)) &
     return  ! bail out
 
+  Time_step_coupled = esmf2fms_time(timeStep)
+  Time = esmf2fms_time(currTime)
+
   !---------------
-  ! Apply ocean lag at startup:
+  ! Apply ocean lag for startup runs:
   !---------------
 
   if (cesm_coupled) then
@@ -1881,15 +1884,8 @@ subroutine ModelAdvance(gcomp, rc)
           file=__FILE__)) &
           return  ! bail out
         Time_step_coupled = 2 * esmf2fms_time(timeStep)
-      else
-        Time_step_coupled = esmf2fms_time(timeStep)
-        Time = esmf2fms_time(currTime)
       endif
     endif
-
-  else ! non-cesm runs:
-    Time_step_coupled = esmf2fms_time(timeStep)
-    Time = esmf2fms_time(currTime)
   endif
 
 


### PR DESCRIPTION
Corrected time and coupling timestep duration for continued runs.
Exact restart tests are now passing.

testing: aux_mom/cheyenne/intel