### PR TITLE
Adding GME and GEOMETRIC

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -56,7 +56,7 @@ implicit none ; private
 #endif
 
 public btcalc, bt_mass_source, btstep, barotropic_init, barotropic_end
-public register_barotropic_restarts, set_dtbt
+public register_barotropic_restarts, set_dtbt, barotropic_get_tav
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
@@ -4363,6 +4363,29 @@ subroutine barotropic_init(u, v, h, eta, Time, G, GV, US, param_file, diag, CS, 
 
 end subroutine barotropic_init
 
+!> Copies ubtav and vbtav from private type into arrays
+subroutine barotropic_get_tav(CS, ubtav, vbtav, G)
+  type(barotropic_CS),                 pointer     :: CS   !< Control structure for
+                                                   !! this module
+  type(ocean_grid_type),               intent(in)  :: G    !< Grid structure
+  real, dimension(SZIB_(G),SZJ_(G)), intent(inout) :: ubtav!< zonal barotropic vel.
+                                                   !! ave. over baroclinic time-step (m s-1)
+  real, dimension(SZI_(G),SZJB_(G)), intent(inout) :: vbtav!< meridional barotropic vel.
+                                                   !! ave. over baroclinic time-step (m s-1)
+  ! Local variables
+  integer :: i,j
+
+  do j = G%jsc, G%jec ; do I = G%isc-1, G%iec
+    ubtav(I,j) = CS%ubtav(I,j)
+  enddo ; enddo
+
+  do J = G%jsc-1, G%jec ; do i = G%isc, G%iec
+    vbtav(i,J) = CS%vbtav(i,J)
+  enddo ; enddo
+
+end subroutine barotropic_get_tav
+
+
 !> Clean up the barotropic control structure.
 subroutine barotropic_end(CS)
   type(barotropic_CS), pointer :: CS  !< Control structure to clear out.
@@ -4381,7 +4404,7 @@ subroutine barotropic_end(CS)
 end subroutine barotropic_end
 
 !> This subroutine is used to register any fields from MOM_barotropic.F90
-!! that should be written to or read from the restart file.
+!!! that should be written to or read from the restart file.
 subroutine register_barotropic_restarts(HI, GV, param_file, CS, restart_CS)
   type(hor_index_type),    intent(in) :: HI         !< A horizontal index type structure.
   type(param_file_type),   intent(in) :: param_file !< A structure to parse for run-time parameters.

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -52,6 +52,7 @@ use MOM_open_boundary,         only : open_boundary_zero_normal_flow
 use MOM_open_boundary,         only : open_boundary_test_extern_h
 use MOM_PressureForce,         only : PressureForce, PressureForce_init, PressureForce_CS
 use MOM_set_visc,              only : set_viscous_ML, set_visc_CS
+use MOM_thickness_diffuse,     only : thickness_diffuse_CS
 use MOM_tidal_forcing,         only : tidal_forcing_init, tidal_forcing_CS
 use MOM_unit_scaling,          only : unit_scale_type
 use MOM_vert_friction,         only : vertvisc, vertvisc_coef, vertvisc_remnant
@@ -184,6 +185,8 @@ type, public :: MOM_dyn_split_RK2_CS ; private
   type(PressureForce_CS), pointer :: PressureForce_CSp => NULL()
   !> A pointer to the barotropic stepping control structure
   type(barotropic_CS),    pointer :: barotropic_CSp    => NULL()
+  !> A pointer to a structure containing interface height diffusivities
+  type(thickness_diffuse_CS), pointer :: thickness_diffuse_CSp => NULL()
   !> A pointer to the vertical viscosity control structure
   type(vertvisc_CS),      pointer :: vertvisc_CSp      => NULL()
   !> A pointer to the set_visc control structure
@@ -230,7 +233,7 @@ contains
 subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
                  Time_local, dt, forces, p_surf_begin, p_surf_end, &
                  uh, vh, uhtr, vhtr, eta_av, &
-                 G, GV, US, CS, calc_dtbt, VarMix, MEKE, Waves)
+                 G, GV, US, CS, calc_dtbt, VarMix, MEKE, thickness_diffuse_CSp, Waves)
   type(ocean_grid_type),             intent(inout) :: G            !< ocean grid structure
   type(verticalGrid_type),           intent(in)    :: GV           !< ocean vertical grid structure
   type(unit_scale_type),             intent(in)    :: US           !< A dimensional unit scaling type
@@ -267,8 +270,12 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
   logical,                           intent(in)    :: calc_dtbt    !< if true, recalculate barotropic time step
   type(VarMix_CS),                   pointer       :: VarMix       !< specify the spatially varying viscosities
   type(MEKE_type),                   pointer       :: MEKE         !< related to mesoscale eddy kinetic energy param
+  type(thickness_diffuse_CS),        pointer       :: thickness_diffuse_CSp!< Pointer to a structure containing
+                                                                    !! interface height diffusivities
   type(wave_parameters_CS), optional, pointer      :: Waves        !< A pointer to a structure containing
                                                                    !! fields related to the surface wave conditions
+
+  ! local variables
   real :: dt_pred   ! The time step for the predictor part of the baroclinic time stepping.
 
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)) :: up   ! Predicted zonal velocity [m s-1].
@@ -682,7 +689,8 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, &
 ! diffu = horizontal viscosity terms (u_av)
   call cpu_clock_begin(id_clock_horvisc)
   call horizontal_viscosity(u_av, v_av, h_av, CS%diffu, CS%diffv, &
-                            MEKE, Varmix, G, GV, US, CS%hor_visc_CSp, OBC=CS%OBC)
+                            MEKE, Varmix, CS%barotropic_CSp, thickness_diffuse_CSp, &
+                            G, GV, US, CS%hor_visc_CSp, OBC=CS%OBC)
   call cpu_clock_end(id_clock_horvisc)
   if (showCallTree) call callTree_wayPoint("done with horizontal_viscosity (step_MOM_dyn_split_RK2)")
 
@@ -953,7 +961,8 @@ end subroutine register_restarts_dyn_split_RK2
 !! dynamic core, including diagnostics and the cpu clocks.
 subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param_file, &
                       diag, CS, restart_CS, dt, Accel_diag, Cont_diag, MIS, &
-                      VarMix, MEKE, OBC, update_OBC_CSp, ALE_CSp, setVisc_CSp, &
+                      VarMix, MEKE, thickness_diffuse_CSp,                  &
+                      OBC, update_OBC_CSp, ALE_CSp, setVisc_CSp, &
                       visc, dirs, ntrunc, calc_dtbt)
   type(ocean_grid_type),            intent(inout) :: G          !< ocean grid structure
   type(verticalGrid_type),          intent(in)    :: GV         !< ocean vertical grid structure
@@ -981,6 +990,10 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
                                                                 !! diagnostic pointers
   type(VarMix_CS),                  pointer       :: VarMix     !< points to spatially variable viscosities
   type(MEKE_type),                  pointer       :: MEKE       !< points to mesoscale eddy kinetic energy fields
+!  type(Barotropic_CS),              pointer       :: Barotropic_CSp !< Pointer to the control structure for
+!                                                                !! the barotropic module
+  type(thickness_diffuse_CS),       pointer       :: thickness_diffuse_CSp !< Pointer to the control structure
+                                                  !! used for the isopycnal height diffusive transport.
   type(ocean_OBC_type),             pointer       :: OBC        !< points to OBC related fields
   type(update_OBC_CS),              pointer       :: update_OBC_CSp !< points to OBC update related fields
   type(ALE_CS),                     pointer       :: ALE_CSp    !< points to ALE control structure
@@ -992,6 +1005,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
                                                                 !! truncated (this should be 0).
   logical,                          intent(out)   :: calc_dtbt  !< If true, recalculate the barotropic time step
 
+  ! local variables
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_tmp
   character(len=40) :: mdl = "MOM_dynamics_split_RK2" ! This module's name.
   character(len=48) :: thickness_units, flux_units, eta_rest_name
@@ -1133,9 +1147,13 @@ subroutine initialize_dyn_split_RK2(u, v, h, uh, vh, eta, Time, G, GV, US, param
                        CS%barotropic_CSp, restart_CS, calc_dtbt, CS%BT_cont, &
                        CS%tides_CSp)
 
+!  CS%barotropic_CSp => Barotropic_CSp
+!  CS%thickness_diffuse_CSp => thickness_diffuse_CSp
+
   if (.not. query_initialized(CS%diffu,"diffu",restart_CS) .or. &
       .not. query_initialized(CS%diffv,"diffv",restart_CS)) &
     call horizontal_viscosity(u, v, h, CS%diffu, CS%diffv, MEKE, VarMix, &
+                              CS%barotropic_CSp, thickness_diffuse_CSp, &
                               G, GV, US, CS%hor_visc_CSp, OBC=CS%OBC)
   if (.not. query_initialized(CS%u_av,"u2", restart_CS) .or. &
       .not. query_initialized(CS%u_av,"v2", restart_CS)) then

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1195,7 +1195,7 @@ subroutine MEKE_alloc_register_restart(HI, param_file, MEKE, restart_CS)
   call register_restart_field(MEKE%MEKE, vd, .false., restart_CS)
   if (MEKE_GMcoeff>=0.) then
     allocate(MEKE%GM_src(isd:ied,jsd:jed)) ; MEKE%GM_src(:,:) = 0.0
-  endif 
+  endif
   if (MEKE_FrCoeff>=0. .or. MEKE_GMECoeff>=0.)  then
     allocate(MEKE%mom_src(isd:ied,jsd:jed)) ; MEKE%mom_src(:,:) = 0.0
   endif

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -508,6 +508,10 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
             enddo ; enddo
           else
             do j=js,je ; do i=is,ie
+              drag_rate(i,j) = (Rho0 * I_mass(i,j)) * sqrt( drag_rate_visc(i,j)**2 &
+              + cdrag2 * ( max(0.0, 2.0*bottomFac2(i,j)*MEKE%MEKE(i,j)) + CS%MEKE_Uscale**2 ) )
+            enddo ; enddo
+            do j=js,je ; do i=is,ie
               ldamping = CS%MEKE_damping + drag_rate(i,j) * bottomFac2(i,j)
               if (MEKE%MEKE(i,j)<0.) ldamping = 0.
               ! notice that the above line ensures a damping only if MEKE is positive,
@@ -521,9 +525,9 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
       endif
     endif ! MEKE_KH>=0
 
-    do j=js,je ; do i=is,ie
-      MEKE%MEKE(i,j) =  MAX(MEKE%MEKE(i,j),0.0)
-    enddo ; enddo
+ !   do j=js,je ; do i=is,ie
+ !     MEKE%MEKE(i,j) =  MAX(MEKE%MEKE(i,j),0.0)
+ !   enddo ; enddo
 
 !$OMP end parallel
     call cpu_clock_begin(CS%id_clock_pass)
@@ -738,8 +742,8 @@ subroutine MEKE_equilibrium(CS, MEKE, G, GV, US, SN_u, SN_v, drag_rate_visc, I_m
     else
       EKE = 0.
     endif
-!    MEKE%MEKE(i,j) = EKE
-    MEKE%MEKE(i,j) = (US%Z_to_m*G%bathyT(i,j)*SN / (8*CS%cdrag))**2
+    MEKE%MEKE(i,j) = EKE
+!    MEKE%MEKE(i,j) = (US%Z_to_m*G%bathyT(i,j)*SN / (8*CS%cdrag))**2
   enddo ; enddo
 
 end subroutine MEKE_equilibrium

--- a/src/parameterizations/lateral/MOM_MEKE_types.F90
+++ b/src/parameterizations/lateral/MOM_MEKE_types.F90
@@ -8,20 +8,23 @@ implicit none ; private
 type, public :: MEKE_type
   ! Variables
   real, dimension(:,:), pointer :: &
-    MEKE => NULL(), &   !< Vertically averaged eddy kinetic energy [m2 s-2].
-    GM_src => NULL(), & !< MEKE source due to thickness mixing (GM) [W m-2].
-    mom_src => NULL(),& !< MEKE source from lateral friction in the momentum equations [W m-2].
-    Kh => NULL(), &     !< The MEKE-derived lateral mixing coefficient [m2 s-1.
-    Rd_dx_h => NULL()   !< The deformation radius compared with the grid spacing [nondim].
+    MEKE => NULL(), &   !< Vertically averaged eddy kinetic energy, in m2 s-2.
+    GM_src => NULL(), & !< MEKE source due to thickness mixing (GM), in W m-2.
+    mom_src => NULL(),& !< MEKE source from lateral friction in the momentum equations, in W m-2.
+    GME_snk => NULL(),& !< MEKE sink from GME backscatter in the momentum equations, in W m-2.
+    Kh => NULL(), &     !< The MEKE-derived lateral mixing coefficient in m2 s-1.
+    Rd_dx_h => NULL()   !< The deformation radius compared with the grid spacing, nondim.
                         !! Rd_dx_h is copied from VarMix_CS.
   real, dimension(:,:), pointer :: Ku => NULL() !< The MEKE-derived lateral viscosity coefficient [m2 s-1].
                         !! This viscosity can be negative when representing backscatter
                         !! from unresolved eddies (see Jansen and Held, 2014).
+  real, dimension(:,:), pointer :: Au => NULL() !< The MEKE-derived lateral biharmonic viscosity coefficient in m4 s-1.
   ! Parameters
   real :: KhTh_fac = 1.0 !< Multiplier to map Kh(MEKE) to KhTh [nondim]
   real :: KhTr_fac = 1.0 !< Multiplier to map Kh(MEKE) to KhTr [nondim].
   real :: backscatter_Ro_pow = 0.0 !< Power in Rossby number function for backscatter.
   real :: backscatter_Ro_c = 0.0 !< Coefficient in Rossby number function for backscatter.
+
 end type MEKE_type
 
 end module MOM_MEKE_types

--- a/src/parameterizations/lateral/MOM_MEKE_types.F90
+++ b/src/parameterizations/lateral/MOM_MEKE_types.F90
@@ -13,6 +13,7 @@ type, public :: MEKE_type
     mom_src => NULL(),& !< MEKE source from lateral friction in the momentum equations, in W m-2.
     GME_snk => NULL(),& !< MEKE sink from GME backscatter in the momentum equations, in W m-2.
     Kh => NULL(), &     !< The MEKE-derived lateral mixing coefficient in m2 s-1.
+    Kh_diff => NULL(), & !< Uses the non-MEKE-derived thickness diffusion coefficient to diffuse MEKE, in m2 s-1.
     Rd_dx_h => NULL()   !< The deformation radius compared with the grid spacing, nondim.
                         !! Rd_dx_h is copied from VarMix_CS.
   real, dimension(:,:), pointer :: Ku => NULL() !< The MEKE-derived lateral viscosity coefficient [m2 s-1].

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -168,7 +168,7 @@ type, public :: hor_visc_CS ; private
   integer :: id_vort_xy_q = -1, id_div_xx_h      = -1
   integer :: id_FrictWork = -1, id_FrictWorkIntz = -1
   integer :: id_FrictWorkMax = -1
-  integer :: id_FrictWork_diss = -1, id_FrictWork_GME
+  integer :: id_FrictWork_diss = -1, id_FrictWork_GME = -1
   !!@}
 
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -5,12 +5,14 @@ module MOM_hor_visc
 
 use MOM_diag_mediator,         only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator,         only : diag_ctrl, time_type
-use MOM_domains,               only : pass_var
-use MOM_error_handler,         only : MOM_error, FATAL, WARNING
+use MOM_domains,               only : pass_var, CORNER, pass_vector
+use MOM_error_handler,         only : MOM_error, FATAL, WARNING, is_root_pe
 use MOM_file_parser,           only : get_param, log_version, param_file_type
 use MOM_grid,                  only : ocean_grid_type
+use MOM_lateral_mixing_coeffs, only : VarMix_CS, calc_QG_Leith_viscosity
+use MOM_barotropic,            only : barotropic_CS, barotropic_get_tav
+use MOM_thickness_diffuse,     only : thickness_diffuse_CS, thickness_diffuse_get_KH
 use MOM_io,                    only : MOM_read_data, slasher
-use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types,            only : MEKE_type
 use MOM_open_boundary,         only : ocean_OBC_type, OBC_DIRECTION_E, OBC_DIRECTION_W
 use MOM_open_boundary,         only : OBC_DIRECTION_N, OBC_DIRECTION_S, OBC_NONE
@@ -54,8 +56,11 @@ type, public :: hor_visc_CS ; private
                              !! viscosity. KH is the background value.
   logical :: Modified_Leith  !< If true, use extra component of Leith viscosity
                              !! to damp divergent flow. To use, still set Leith_Kh=.TRUE.
+  logical :: use_beta_in_Leith !< If true, includes the beta term in the Leith viscosity
   logical :: Leith_Ah        !< If true, use a biharmonic form of 2D Leith
                              !! nonlinear eddy viscosity. AH is the background.
+  logical :: use_QG_Leith_visc    !< If true, use QG Leith nonlinear eddy viscosity.
+                             !! KH is the background value.
   logical :: bound_Coriolis  !< If true & SMAGORINSKY_AH is used, the biharmonic
                              !! viscosity is modified to include a term that
                              !! scales quadratically with the velocity shears.
@@ -71,6 +76,8 @@ type, public :: hor_visc_CS ; private
   real    :: Kh_aniso        !< The anisotropic viscosity [m2 s-1].
   logical :: dynamic_aniso   !< If true, the anisotropic viscosity is recomputed as a function
                              !! of state. This is set depending on ANISOTROPIC_MODE.
+  logical :: use_GME         !< If true, use GME backscatter scheme.
+
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: Kh_bg_xx
                       !< The background Laplacian viscosity at h points [m2 s-1].
                       !! The actual viscosity may be the larger of this
@@ -83,7 +90,7 @@ type, public :: hor_visc_CS ; private
                       !< The background biharmonic viscosity at h points [m4 s-1].
                       !! The actual viscosity may be the larger of this
                       !! viscosity and the Smagorinsky and Leith viscosities.
-  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: Biharm_Const2_xx
+  real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: Biharm5_const2_xx
                       !< A constant relating the biharmonic viscosity to the
                       !! square of the velocity shear [m4 s].  This value is
                       !! set to be the magnitude of the Coriolis terms once the
@@ -105,7 +112,7 @@ type, public :: hor_visc_CS ; private
                       !< The background biharmonic viscosity at q points [m4 s-1].
                       !! The actual viscosity may be the larger of this
                       !! viscosity and the Smagorinsky and Leith viscosities.
-  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: Biharm_Const2_xy
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: Biharm5_const2_xy
                       !< A constant relating the biharmonic viscosity to the
                       !! square of the velocity shear [m4 s].  This value is
                       !! set to be the magnitude of the Coriolis terms once the
@@ -139,16 +146,16 @@ type, public :: hor_visc_CS ; private
   ! The following variables are precalculated time-invariant combinations of
   ! parameters and metric terms.
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
-    Laplac_Const_xx,  & !< Laplacian  metric-dependent constants [nondim]
-    Biharm_Const_xx,  & !< Biharmonic metric-dependent constants [nondim]
-    Laplac3_Const_xx, & !< Laplacian  metric-dependent constants [nondim]
-    Biharm5_Const_xx    !< Biharmonic metric-dependent constants [nondim]
+    Laplac2_const_xx,  & !< Laplacian  metric-dependent constants (nondim)
+    Biharm5_const_xx,  & !< Biharmonic metric-dependent constants (nondim)
+    Laplac3_const_xx, &  !< Laplacian  metric-dependent constants (nondim)
+    Biharm6_const_xx     !< Biharmonic metric-dependent constants (nondim)
 
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &
-    Laplac_Const_xy,  & !< Laplacian  metric-dependent constants [nondim]
-    Biharm_Const_xy,  & !< Biharmonic metric-dependent constants [nondim]
-    Laplac3_Const_xy, & !< Laplacian  metric-dependent constants [nondim]
-    Biharm5_Const_xy    !< Biharmonic metric-dependent constants [nondim]
+    Laplac2_const_xy,  & !< Laplacian  metric-dependent constants (nondim)
+    Biharm5_const_xy,  & !< Biharmonic metric-dependent constants (nondim)
+    Laplac3_const_xy, &  !< Laplacian  metric-dependent constants (nondim)
+    Biharm6_const_xy     !< Biharmonic metric-dependent constants (nondim)
 
   type(diag_ctrl), pointer :: diag => NULL() !< structure to regulate diagnostics
 
@@ -157,8 +164,13 @@ type, public :: hor_visc_CS ; private
   integer :: id_diffu     = -1, id_diffv         = -1
   integer :: id_Ah_h      = -1, id_Ah_q          = -1
   integer :: id_Kh_h      = -1, id_Kh_q          = -1
+  integer :: id_GME_coeff_h = -1, id_GME_coeff_q = -1
+  integer :: id_vort_xy_q = -1, id_div_xx_h      = -1
   integer :: id_FrictWork = -1, id_FrictWorkIntz = -1
+  integer :: id_FrictWorkMax = -1, id_target_FrictWork_GME = -1
+  integer :: id_FrictWork_diss = -1, id_FrictWork_GME
   !!@}
+
 
 end type hor_visc_CS
 
@@ -176,7 +188,8 @@ contains
 !!   u[is-2:ie+2,js-2:je+2]
 !!   v[is-2:ie+2,js-2:je+2]
 !!   h[is-1:ie+1,js-1:je+1]
-subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, CS, OBC)
+subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, Barotropic, &
+                                thickness_diffuse, G, GV, US, CS, OBC)
   type(ocean_grid_type),         intent(in)  :: G      !< The ocean's grid structure.
   type(verticalGrid_type),       intent(in)  :: GV     !< The ocean's vertical grid structure.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
@@ -184,7 +197,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), &
                                  intent(in)  :: v      !< The meridional velocity [m s-1].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)),  &
-                                 intent(in)  :: h      !< Layer thicknesses [H ~> m or kg m-2]
+                                 intent(inout)  :: h      !< Layer thicknesses, in H
+                                                       !! (usually m or kg m-2).
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), &
                                  intent(out) :: diffu  !< Zonal acceleration due to convergence of
                                                        !! along-coordinate stress tensor [m s-2]
@@ -195,91 +209,146 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
                                                        !! related to Mesoscale Eddy Kinetic Energy.
   type(VarMix_CS),               pointer     :: VarMix !< Pointer to a structure with fields that
                                                        !! specify the spatially variable viscosities
+  type(barotropic_CS),           pointer     :: Barotropic  !< Pointer to a structure containing
+                                                       !! barotropic velocities
+  type(thickness_diffuse_CS),    pointer     :: thickness_diffuse  !< Pointer to a structure containing
+                                                       !! interface height diffusivities
+  type(hor_visc_CS),             pointer     :: CS     !< Control structure returned by a previous
   type(unit_scale_type),         intent(in)  :: US     !< A dimensional unit scaling type
-  type(hor_visc_CS),             pointer     :: CS     !< Pontrol structure returned by a previous
                                                        !! call to hor_visc_init.
   type(ocean_OBC_type), optional, pointer    :: OBC    !< Pointer to an open boundary condition type
+
   ! Local variables
   real, dimension(SZIB_(G),SZJ_(G)) :: &
-    u0, &   ! Laplacian of u [m-1 s-1]
-    h_u     ! Thickness interpolated to u points [H ~> m or kg m-2].
+    u0, &         ! Laplacian of u (m-1 s-1)
+    h_u, &        ! Thickness interpolated to u points, in H.
+    vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) (m-1 s-1)
+    div_xx_dx, &  ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) (m-1 s-1)
+    ubtav         ! zonal barotropic vel. ave. over baroclinic time-step (m s-1)
   real, dimension(SZI_(G),SZJB_(G)) :: &
-    v0, &   ! Laplacian of v [m-1 s-1]
-    h_v     ! Thickness interpolated to v points [H ~> m or kg m-2].
-
+    v0, &         ! Laplacian of v (m-1 s-1)
+    h_v, &        ! Thickness interpolated to v points, in H.
+    vort_xy_dx, & ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) (m-1 s-1)
+    div_xx_dy, &  ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) (m-1 s-1)
+    vbtav         ! meridional barotropic vel. ave. over baroclinic time-step (m s-1)
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    sh_xx, &      ! horizontal tension (du/dx - dv/dy) including metric terms [s-1]
-    str_xx,&      ! str_xx is the diagonal term in the stress tensor [H m2 s-2 ~> m3 s-2 or kg s-2]
-    bhstr_xx,&    ! A copy of str_xx that only contains the biharmonic contribution [H m2 s-2 ~> m3 s-2 or kg s-2]
-    div_xx, &     ! horizontal divergence (du/dx + dv/dy) including metric terms [s-1]
-    FrictWorkIntz ! depth integrated energy dissipated by lateral friction [W m-2]
+    dudx_bt, dvdy_bt, & ! components in the barotropic horizontal tension (s-1)
+    div_xx, &     ! Estimate of horizontal divergence at h-points (s-1)
+    sh_xx, &      ! horizontal tension (du/dx - dv/dy) (1/sec) including metric terms
+    sh_xx_bt, &   ! barotropic horizontal tension (du/dx - dv/dy) (1/sec) including metric terms
+    str_xx,&      ! str_xx is the diagonal term in the stress tensor (H m2 s-2)
+    str_xx_GME,&  ! smoothed diagonal term in the stress tensor from GME (H m2 s-2)
+    bhstr_xx,&    ! A copy of str_xx that only contains the biharmonic contribution (H m2 s-2)
+    FrictWorkIntz, & ! depth integrated energy dissipated by lateral friction (W/m2)
+    Leith_Kh_h, & ! Leith Laplacian viscosity at h-points (m2 s-1)
+    Leith_Ah_h, & ! Leith bi-harmonic viscosity at h-points (m4 s-1)
+    beta_h,     & ! Gradient of planetary vorticity at h-points (m-1 s-1)
+    grad_vort_mag_h, & ! Magnitude of vorticity gradient at h-points (m-1 s-1)
+    grad_vort_mag_h_2d, & ! Magnitude of 2d vorticity gradient at h-points (m-1 s-1)
+    grad_div_mag_h, &     ! Magnitude of divergence gradient at h-points (m-1 s-1)
+    dudx, dvdy, &    ! components in the horizontal tension (s-1)
+    grad_vel_mag_h, & ! Magnitude of the velocity gradient tensor squared at h-points (s-2)
+    grad_vel_mag_bt_h, & ! Magnitude of the barotropic velocity gradient tensor squared at h-points (s-2)
+    grad_d2vel_mag_h, & ! Magnitude of the Laplacian of the velocity vector, squared (m-2 s-2)
+    max_diss_rate_bt, & ! maximum possible energy dissipated by barotropic lateral friction (m2 s-3)
+    boundary_mask ! A mask that zeroes out cells with at least one land edge
 
   real, dimension(SZIB_(G),SZJB_(G)) :: &
-    dvdx, dudy, & ! components in the shearing strain [s-1]
-    sh_xy,  &     ! horizontal shearing strain (du/dy + dv/dx) including metric terms [s-1]
-    str_xy, &     ! str_xy is the cross term in the stress tensor [H m2 s-2 ~> m3 s-2 or kg s-2]
-    bhstr_xy, &   ! A copy of str_xy that only contains the biharmonic contribution [H m2 s-2 ~> m3 s-2 or kg s-2]
-    vort_xy       ! vertical vorticity (dv/dx - du/dy) including metric terms [s-1]
-
-  real, dimension(SZI_(G),SZJB_(G)) :: &
-    vort_xy_dx, & ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) including metric terms [m-1 s-1]
-    div_xx_dy     ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) including metric terms [m-1 s-1]
-
-  real, dimension(SZIB_(G),SZJ_(G)) :: &
-    vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) including metric terms [m-1 s-1]
-    div_xx_dx     ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) including metric terms [m-1 s-1]
+    dvdx, dudy, & ! components in the shearing strain (s-1)
+    dvdx_bt, dudy_bt, & ! components in the barotropic shearing strain (s-1)
+    sh_xy,  &     ! horizontal shearing strain (du/dy + dv/dx) (1/sec) including metric terms
+    sh_xy_bt, &   ! barotropic horizontal shearing strain (du/dy + dv/dx) (1/sec) inc. metric terms
+    str_xy, &     ! str_xy is the cross term in the stress tensor (H m2 s-2)
+    str_xy_GME, & ! smoothed cross term in the stress tensor from GME (H m2 s-2)
+    bhstr_xy, &   ! A copy of str_xy that only contains the biharmonic contribution (H m2 s-2)
+    vort_xy, & ! Vertical vorticity (dv/dx - du/dy) (s-1)
+    Leith_Kh_q, & ! Leith Laplacian viscosity at q-points (m2 s-1)
+    Leith_Ah_q, & ! Leith bi-harmonic viscosity at q-points (m4 s-1)
+    beta_q,     & ! Gradient of planetary vorticity at q-points (m-1 s-1)
+    grad_vort_mag_q, & ! Magnitude of vorticity gradient at q-points (m-1 s-1)
+    grad_vort_mag_q_2d, & ! Magnitude of 2d vorticity gradient at q-points (m-1 s-1)
+    grad_div_mag_q, &  ! Magnitude of divergence gradient at q-points (m-1 s-1)
+    grad_vel_mag_q, &  ! Magnitude of the velocity gradient tensor squared at q-points (s-2)
+    hq, &  ! harmonic mean of the harmonic means of the u- & v point thicknesses, in H; This form guarantees that hq/hu < 4.
+    grad_vel_mag_bt_q  ! Magnitude of the barotropic velocity gradient tensor squared at q-points (s-2)
 
   real, dimension(SZIB_(G),SZJB_(G),SZK_(G)) :: &
-    Ah_q, &   ! biharmonic viscosity at corner points [m4 s-1]
-    Kh_q      ! Laplacian viscosity at corner points [m2 s-1]
+    Ah_q, &      ! biharmonic viscosity at corner points (m4/s)
+    Kh_q, &      ! Laplacian viscosity at corner points (m2/s)
+    vort_xy_q, & ! vertical vorticity at corner points (s-1)
+    GME_coeff_q  !< GME coeff. at q-points (m2 s-1)
 
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)+1) :: &
+    KH_u_GME  !< interface height diffusivities in u-columns (m2 s-1)
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)+1) :: &
+    KH_v_GME  !< interface height diffusivities in v-columns (m2 s-1)
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: &
-    Ah_h, &          ! biharmonic viscosity at thickness points [m4 s-1]
-    Kh_h, &          ! Laplacian viscosity at thickness points [m2 s-1]
-    FrictWork        ! energy dissipated by lateral friction [W m-2]
-
-  real :: Ah         ! biharmonic viscosity [m4 s-1]
-  real :: Kh         ! Laplacian  viscosity [m2 s-1]
-  real :: AhSm       ! Smagorinsky biharmonic viscosity [m4 s-1]
-  real :: KhSm       ! Smagorinsky Laplacian viscosity  [m2 s-1]
-  real :: AhLth      ! 2D Leith biharmonic viscosity [m4 s-1]
-  real :: KhLth      ! 2D Leith Laplacian viscosity  [m2 s-1]
+    Ah_h, &          ! biharmonic viscosity at thickness points (m4/s)
+    Kh_h, &          ! Laplacian viscosity at thickness points (m2/s)
+    diss_rate, & ! MKE dissipated by parameterized shear production (m2 s-3)
+    max_diss_rate, & ! maximum possible energy dissipated by lateral friction (m2 s-3)
+    target_diss_rate_GME, & ! target amount of energy to add via GME (m2 s-3)
+    FrictWork, &     ! work done by MKE dissipation mechanisms (W/m2)
+    FrictWork_diss, &  ! negative definite work done by MKE dissipation mechanisms (W/m2)
+    FrictWorkMax, &     ! maximum possible work done by MKE dissipation mechanisms (W/m2)
+    FrictWork_GME, &  ! work done by GME (W/m2)
+    target_FrictWork_GME, & ! target amount of work for GME to do (W/m2)
+    div_xx_h         ! horizontal divergence (s-1)
+  !real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: &
+  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: &
+    KH_t_GME, &      !< interface height diffusivities in t-columns (m2 s-1)
+    GME_coeff_h      !< GME coeff. at h-points (m2 s-1)
+  real :: Ah         ! biharmonic viscosity (m4/s)
+  real :: Kh         ! Laplacian  viscosity (m2/s)
+  real :: AhSm       ! Smagorinsky biharmonic viscosity (m4/s)
+  real :: KhSm       ! Smagorinsky Laplacian viscosity  (m2/s)
+  real :: AhLth      ! 2D Leith biharmonic viscosity (m4/s)
+  real :: KhLth      ! 2D Leith Laplacian viscosity  (m2/s)
   real :: mod_Leith  ! nondimensional coefficient for divergence part of modified Leith
                      ! viscosity. Here set equal to nondimensional Laplacian Leith constant.
                      ! This is set equal to zero if modified Leith is not used.
-  real :: Shear_mag  ! magnitude of the shear [s-1]
-  real :: Vort_mag   ! magnitude of the vorticity [s-1]
-  real :: h2uq, h2vq ! temporary variables [H2 ~> m2 or kg2 m-4].
+  real :: Shear_mag  ! magnitude of the shear (1/s)
+  real :: vert_vort_mag  ! magnitude of the vertical vorticity gradient (m-1 s-1)
+  real :: h2uq, h2vq ! temporary variables in units of H^2 (i.e. m2 or kg2 m-4).
   real :: hu, hv     ! Thicknesses interpolated by arithmetic means to corner
                      ! points; these are first interpolated to u or v velocity
-                     ! points where masks are applied [H ~> m or kg m-2].
-  real :: hq         ! harmonic mean of the harmonic means of the u- & v- poing thicknesses,
-                     ! [H ~> m or kg m-2]; This form guarantees that hq/hu < 4.
-  real :: h_neglect  ! thickness so small it can be lost in roundoff and so neglected [H ~> m or kg m-2]
-  real :: h_neglect3 ! h_neglect^3 [H3 ~> m3 or kg3 m-6]
+                     ! points where masks are applied, in units of H (i.e. m or kg m-2).
+!  real :: hq         ! harmonic mean of the harmonic means of the u- & v-
+!                     ! point thicknesses, in H; This form guarantees that hq/hu < 4.
+  real :: h_neglect  ! thickness so small it can be lost in roundoff and so neglected (H)
+  real :: h_neglect3 ! h_neglect^3, in H3
   real :: hrat_min   ! minimum thicknesses at the 4 neighboring
                      ! velocity points divided by the thickness at the stress
                      ! point (h or q point) [nondim]
   real :: visc_bound_rem ! fraction of overall viscous bounds that
                          ! remain to be applied [nondim]
   real :: Kh_scale  ! A factor between 0 and 1 by which the horizontal
-                    ! Laplacian viscosity is rescaled [nondim]
-  real :: RoScl     ! The scaling function for MEKE source term [nondim]
-  real :: FatH      ! abs(f) at h-point for MEKE source term [s-1]
-  real :: local_strain ! Local variable for interpolating computed strain rates [s-1].
-
+                    ! Laplacian viscosity is rescaled
+  real :: RoScl     ! The scaling function for MEKE source term
+  real :: FatH      ! abs(f) at h-point for MEKE source term (s-1)
+  real :: local_strain ! Local variable for interpolating computed strain rates (s-1).
+  real :: epsilon
+  real :: GME_coeff ! The GME (negative) viscosity coefficient (m2 s-1)
+  real :: GME_coeff_limiter ! Maximum permitted value of the GME coefficient (m2 s-1)
+  real :: FWfrac ! Fraction of maximum theoretical energy transfer to use when scaling GME coefficient
+  real :: DY_dxBu, DX_dyBu
+  real :: H0 ! Depth used to scale down GME coefficient in shallow areas (m)
   logical :: rescale_Kh, legacy_bound
   logical :: find_FrictWork
   logical :: apply_OBC = .false.
   logical :: use_MEKE_Ku
+  logical :: use_MEKE_Au
   integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: i, j, k, n
-
+  real :: inv_PI3, inv_PI6
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = G%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
 
   h_neglect  = GV%H_subroundoff
   h_neglect3 = h_neglect**3
+  inv_PI3 = 1.0/((4.0*atan(1.0))**3)
+  inv_PI6 = inv_PI3**2
+  epsilon = 1.e-7
 
   if (present(OBC)) then ; if (associated(OBC)) then ; if (OBC%OBC_pe) then
     apply_OBC = OBC%Flather_u_BCs_exist_globally .or. OBC%Flather_v_BCs_exist_globally
@@ -307,27 +376,110 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   legacy_bound = (CS%Smagorinsky_Kh .or. CS%Leith_Kh) .and. &
                  (CS%bound_Kh .and. .not.CS%better_bound_Kh)
 
-  ! Coefficient for modified Leith
-  if (CS%Modified_Leith) then
-    mod_Leith = 1.0
-  else
-    mod_Leith = 0.0
-  endif
-
   ! Toggle whether to use a Laplacian viscosity derived from MEKE
   use_MEKE_Ku = associated(MEKE%Ku)
+  use_MEKE_Au = associated(MEKE%Au)
 
-  !$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,nz,CS,G,GV,u,v,is,js,ie,je,h,  &
-  !$OMP                                  rescale_Kh,VarMix,h_neglect,h_neglect3,        &
-  !$OMP                                  Kh_h,Ah_h,Kh_q,Ah_q,diffu,apply_OBC,OBC,diffv, &
-  !$OMP                                  find_FrictWork,FrictWork,use_MEKE_Ku,MEKE,     &
-  !$OMP                                  mod_Leith, legacy_bound)                       &
-  !$OMP                          private(u0, v0, sh_xx, str_xx, visc_bound_rem,         &
-  !$OMP                                  sh_xy, str_xy, Ah, Kh, AhSm, KhSm, dvdx, dudy, &
-  !$OMP                                  bhstr_xx, bhstr_xy,FatH,RoScl, hu, hv, h_u, h_v, &
-  !$OMP                                  vort_xy,vort_xy_dx,vort_xy_dy,Vort_mag,AhLth,KhLth, &
-  !$OMP                                  div_xx, div_xx_dx, div_xx_dy, local_strain,    &
-  !$OMP                                  Shear_mag, h2uq, h2vq, hq, Kh_scale, hrat_min)
+!$OMP parallel do default(none) shared(Isq,Ieq,Jsq,Jeq,nz,CS,G,GV,u,v,is,js,ie,je,h,  &
+!$OMP                                  rescale_Kh,VarMix,h_neglect,h_neglect3,        &
+!$OMP                                  Kh_h,Ah_h,Kh_q,Ah_q,diffu,apply_OBC,OBC,diffv, &
+!$OMP                                  find_FrictWork,FrictWork,use_MEKE_Ku,          &
+!$OMP                                  use_MEKE_Au, MEKE, hq,                         &
+!$OMP                                  mod_Leith, legacy_bound, div_xx_h, vort_xy_q)  &
+!$OMP                          private(u0, v0, sh_xx, str_xx, visc_bound_rem, &
+!$OMP                                  sh_xy, str_xy, Ah, Kh, AhSm, KhSm, dvdx, dudy, &
+!$OMP                                  sh_xx_bt, sh_xy_bt, dvdx_bt, dudy_bt, &
+!$OMP                                  bhstr_xx, bhstr_xy,FatH,RoScl, hu, hv, h_u, h_v, &
+!$OMP                                  vort_xy,vort_xy_dx,vort_xy_dy,Vort_mag,AhLth,KhLth, &
+!$OMP                                  div_xx, div_xx_dx, div_xx_dy,local_strain,          &
+!$OMP                                  Shear_mag, h2uq, h2vq, Kh_scale, hrat_min)
+
+  if (CS%use_GME) then
+    ! GME tapers off above this depth
+    H0 = 1000.0
+    FWfrac = 0.1
+    GME_coeff_limiter = 1e7
+
+    ! initialize diag. array with zeros
+    GME_coeff_h(:,:,:) = 0.0
+    GME_coeff_q(:,:,:) = 0.0
+    str_xx_GME(:,:) = 0.0
+    str_xy_GME(:,:) = 0.0
+
+    do j=js,je ; do i=is,ie
+      boundary_mask(i,j) = (G%mask2dCu(I,j) * G%mask2dCv(i,J) * G%mask2dCu(I-1,j) * G%mask2dCv(i,J-1))
+    enddo ; enddo
+
+    call pass_var(boundary_mask, G%Domain, complete=.true.)
+
+    ! Get barotropic velocities and their gradients
+    call barotropic_get_tav(Barotropic, ubtav, vbtav, G)
+    call pass_vector(ubtav, vbtav, G%Domain)
+
+    do j=js,je ; do i=is,ie
+      dudx_bt(i,j) = CS%DY_dxT(i,j)*(G%IdyCu(I,j) * ubtav(I,j) - &
+                                     G%IdyCu(I-1,j) * ubtav(I-1,j))
+      dvdy_bt(i,j) = CS%DX_dyT(i,j)*(G%IdxCv(i,J) * vbtav(i,J) - &
+                                     G%IdxCv(i,J-1) * vbtav(i,J-1))
+    enddo; enddo
+
+    call pass_var(dudx_bt, G%Domain, complete=.true.)
+    call pass_var(dvdy_bt, G%Domain, complete=.true.)
+
+    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+      sh_xx_bt(i,j) = dudx_bt(i,j) - dvdy_bt(i,j)
+    enddo ; enddo
+
+    ! Components for the barotropic shearing strain
+    do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+      dvdx_bt(I,J) = CS%DY_dxBu(I,J)*(vbtav(i+1,J)*G%IdyCv(i+1,J) &
+                                    - vbtav(i,J)*G%IdyCv(i,J))
+      dudy_bt(I,J) = CS%DX_dyBu(I,J)*(ubtav(I,j+1)*G%IdxCu(I,j+1) &
+                                    - ubtav(I,j)*G%IdxCu(I,j))
+    enddo ; enddo
+
+    call pass_var(dvdx_bt, G%Domain, position=CORNER, complete=.true.)
+    call pass_var(dudy_bt, G%Domain, position=CORNER, complete=.true.)
+
+    if (CS%no_slip) then
+      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+        sh_xy_bt(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
+      enddo ; enddo
+    else
+      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+        sh_xy_bt(I,J) = G%mask2dBu(I,J) * ( dvdx_bt(I,J) + dudy_bt(I,J) )
+      enddo ; enddo
+    endif
+
+    ! Get thickness diffusivity for use in GME
+!    call thickness_diffuse_get_KH(thickness_diffuse, KH_u_GME, KH_v_GME, G)
+
+    do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+      grad_vel_mag_bt_h(i,j) = boundary_mask(i,j) * (dudx_bt(i,j)**2 + dvdy_bt(i,j)**2 + &
+            (0.25*(dvdx_bt(I,J)+dvdx_bt(I-1,J)+dvdx_bt(I,J-1)+dvdx_bt(I-1,J-1)) )**2 + &
+            (0.25*(dudy_bt(I,J)+dudy_bt(I-1,J)+dudy_bt(I,J-1)+dudy_bt(I-1,J-1)) )**2)
+    enddo ; enddo
+
+    if (associated(MEKE)) then ; if (associated(MEKE%mom_src)) then
+      do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+        max_diss_rate_bt(i,j) = 2.0*MEKE%MEKE(i,j) * grad_vel_mag_bt_h(i,j)
+      enddo ; enddo
+    endif ; endif
+
+    do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+      grad_vel_mag_bt_q(I,J) = boundary_mask(i,j) * (dvdx_bt(i,j)**2 + dudy_bt(i,j)**2 + &
+            (0.25*(dudx_bt(i,j)+dudx_bt(i+1,j)+dudx_bt(i,j+1)+dudx_bt(i+1,j+1)))**2 + &
+            (0.25*(dvdy_bt(i,j)+dvdy_bt(i+1,j)+dvdy_bt(i,j+1)+dvdy_bt(i+1,j+1)) )**2)
+    enddo ; enddo
+
+
+    ! halo updates (presently not used since GME is now hooked to MEKE)
+!    call pass_vector(KH_u_GME, KH_v_GME, G%Domain)
+!    call pass_vector(VarMix%slope_x, VarMix%slope_y, G%Domain)
+!    call pass_vector(VarMix%N2_u, VarMix%N2_v, G%Domain)
+
+  endif ! use_GME
+
   do k=1,nz
 
     ! The following are the forms of the horizontal tension and horizontal
@@ -336,10 +488,11 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
     ! Calculate horizontal tension
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-      sh_xx(i,j) = (CS%DY_dxT(i,j)*(G%IdyCu(I,j) * u(I,j,k) - &
-                                    G%IdyCu(I-1,j) * u(I-1,j,k)) - &
-                    CS%DX_dyT(i,j)*(G%IdxCv(i,J) * v(i,J,k) - &
-                                    G%IdxCv(i,J-1)*v(i,J-1,k)))
+          dudx(i,j) = CS%DY_dxT(i,j)*(G%IdyCu(I,j) * u(I,j,k) - &
+                                     G%IdyCu(I-1,j) * u(I-1,j,k))
+          dvdy(i,j) = CS%DX_dyT(i,j)*(G%IdxCv(i,J) * v(i,J,k) - &
+                                     G%IdxCv(i,J-1) * v(i,J-1,k))
+          sh_xx(i,j) = dudx(i,j) - dvdy(i,j)
     enddo ; enddo
 
     ! Components for the shearing strain
@@ -476,18 +629,6 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       endif
     enddo ; endif
 
-    ! Calculate horizontal divergence (not from continuity) if needed.
-    ! h_u and h_v include modifications at OBCs from above.
-    if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
-      do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
-        div_xx(i,j) = ((G%dyCu(I  ,j) * u(I  ,j,k) * h_u(I  ,j) - &
-                        G%dyCu(I-1,j) * u(I-1,j,k) * h_u(I-1,j) ) + &
-                       (G%dxCv(i,J  ) * v(i,J  ,k) * h_v(i,J  ) - &
-                        G%dxCv(i,J-1) * v(i,J-1,k) * h_v(i,J-1) ) )*G%IareaT(i,j)/ &
-                                  (h(i,j,k) + h_neglect)
-      enddo ; enddo
-    endif
-
     ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
     ! dudy and dvdx include modifications at OBCs from above.
     if (CS%no_slip) then
@@ -497,38 +638,6 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     else
       do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
         sh_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) + dudy(I,J) )
-      enddo ; enddo
-    endif
-
-    if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
-      ! Calculate relative vorticity (including no-slip boundary conditions at the 2-D land-sea mask).
-      ! dudy and dvdx include modifications at OBCs from above.
-      if (CS%no_slip) then
-        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-          vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
-        enddo ; enddo
-      else
-        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
-          vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
-        enddo ; enddo
-      endif
-
-      ! Vorticity gradient
-      do J=js-2,Jeq+1 ; do I=is-1,Ieq+1
-        vort_xy_dx(i,J) = CS%DY_dxBu(I,J)*(vort_xy(I,J)*G%IdyCu(I,j) - vort_xy(I-1,J)*G%IdyCu(I-1,j))
-      enddo ; enddo
-
-      do J=js-1,Jeq+1 ; do I=is-2,Ieq+1
-        vort_xy_dy(I,j) = CS%DX_dyBu(I,J)*(vort_xy(I,J)*G%IdxCv(i,J) - vort_xy(I,J-1)*G%IdxCv(i,J-1))
-      enddo ; enddo
-
-      ! Divergence gradient
-      do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
-        div_xx_dx(I,j) = G%IdxCu(I,j)*(div_xx(i+1,j) - div_xx(i,j))
-      enddo ; enddo
-
-      do J=Jsq-1,Jeq+1 ; do i=is-1,Ieq+1
-        div_xx_dy(i,J) = G%IdyCv(i,J)*(div_xx(i,j+1) - div_xx(i,j))
       enddo ; enddo
     endif
 
@@ -558,18 +667,156 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       endif; endif
     endif
 
-    do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+    if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
+
+      ! Components for the vertical vorticity
+      ! Note this a simple re-calculation of shearing components using the same discretization.
+      ! We will consider using a circulation based calculation of vorticity later.
+      ! Also note this will need OBC boundary conditions re-applied...
+      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+        DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+        dvdx(I,J) = DY_dxBu * (v(i+1,J,k) * G%IdyCv(i+1,J) - v(i,J,k) * G%IdyCv(i,J))
+        DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+        dudy(I,J) = DX_dyBu * (u(I,j+1,k) * G%IdxCu(I,j+1) - u(I,j,k) * G%IdxCu(I,j))
+      enddo ; enddo
+
+      ! Vorticity
+      if (CS%no_slip) then
+        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+          vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
+          dudy(I,J) = (2.0-G%mask2dBu(I,J)) * dudy(I,J)
+          dvdx(I,J) = (2.0-G%mask2dBu(I,J)) * dvdx(I,J)
+        enddo ; enddo
+      else
+        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+          vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
+          dudy(I,J) = G%mask2dBu(I,J) * dudy(I,J)
+          dvdx(I,J) = G%mask2dBu(I,J) * dvdx(I,J)
+        enddo ; enddo
+      endif
+
+      call pass_var(vort_xy, G%Domain, position=CORNER, complete=.true.)
+
+      ! Vorticity gradient
+      do J=js-2,Jeq+1 ; do i=is-1,Ieq+1
+        DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+        vort_xy_dx(i,J) = DY_dxBu * (vort_xy(I,J) * G%IdyCu(I,j) - vort_xy(I-1,J) * G%IdyCu(I-1,j))
+      enddo ; enddo
+
+      do j=js-1,Jeq+1 ; do I=is-2,Ieq+1
+        DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+        vort_xy_dy(I,j) = DX_dyBu * (vort_xy(I,J) * G%IdxCv(i,J) - vort_xy(I,J-1) * G%IdxCv(i,J-1))
+      enddo ; enddo
+
+      call pass_vector(vort_xy_dy, vort_xy_dx, G%Domain)
+
+      if (CS%modified_Leith) then
+        ! Divergence
+        do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+          div_xx(i,j) = 0.5*((G%dyCu(I,j) * u(I,j,k) * (h(i+1,j,k)+h(i,j,k)) - &
+                        G%dyCu(I-1,j) * u(I-1,j,k) * (h(i-1,j,k)+h(i,j,k)) ) + &
+                        (G%dxCv(i,J) * v(i,J,k) * (h(i,j,k)+h(i,j+1,k)) - &
+                        G%dxCv(i,J-1)*v(i,J-1,k)*(h(i,j,k)+h(i,j-1,k))))*G%IareaT(i,j)/ &
+                        (h(i,j,k) + GV%H_subroundoff)
+        enddo ; enddo
+
+        call pass_var(div_xx, G%Domain, complete=.true.)
+
+        ! Divergence gradient
+        do j=Jsq-1,Jeq+2 ; do I=is-2,Ieq+1
+          div_xx_dx(I,j) = G%IdxCu(I,j)*(div_xx(i+1,j) - div_xx(i,j))
+        enddo ; enddo
+        do J=js-2,Jeq+1 ; do i=Isq-1,Ieq+2
+          div_xx_dy(i,J) = G%IdyCv(i,J)*(div_xx(i,j+1) - div_xx(i,j))
+        enddo ; enddo
+
+        call pass_vector(div_xx_dx, div_xx_dy, G%Domain)
+
+        ! Magnitude of divergence gradient
+        do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+          grad_div_mag_h(i,j) =sqrt((0.5*(div_xx_dx(I,j) + div_xx_dx(I-1,j)))**2 + &
+          (0.5 * (div_xx_dy(i,J) + div_xx_dy(i,J-1)))**2)
+        enddo ; enddo
+        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+          grad_div_mag_q(I,J) =sqrt((0.5*(div_xx_dx(I,j) + div_xx_dx(I,j+1)))**2 + &
+          (0.5 * (div_xx_dy(i,J) + div_xx_dy(i+1,J)))**2)
+        enddo ; enddo
+
+      else
+
+        do j=Jsq-1,Jeq+2 ; do I=is-2,Ieq+1
+          div_xx_dx(I,j) = 0.0
+        enddo ; enddo
+        do J=js-2,Jeq+1 ; do i=Isq-1,Ieq+2
+          div_xx_dy(i,J) = 0.0
+        enddo ; enddo
+        do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+          grad_div_mag_h(i,j) = 0.0
+        enddo ; enddo
+        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+          grad_div_mag_q(I,J) = 0.0
+        enddo ; enddo
+
+      endif ! CS%modified_Leith
+
+      ! Add in beta for the Leith viscosity
+      if (CS%use_beta_in_Leith) then
+        do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+          beta_h(i,j) = sqrt( G%dF_dx(i,j)**2 + G%dF_dy(i,j)**2 )
+        enddo; enddo
+        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+          beta_q(I,J) = sqrt( (0.25*(G%dF_dx(i,j)+G%dF_dx(i+1,j)+G%dF_dx(i,j+1)+G%dF_dx(i+1,j+1))**2) + &
+                       (0.25*(G%dF_dy(i,j)+G%dF_dy(i+1,j)+G%dF_dy(i,j+1)+G%dF_dy(i+1,j+1))**2) )
+        enddo ; enddo
+
+        do J=js-2,Jeq+1 ; do i=is-1,Ieq+1
+            vort_xy_dx(i,J) = vort_xy_dx(i,J) + 0.5 * ( G%dF_dx(i,j) + G%dF_dx(i,j+1))
+        enddo ; enddo
+        do j=js-1,Jeq+1 ; do I=is-2,Ieq+1
+            vort_xy_dy(I,j) = vort_xy_dy(I,j) + 0.5 * ( G%dF_dy(i,j) + G%dF_dy(i+1,j))
+        enddo ; enddo
+      endif ! CS%use_beta_in_Leith
+
+      if (CS%use_QG_Leith_visc) then
+
+        do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+          grad_vort_mag_h_2d(i,j) = SQRT((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i,J-1)))**2 + (0.5*(vort_xy_dy(I,j) +  &
+                               vort_xy_dy(I-1,j)))**2 )
+        enddo; enddo
+        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+          grad_vort_mag_q_2d(I,J) = SQRT((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i+1,J)))**2 + (0.5*(vort_xy_dy(I,j) +  &
+                                 vort_xy_dy(I,j+1)))**2 )
+        enddo ; enddo
+
+        call calc_QG_Leith_viscosity(VarMix, G, GV, h, k, div_xx_dx, div_xx_dy, &
+                                     vort_xy_dx, vort_xy_dy)
+
+      endif
+
+      do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+        grad_vort_mag_h(i,j) = SQRT((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i,J-1)))**2 + (0.5*(vort_xy_dy(I,j) +  &
+                               vort_xy_dy(I-1,j)))**2 )
+      enddo; enddo
+      do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+        grad_vort_mag_q(I,J) = SQRT((0.5*(vort_xy_dx(i,J) + vort_xy_dx(i+1,J)))**2 + (0.5*(vort_xy_dy(I,j) +  &
+                                 vort_xy_dy(I,j+1)))**2 )
+      enddo ; enddo
+
+    endif ! CS%Leith_Kh
+
+    do J=Jsq,Jeq+1 ; do i=Isq,Ieq+1
       if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
         Shear_mag = sqrt(sh_xx(i,j)*sh_xx(i,j) + &
           0.25*((sh_xy(I-1,J-1)*sh_xy(I-1,J-1) + sh_xy(I,J)*sh_xy(I,J)) + &
                 (sh_xy(I-1,J)*sh_xy(I-1,J) + sh_xy(I,J-1)*sh_xy(I,J-1))))
       endif
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
-        Vort_mag = sqrt( &
-          0.5*((vort_xy_dx(i,J-1)*vort_xy_dx(i,J-1) + vort_xy_dx(i,J)*vort_xy_dx(i,J)) + &
-                (vort_xy_dy(I-1,j)*vort_xy_dy(I-1,j) + vort_xy_dy(I,j)*vort_xy_dy(I,j))) + &
-          mod_Leith*0.5*((div_xx_dx(I,j)*div_xx_dx(I,j) + div_xx_dx(I-1,j)*div_xx_dx(I-1,j)) + &
-                (div_xx_dy(i,J)*div_xx_dy(i,J) + div_xx_dy(i,J-1)*div_xx_dy(i,J-1))))
+        if (CS%use_QG_Leith_visc) then
+          !vert_vort_mag = MIN(grad_vort_mag_h(i,j) + grad_div_mag_h(i,j), beta_h(i,j)*3)
+          vert_vort_mag = MIN(grad_vort_mag_h(i,j) + grad_div_mag_h(i,j),3*grad_vort_mag_h_2d(i,j))
+        else
+          vert_vort_mag = grad_vort_mag_h(i,j) + grad_div_mag_h(i,j)
+        endif
       endif
       if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
         hrat_min = min(1.0, min(h_u(I,j), h_u(I-1,j), h_v(i,J), h_v(i,J-1)) / &
@@ -581,8 +828,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         ! Determine the Laplacian viscosity at h points, using the
         ! largest value from several parameterizations.
         Kh = CS%Kh_bg_xx(i,j) ! Static (pre-computed) background viscosity
-        if (CS%Smagorinsky_Kh) Kh = max( Kh, CS%LAPLAC_CONST_xx(i,j) * Shear_mag )
-        if (CS%Leith_Kh) Kh = max( Kh, CS%LAPLAC3_CONST_xx(i,j) * Vort_mag )
+        if (CS%Smagorinsky_Kh) Kh = max( Kh, CS%Laplac2_const_xx(i,j) * Shear_mag )
+        if (CS%Leith_Kh) Kh = max( Kh, CS%Laplac3_const_xx(i,j) * vert_vort_mag*inv_PI3)
         ! All viscosity contributions above are subject to resolution scaling
         if (rescale_Kh) Kh = VarMix%Res_fn_h(i,j) * Kh
         ! Older method of bounding for stability
@@ -603,10 +850,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
           endif
         endif
 
-        if (CS%id_Kh_h>0) Kh_h(i,j,k) = Kh
+        if ((CS%id_Kh_h>0) .or. find_FrictWork) Kh_h(i,j,k) = Kh
+        if (CS%id_div_xx_h>0) div_xx_h(i,j,k) = div_xx(i,j)
 
         str_xx(i,j) = -Kh * sh_xx(i,j)
       else   ! not Laplacian
+        Kh_h(i,j,k) = 0.0
         str_xx(i,j) = 0.0
       endif ! Laplacian
 
@@ -624,14 +873,13 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah)) then
           if (CS%Smagorinsky_Ah) then
             if (CS%bound_Coriolis) then
-              AhSm =  Shear_mag * (CS%BIHARM_CONST_xx(i,j) + &
-                                 CS%Biharm_Const2_xx(i,j)*Shear_mag)
+              AhSm =  Shear_mag * (CS%Biharm5_const_xx(i,j) + &
+                                 CS%Biharm5_const2_xx(i,j)*Shear_mag)
             else
-              AhSm = CS%BIHARM_CONST_xx(i,j) * Shear_mag
+              AhSm = CS%Biharm5_const_xx(i,j) * Shear_mag
             endif
           endif
-          if (CS%Leith_Ah) &
-            AhLth = Vort_mag * (CS%BIHARM_CONST_xx(i,j))
+          if (CS%Leith_Ah) AhLth = CS%Biharm6_const_xx(i,j) * vert_vort_mag*inv_PI6
           Ah = MAX(MAX(CS%Ah_bg_xx(i,j), AhSm),AhLth)
           if (CS%bound_Ah .and. .not.CS%better_bound_Ah) &
             Ah = MIN(Ah, CS%Ah_Max_xx(i,j))
@@ -639,11 +887,13 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
           Ah = CS%Ah_bg_xx(i,j)
         endif ! Smagorinsky_Ah or Leith_Ah
 
+        if (use_MEKE_Au) Ah = Ah + MEKE%Au(i,j) ! *Add* the MEKE contribution
+
         if (CS%better_bound_Ah) then
           Ah = MIN(Ah, visc_bound_rem*hrat_min*CS%Ah_Max_xx(i,j))
         endif
 
-        if (CS%id_Ah_h>0) Ah_h(i,j,k) = Ah
+        if ((CS%id_Ah_h>0) .or. find_FrictWork) Ah_h(i,j,k) = Ah
 
         str_xx(i,j) = str_xx(i,j) + Ah * &
           (CS%DY_dxT(i,j)*(G%IdyCu(I,j)*u0(I,j) - G%IdyCu(I-1,j)*u0(I-1,j)) - &
@@ -655,9 +905,10 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
            CS%DX_dyT(i,j) *(G%IdxCv(i,J)*v0(i,J) - G%IdxCv(i,J-1)*v0(i,J-1)))
         bhstr_xx(i,j) = bhstr_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
 
+      else
+        Ah_h(i,j,k) = 0.0
       endif  ! biharmonic
 
-      str_xx(i,j) = str_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
     enddo ; enddo
 
     if (CS%biharmonic) then
@@ -697,23 +948,24 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
             0.25*((sh_xx(i,j)*sh_xx(i,j) + sh_xx(i+1,j+1)*sh_xx(i+1,j+1)) + &
                   (sh_xx(i,j+1)*sh_xx(i,j+1) + sh_xx(i+1,j)*sh_xx(i+1,j))))
       endif
-      if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) &
-        Vort_mag = sqrt( &
-          0.5*((vort_xy_dx(i,J)*vort_xy_dx(i,J) + vort_xy_dx(i+1,J)*vort_xy_dx(i+1,J)) + &
-                (vort_xy_dy(I,j)*vort_xy_dy(I,j) + vort_xy_dy(I,j+1)*vort_xy_dy(I,j+1))) + &
-          mod_Leith*0.5*((div_xx_dx(I,j)*div_xx_dx(I,j) + div_xx_dx(I,j+1)*div_xx_dx(I,j+1)) + &
-                (div_xx_dy(i,J)*div_xx_dy(i,J) + div_xx_dy(i+1,J)*div_xx_dy(i+1,J))))
-
+      if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
+        if (CS%use_QG_Leith_visc) then
+          vert_vort_mag = MIN(grad_vort_mag_q(I,J) + grad_div_mag_q(I,J), 3*grad_vort_mag_q_2d(I,J))
+          !vert_vort_mag = MIN(grad_vort_mag_q(I,J) + grad_div_mag_q(I,J), beta_q(I,J)*3)
+        else
+          vert_vort_mag = grad_vort_mag_q(I,J) + grad_div_mag_q(I,J)
+        endif
+      endif
       h2uq = 4.0 * h_u(I,j) * h_u(I,j+1)
       h2vq = 4.0 * h_v(i,J) * h_v(i+1,J)
       !hq = 2.0 * h2uq * h2vq / (h_neglect3 + (h2uq + h2vq) * &
       !    ((h(i,j,k) + h(i+1,j+1,k)) + (h(i,j+1,k) + h(i+1,j,k))))
-      hq = 2.0 * h2uq * h2vq / (h_neglect3 + (h2uq + h2vq) * &
-          ((h_u(I,j) + h_u(I,j+1)) + (h_v(i,J) + h_v(i+1,J))))
+      hq(I,J) = 2.0 * h2uq * h2vq / (h_neglect3 + (h2uq + h2vq) * &
+              ((h_u(I,j) + h_u(I,j+1)) + (h_v(i,J) + h_v(i+1,J))))
 
       if (CS%better_bound_Ah .or. CS%better_bound_Kh) then
         hrat_min = min(1.0, min(h_u(I,j), h_u(I,j+1), h_v(i,J), h_v(i+1,J)) / &
-                            (hq + h_neglect) )
+                            (hq(I,J) + h_neglect) )
         visc_bound_rem = 1.0
       endif
 
@@ -727,12 +979,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
           if ((G%mask2dCu(I,j) + G%mask2dCu(I,j+1)) * &
               (G%mask2dCv(i,J) + G%mask2dCv(i+1,J)) == 0.0) then
             ! Only one of hu and hv is nonzero, so just add them.
-            hq = hu + hv
+            hq(I,J) = hu + hv
             hrat_min = 1.0
           else
             ! Both hu and hv are nonzero, so take the harmonic mean.
-            hq = 2.0 * (hu * hv) / ((hu + hv) + h_neglect)
-            hrat_min = min(1.0, min(hu, hv) / (hq + h_neglect) )
+            hq(I,J) = 2.0 * (hu * hv) / ((hu + hv) + h_neglect)
+            hrat_min = min(1.0, min(hu, hv) / (hq(I,J) + h_neglect) )
           endif
         endif
       endif
@@ -741,8 +993,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         ! Determine the Laplacian viscosity at q points, using the
         ! largest value from several parameterizations.
         Kh = CS%Kh_bg_xy(i,j) ! Static (pre-computed) background viscosity
-        if (CS%Smagorinsky_Kh) Kh = max( Kh, CS%LAPLAC_CONST_xy(I,J) * Shear_mag )
-        if (CS%Leith_Kh) Kh = max( Kh, CS%LAPLAC3_CONST_xy(I,J) * Vort_mag)
+        if (CS%Smagorinsky_Kh) Kh = max( Kh, CS%Laplac2_const_xy(I,J) * Shear_mag )
+        if (CS%Leith_Kh) Kh = max( Kh, CS%Laplac3_const_xy(I,J) * vert_vort_mag*inv_PI3)
         ! All viscosity contributions above are subject to resolution scaling
         if (rescale_Kh) Kh = VarMix%Res_fn_q(i,j) * Kh
         ! Older method of bounding for stability
@@ -767,6 +1019,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         endif
 
         if (CS%id_Kh_q>0) Kh_q(I,J,k) = Kh
+        if (CS%id_vort_xy_q>0) vort_xy_q(I,J,k) = vort_xy(I,J)
 
         str_xy(I,J) = -Kh * sh_xy(I,J)
       else   ! not Laplacian
@@ -787,20 +1040,25 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         if (CS%Smagorinsky_Ah .or. CS%Leith_Ah) then
           if (CS%Smagorinsky_Ah) then
             if (CS%bound_Coriolis) then
-              AhSm =  Shear_mag * (CS%BIHARM_CONST_xy(I,J) + &
-                                 CS%Biharm_Const2_xy(I,J)*Shear_mag)
+              AhSm =  Shear_mag * (CS%Biharm5_const_xy(I,J) + &
+                                 CS%Biharm5_const2_xy(I,J)*Shear_mag)
             else
-              AhSm = CS%BIHARM_CONST_xy(I,J) * Shear_mag
+              AhSm = CS%Biharm5_const_xy(I,J) * Shear_mag
             endif
           endif
-          if (CS%Leith_Ah) &
-            AhLth =  Vort_mag * (CS%BIHARM5_CONST_xy(I,J))
+          if (CS%Leith_Ah) AhLth = CS%Biharm6_const_xy(I,J) * vert_vort_mag * inv_PI6
           Ah = MAX(MAX(CS%Ah_bg_xy(I,J), AhSm),AhLth)
           if (CS%bound_Ah .and. .not.CS%better_bound_Ah) &
             Ah = MIN(Ah, CS%Ah_Max_xy(I,J))
         else
           Ah = CS%Ah_bg_xy(I,J)
         endif ! Smagorinsky_Ah or Leith_Ah
+
+        if (use_MEKE_Au) then ! *Add* the MEKE contribution
+          Ah = Ah + 0.25*( (MEKE%Au(I,J)+MEKE%Au(I+1,J+1))    &
+                          +(MEKE%Au(I+1,J)+MEKE%Au(I,J+1)) )
+        endif
+
         if (CS%better_bound_Ah) then
           Ah = MIN(Ah, visc_bound_rem*hrat_min*CS%Ah_Max_xy(I,J))
         endif
@@ -811,16 +1069,156 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         bhstr_xy(I,J) = Ah * ( dvdx(I,J) + dudy(I,J) ) * &
-                        (hq * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+                        (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
 
       endif  ! biharmonic
 
-      if (CS%no_slip) then
-        str_xy(I,J) = str_xy(I,J) * (hq * CS%reduction_xy(I,J))
-      else
-        str_xy(I,J) = str_xy(I,J) * (hq * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
-      endif
     enddo ; enddo
+
+
+    if (find_FrictWork) then
+      if (CS%biharmonic) call pass_vector(u0, v0, G%Domain)
+      call pass_var(dudx, G%Domain, complete=.true.)
+      call pass_var(dvdy, G%Domain, complete=.true.)
+      call pass_var(dvdx, G%Domain, position=CORNER, complete=.true.)
+      call pass_var(dudy, G%Domain, position=CORNER, complete=.true.)
+
+      if (CS%Laplacian) then
+        do j=js,je ; do i=is,ie
+          grad_vel_mag_h(i,j) = boundary_mask(i,j) * (dudx(i,j)**2 + dvdy(i,j)**2 + &
+             (0.25*(dvdx(I,J)+dvdx(I-1,J)+dvdx(I,J-1)+dvdx(I-1,J-1)) )**2 + &
+             (0.25*(dudy(I,J)+dudy(I-1,J)+dudy(I,J-1)+dudy(I-1,J-1)) )**2)
+        enddo ; enddo
+      else
+        do j=js,je ; do i=is,ie
+          grad_vel_mag_h(i,j) = 0.0
+        enddo ; enddo
+      endif
+
+      if (CS%biharmonic) then
+        do j=js,je ; do i=is,ie
+          grad_d2vel_mag_h(i,j) = boundary_mask(i,j) * ((0.5*(u0(I,j) + u0(I-1,j)))**2 + &
+             (0.5*(v0(i,J) + v0(i,J-1)))**2)
+        enddo ; enddo
+      else
+        do j=js,je ; do i=is,ie
+          grad_d2vel_mag_h(i,j) = 0.0
+        enddo ; enddo
+      endif
+
+      do j=js,je ; do i=is,ie
+        ! Diagnose  -Kh * |del u|^2 - Ah * |del^2 u|^2
+        diss_rate(i,j,k) = -Kh_h(i,j,k) * grad_vel_mag_h(i,j) - &
+                              Ah_h(i,j,k) * grad_d2vel_mag_h(i,j)
+        FrictWork_diss(i,j,k) = diss_rate(i,j,k) * h(i,j,k) * GV%H_to_kg_m2
+
+        if (associated(MEKE)) then ; if (associated(MEKE%mom_src)) then
+          ! This is the maximum possible amount of energy that can be converted
+          ! per unit time, according to theory (multiplied by h)
+          max_diss_rate(i,j,k) = 2.0*MEKE%MEKE(i,j) * sqrt(grad_vel_mag_h(i,j)) * (MIN(G%bathyT(i,j)/H0,1.0)**2)
+
+          FrictWorkMax(i,j,k) = max_diss_rate(i,j,k) * h(i,j,k) * GV%H_to_kg_m2
+
+        ! Determine how much work GME needs to do to reach the "target" ratio between
+        ! the amount of work actually done and the maximum allowed by theory. Note that
+        ! we need to add the FrictWork done by the dissipation operators, since this work
+        ! is done only for numerical stability and is therefore spurious
+          if (CS%use_GME) then
+            target_diss_rate_GME(i,j,k) = FWfrac * max_diss_rate(i,j,k) - diss_rate(i,j,k)
+            target_FrictWork_GME(i,j,k) = target_diss_rate_GME(i,j,k) * h(i,j,k) * GV%H_to_kg_m2
+          endif
+
+        endif ; endif
+
+      enddo ; enddo
+    endif
+
+
+    if (CS%use_GME) then
+
+      if (.not. (associated(MEKE))) call MOM_error(FATAL, &
+        "MEKE must be enabled for GME to be used.")
+
+      if (.not. (associated(MEKE%mom_src))) call MOM_error(FATAL, &
+        "MEKE%mom_src must be enabled for GME to be used.")
+
+      do J=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+
+        if ((max_diss_rate(i,j,k) > 0) .and. (grad_vel_mag_bt_h(i,j)>0) ) then
+          GME_coeff = (MIN(G%bathyT(i,j)/H0,1.0)**2) * FWfrac*max_diss_rate(i,j,k) / grad_vel_mag_bt_h(i,j)
+        else
+          GME_coeff = 0.0
+        endif
+
+        ! apply mask
+        GME_coeff = GME_coeff * boundary_mask(i,j)
+
+        GME_coeff = MIN(GME_coeff,GME_coeff_limiter)
+
+        if ((CS%id_GME_coeff_h>0) .or. find_FrictWork) GME_coeff_h(i,j,k) = GME_coeff
+
+        str_xx_GME(i,j) = GME_coeff * sh_xx_bt(i,j)
+
+      enddo ; enddo
+
+
+      do J=js-1,Jeq ; do I=is-1,Ieq
+
+        if ((max_diss_rate(i,j,k) > 0) .and. (grad_vel_mag_bt_q(i,j)>0) ) then
+          GME_coeff = (MIN(G%bathyT(i,j)/H0,1.0)**2) * FWfrac*max_diss_rate(i,j,k) / grad_vel_mag_bt_q(I,J)
+        else
+          GME_coeff = 0.0
+        endif
+
+        ! apply mask
+        GME_coeff = GME_coeff * boundary_mask(i,j)
+
+        GME_coeff = MIN(GME_coeff,GME_coeff_limiter)
+
+        if (CS%id_GME_coeff_q>0) GME_coeff_q(I,J,k) = GME_coeff
+        str_xy_GME(I,J) = GME_coeff * sh_xy_bt(I,J)
+
+      enddo ; enddo
+
+    ! applying GME diagonal term
+      call smooth_GME(CS,G,GME_flux_h=str_xx_GME)
+      call smooth_GME(CS,G,GME_flux_q=str_xy_GME)
+
+      do J=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        str_xx(i,j) = (str_xx(i,j) + str_xx_GME(i,j)) * (h(i,j,k) * CS%reduction_xx(i,j))
+      enddo ; enddo
+
+      do J=js-1,Jeq ; do I=is-1,Ieq
+        ! GME is applied below
+        if (CS%no_slip) then
+          str_xy(I,J) = (str_xy(I,J) + str_xy_GME(I,J)) * (hq(I,J) * CS%reduction_xy(I,J))
+        else
+          str_xy(I,J) = (str_xy(I,J) + str_xy_GME(I,J)) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+        endif
+      enddo ; enddo
+
+      if (associated(MEKE%GME_snk)) then
+        do j=js,je ; do i=is,ie
+          FrictWork_GME(i,j,k) = GME_coeff_h(i,j,k) * h(i,j,k) * GV%H_to_kg_m2 * grad_vel_mag_bt_h(i,j)
+        enddo ; enddo
+      endif
+
+    else ! use_GME
+      do J=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+        str_xx(i,j) = str_xx(i,j) * (h(i,j,k) * CS%reduction_xx(i,j))
+      enddo ; enddo
+
+      do J=js-1,Jeq ; do I=is-1,Ieq
+        if (CS%no_slip) then
+          str_xy(I,J) = str_xy(I,J) * (hq(I,J) * CS%reduction_xy(I,J))
+        else
+          str_xy(I,J) = str_xy(I,J) * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
+        endif
+      enddo ; enddo
+
+    endif ! use_GME
+
+
 
     ! Evaluate 1/h x.Div(h Grad u) or the biharmonic equivalent.
     do j=js,je ; do I=Isq,Ieq
@@ -867,6 +1265,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
     if (find_FrictWork) then ; do j=js,je ; do i=is,ie
       ! Diagnose   str_xx*d_x u - str_yy*d_y v + str_xy*(d_y u + d_x v)
+      ! This is the old formulation that includes energy diffusion
       FrictWork(i,j,k) = GV%H_to_kg_m2 * ( &
               (str_xx(i,j)*(u(I,j,k)-u(I-1,j,k))*G%IdxT(i,j)     &
               -str_xx(i,j)*(v(i,J,k)-v(i,J-1,k))*G%IdyT(i,j))    &
@@ -891,6 +1290,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       if (k==1) then
         do j=js,je ; do i=is,ie
           MEKE%mom_src(i,j) = 0.
+          MEKE%GME_snk(i,j) = 0.
         enddo ; enddo
       endif
       if (MEKE%backscatter_Ro_c /= 0.) then
@@ -925,8 +1325,29 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         enddo ; enddo
       else
         do j=js,je ; do i=is,ie
-         MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork(i,j,k)
+         ! MEKE%mom_src now is sign definite because it only uses the dissipation
+         MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + MAX(-FrictWorkMax(i,j,k),FrictWork_diss(i,j,k))
         enddo ; enddo
+
+        if (CS%use_GME) then
+          if (associated(MEKE%GME_snk)) then
+            do j=js,je ; do i=is,ie
+              MEKE%GME_snk(i,j) = MEKE%GME_snk(i,j) + FrictWork_GME(i,j,k)
+            enddo ; enddo
+          endif
+        endif
+
+!        do j=js,je ; do i=is,ie
+!         ! MEKE%mom_src now is sign definite because it only uses the dissipation
+!         MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + MAX(-FrictWorkMax(i,j,k),FrictWork_diss(i,j,k))
+!        enddo ; enddo
+!        if (CS%use_GME) then
+!          do j=js,je ; do i=is,ie
+!            ! MEKE%mom_src now is sign definite because it only uses the dissipation
+!            MEKE%mom_src(i,j) = MEKE%mom_src(i,j) + FrictWork_GME(i,j,k)
+!          enddo ; enddo
+!        endif
+
       endif
     endif ; endif
 
@@ -936,10 +1357,18 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   if (CS%id_diffu>0)     call post_data(CS%id_diffu, diffu, CS%diag)
   if (CS%id_diffv>0)     call post_data(CS%id_diffv, diffv, CS%diag)
   if (CS%id_FrictWork>0) call post_data(CS%id_FrictWork, FrictWork, CS%diag)
+  if (CS%id_FrictWorkMax>0) call post_data(CS%id_FrictWorkMax, FrictWorkMax, CS%diag)
+  if (CS%id_FrictWork_diss>0) call post_data(CS%id_FrictWork_diss, FrictWork_diss, CS%diag)
+  if (CS%id_FrictWork_GME>0) call post_data(CS%id_FrictWork_GME, FrictWork_GME, CS%diag)
+  if (CS%id_target_FrictWork_GME>0) call post_data(CS%id_target_FrictWork_GME, target_FrictWork_GME, CS%diag)
   if (CS%id_Ah_h>0)      call post_data(CS%id_Ah_h, Ah_h, CS%diag)
+  if (CS%id_div_xx_h>0)  call post_data(CS%id_div_xx_h, div_xx_h, CS%diag)
+  if (CS%id_vort_xy_q>0) call post_data(CS%id_vort_xy_q, vort_xy_q, CS%diag)
   if (CS%id_Ah_q>0)      call post_data(CS%id_Ah_q, Ah_q, CS%diag)
   if (CS%id_Kh_h>0)      call post_data(CS%id_Kh_h, Kh_h, CS%diag)
   if (CS%id_Kh_q>0)      call post_data(CS%id_Kh_q, Kh_q, CS%diag)
+  if (CS%id_GME_coeff_h > 0)  call post_data(CS%id_GME_coeff_h, GME_coeff_h, CS%diag)
+  if (CS%id_GME_coeff_q > 0)  call post_data(CS%id_GME_coeff_q, GME_coeff_q, CS%diag)
 
   if (CS%id_FrictWorkIntz > 0) then
     do j=js,je
@@ -1035,6 +1464,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
   ! cases where the corresponding parameters are not read.
   CS%bound_Kh = .false. ; CS%better_bound_Kh = .false. ; CS%Smagorinsky_Kh = .false. ; CS%Leith_Kh = .false.
   CS%bound_Ah = .false. ; CS%better_bound_Ah = .false. ; CS%Smagorinsky_Ah = .false. ; CS%Leith_Ah = .false.
+  CS%use_QG_Leith_visc = .false.
   CS%bound_Coriolis = .false.
   CS%Modified_Leith = .false.
   CS%anisotropic = .false.
@@ -1084,18 +1514,27 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
     call get_param(param_file, mdl, "LEITH_KH", CS%Leith_Kh, &
                  "If true, use a Leith nonlinear eddy viscosity.", &
                  default=.false.)
-
-    call get_param(param_file, mdl, "MODIFIED_LEITH", CS%Modified_Leith, &
+    if (CS%Leith_Kh .or. get_all) then
+      call get_param(param_file, mdl, "LEITH_LAP_CONST", Leith_Lap_const, &
+                 "The nondimensional Laplacian Leith constant, \n"//&
+                 "often set to 1.0", units="nondim", default=0.0, &
+                  fail_if_missing = CS%Leith_Kh)
+      call get_param(param_file, mdl, "USE_QG_LEITH_VISC", CS%use_QG_Leith_visc, &
+                 "If true, use QG Leith nonlinear eddy viscosity.", &
+                 default=.false.)
+      if (CS%use_QG_Leith_visc .and. .not. CS%Leith_Kh) call MOM_error(FATAL, &
+                 "MOM_lateral_mixing_coeffs.F90, VarMix_init:"//&
+                 "LEITH_KH must be True when USE_QG_LEITH_VISC=True.")
+    endif
+    if (CS%Leith_Kh .or. CS%Leith_Ah .or. get_all) then
+      call get_param(param_file, mdl, "USE_BETA_IN_LEITH", CS%use_beta_in_Leith, &
+                 "If true, include the beta term in the Leith nonlinear eddy viscosity.", &
+                 default=CS%Leith_Kh)
+      call get_param(param_file, mdl, "MODIFIED_LEITH", CS%modified_Leith, &
                  "If true, add a term to Leith viscosity which is \n"//&
                  "proportional to the gradient of divergence.", &
                  default=.false.)
-
-    if (CS%Leith_Kh .or. get_all) &
-      call get_param(param_file, mdl, "LEITH_LAP_CONST", Leith_Lap_const, &
-                 "The nondimensional Laplacian Leith constant, \n"//&
-                 "often ??", units="nondim", default=0.0, &
-                  fail_if_missing = CS%Leith_Kh)
-
+    endif
     call get_param(param_file, mdl, "BOUND_KH", CS%bound_Kh, &
                  "If true, the Laplacian coefficient is locally limited \n"//&
                  "to be stable.", default=.true.)
@@ -1184,13 +1623,11 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
                  units="m s-1", default=maxvel)
       endif
     endif
-
-    if (CS%Leith_Ah .or. get_all) then
-      call get_param(param_file, mdl, "LEITH_BI_CONST",Leith_bi_const, &
+    if (CS%Leith_Ah .or. get_all) &
+        call get_param(param_file, mdl, "LEITH_BI_CONST", Leith_bi_const, &
                  "The nondimensional biharmonic Leith constant, \n"//&
-                 "typical values are thus far undetermined", units="nondim", default=0.0, &
+                 "typical values are thus far undetermined.", units="nondim", default=0.0, &
                  fail_if_missing = CS%Leith_Ah)
-    endif
 
   endif
 
@@ -1221,6 +1658,9 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
                  "viscosities. The final viscosity is the maximum of the other "//&
                  "terms and this background value.", default=.false.)
 
+  call get_param(param_file, mdl, "USE_GME", CS%use_GME, &
+                 "If true, use the GM+E backscatter scheme in association \n"//&
+                 "with the Gent and McWilliams parameterization.", default=.false.)
 
   if (CS%bound_Kh .or. CS%bound_Ah .or. CS%better_bound_Kh .or. CS%better_bound_Ah) &
     call get_param(param_file, mdl, "DT", dt, &
@@ -1258,14 +1698,13 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
       ALLOC_(CS%Kh_Max_xy(IsdB:IedB,JsdB:JedB)) ; CS%Kh_Max_xy(:,:) = 0.0
     endif
     if (CS%Smagorinsky_Kh) then
-      ALLOC_(CS%Laplac_Const_xx(isd:ied,jsd:jed))     ; CS%Laplac_Const_xx(:,:) = 0.0
-      ALLOC_(CS%Laplac_Const_xy(IsdB:IedB,JsdB:JedB)) ; CS%Laplac_Const_xy(:,:) = 0.0
+      ALLOC_(CS%Laplac2_const_xx(isd:ied,jsd:jed))     ; CS%Laplac2_const_xx(:,:) = 0.0
+      ALLOC_(CS%Laplac2_const_xy(IsdB:IedB,JsdB:JedB)) ; CS%Laplac2_const_xy(:,:) = 0.0
     endif
     if (CS%Leith_Kh) then
-      ALLOC_(CS%Laplac3_Const_xx(isd:ied,jsd:jed))     ; CS%Laplac3_Const_xx(:,:) = 0.0
-      ALLOC_(CS%Laplac3_Const_xy(IsdB:IedB,JsdB:JedB)) ; CS%Laplac3_Const_xy(:,:) = 0.0
+      ALLOC_(CS%Laplac3_const_xx(isd:ied,jsd:jed)) ; CS%Laplac3_const_xx(:,:) = 0.0
+      ALLOC_(CS%Laplac3_const_xy(IsdB:IedB,JsdB:JedB)) ; CS%Laplac3_const_xy(:,:) = 0.0
     endif
-
   endif
   ALLOC_(CS%reduction_xx(isd:ied,jsd:jed))     ; CS%reduction_xx(:,:) = 0.0
   ALLOC_(CS%reduction_xy(IsdB:IedB,JsdB:JedB)) ; CS%reduction_xy(:,:) = 0.0
@@ -1313,16 +1752,16 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
       ALLOC_(CS%Ah_Max_xy(IsdB:IedB,JsdB:JedB)) ; CS%Ah_Max_xy(:,:) = 0.0
     endif
     if (CS%Smagorinsky_Ah) then
-      ALLOC_(CS%Biharm_Const_xx(isd:ied,jsd:jed))     ; CS%Biharm_Const_xx(:,:) = 0.0
-      ALLOC_(CS%Biharm_Const_xy(IsdB:IedB,JsdB:JedB)) ; CS%Biharm_Const_xy(:,:) = 0.0
+      ALLOC_(CS%Biharm5_const_xx(isd:ied,jsd:jed))     ; CS%Biharm5_const_xx(:,:) = 0.0
+      ALLOC_(CS%Biharm5_const_xy(IsdB:IedB,JsdB:JedB)) ; CS%Biharm5_const_xy(:,:) = 0.0
       if (CS%bound_Coriolis) then
-        ALLOC_(CS%Biharm_Const2_xx(isd:ied,jsd:jed))     ; CS%Biharm_Const2_xx(:,:) = 0.0
-        ALLOC_(CS%Biharm_Const2_xy(IsdB:IedB,JsdB:JedB)) ; CS%Biharm_Const2_xy(:,:) = 0.0
+        ALLOC_(CS%Biharm5_const2_xx(isd:ied,jsd:jed))     ; CS%Biharm5_const2_xx(:,:) = 0.0
+        ALLOC_(CS%Biharm5_const2_xy(IsdB:IedB,JsdB:JedB)) ; CS%Biharm5_const2_xy(:,:) = 0.0
       endif
     endif
     if (CS%Leith_Ah) then
-      ALLOC_(CS%Biharm5_Const_xx(isd:ied,jsd:jed))     ; CS%Biharm5_Const_xx(:,:) = 0.0
-      ALLOC_(CS%Biharm5_Const_xy(IsdB:IedB,JsdB:JedB)) ; CS%Biharm5_Const_xy(:,:) = 0.0
+        ALLOC_(CS%biharm6_const_xx(isd:ied,jsd:jed)) ; CS%biharm6_const_xx(:,:) = 0.0
+        ALLOC_(CS%biharm6_const_xy(IsdB:IedB,JsdB:JedB)) ; CS%biharm6_const_xy(:,:) = 0.0
     endif
   endif
 
@@ -1377,9 +1816,8 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
       ! Static factors in the Smagorinsky and Leith schemes
       grid_sp_h2 = (2.0*CS%DX2h(i,j)*CS%DY2h(i,j)) / (CS%DX2h(i,j) + CS%DY2h(i,j))
       grid_sp_h3 = grid_sp_h2*sqrt(grid_sp_h2)
-      if (CS%Smagorinsky_Kh) CS%LAPLAC_CONST_xx(i,j) = Smag_Lap_const * grid_sp_h2
-      if (CS%Leith_Kh) CS%LAPLAC3_CONST_xx(i,j) = Leith_Lap_const * grid_sp_h3
-
+      if (CS%Smagorinsky_Kh) CS%Laplac2_const_xx(i,j) = Smag_Lap_const * grid_sp_h2
+      if (CS%Leith_Kh)       CS%Laplac3_const_xx(i,j) = Leith_Lap_const * grid_sp_h3
       ! Maximum of constant background and MICOM viscosity
       CS%Kh_bg_xx(i,j) = MAX(Kh, Kh_vel_scale * sqrt(grid_sp_h2))
 
@@ -1404,9 +1842,8 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
       ! Static factors in the Smagorinsky and Leith schemes
       grid_sp_q2 = (2.0*CS%DX2q(I,J)*CS%DY2q(I,J)) / (CS%DX2q(I,J) + CS%DY2q(I,J))
       grid_sp_q3 = grid_sp_q2*sqrt(grid_sp_q2)
-      if (CS%Smagorinsky_Kh) CS%LAPLAC_CONST_xy(I,J) = Smag_Lap_const * grid_sp_q2
-      if (CS%Leith_Kh) CS%LAPLAC3_CONST_xy(I,J) = Leith_Lap_const * grid_sp_q3
-
+      if (CS%Smagorinsky_Kh) CS%Laplac2_const_xy(I,J) = Smag_Lap_const * grid_sp_q2
+      if (CS%Leith_Kh)       CS%Laplac3_const_xy(I,J) = Leith_Lap_const * grid_sp_q3
       ! Maximum of constant background and MICOM viscosity
       CS%Kh_bg_xy(I,J) = MAX(Kh, Kh_vel_scale * sqrt(grid_sp_q2))
 
@@ -1441,7 +1878,7 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
     CS%Ah_bg_xy(:,:) = 0.0
    ! The 0.3 below was 0.4 in MOM1.10.  The change in hq requires
    ! this to be less than 1/3, rather than 1/2 as before.
-    Ah_Limit = 0.3 / (dt*64.0)
+    if (CS%better_bound_Ah .or. CS%bound_Ah) Ah_Limit = 0.3 / (dt*64.0)
     if (CS%Smagorinsky_Ah .and. CS%bound_Coriolis) &
       BoundCorConst = 1.0 / (5.0*(bound_Cor_vel*bound_Cor_vel))
     do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -1449,18 +1886,17 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
       grid_sp_h3 = grid_sp_h2*sqrt(grid_sp_h2)
 
       if (CS%Smagorinsky_Ah) then
-        CS%BIHARM_CONST_xx(i,j) = Smag_bi_const * (grid_sp_h2 * grid_sp_h2)
+        CS%Biharm5_const_xx(i,j) = Smag_bi_const * (grid_sp_h3 * grid_sp_h2)
         if (CS%bound_Coriolis) then
-          fmax = US%s_to_T*MAX(abs(G%CoriolisBu(I-1,J-1)), abs(G%CoriolisBu(I,J-1)), &
-                               abs(G%CoriolisBu(I-1,J)),   abs(G%CoriolisBu(I,J)))
-          CS%Biharm_Const2_xx(i,j) = (grid_sp_h2 * grid_sp_h2 * grid_sp_h2) * &
+          fmax = MAX(abs(G%CoriolisBu(I-1,J-1)), abs(G%CoriolisBu(I,J-1)), &
+                     abs(G%CoriolisBu(I-1,J)),   abs(G%CoriolisBu(I,J)))
+          CS%Biharm5_const2_xx(i,j) = (grid_sp_h2 * grid_sp_h2 * grid_sp_h2) * &
                                   (fmax * BoundCorConst)
         endif
       endif
       if (CS%Leith_Ah) then
-        CS%BIHARM5_CONST_xx(i,j) = Leith_bi_const * (grid_sp_h2 * grid_sp_h3)
+         CS%biharm6_const_xx(i,j) = Leith_bi_const * (grid_sp_h3**2)
       endif
-
       CS%Ah_bg_xx(i,j) = MAX(Ah, Ah_vel_scale * grid_sp_h2 * sqrt(grid_sp_h2))
       if (CS%bound_Ah .and. .not.CS%better_bound_Ah) then
         CS%Ah_Max_xx(i,j) = Ah_Limit * (grid_sp_h2 * grid_sp_h2)
@@ -1472,15 +1908,14 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
       grid_sp_q3 = grid_sp_q2*sqrt(grid_sp_q2)
 
       if (CS%Smagorinsky_Ah) then
-        CS%BIHARM_CONST_xy(I,J) = Smag_bi_const * (grid_sp_q2 * grid_sp_q2)
+        CS%Biharm5_const_xy(I,J) = Smag_bi_const * (grid_sp_q3 * grid_sp_q2)
         if (CS%bound_Coriolis) then
-          CS%Biharm_Const2_xy(I,J) = (grid_sp_q2 * grid_sp_q2 * grid_sp_q2) * &
-                                      (abs(US%s_to_T*G%CoriolisBu(I,J)) * BoundCorConst)
+          CS%Biharm5_const2_xy(I,J) = (grid_sp_q2 * grid_sp_q2 * grid_sp_q2) * &
+                                      (abs(G%CoriolisBu(I,J)) * BoundCorConst)
         endif
       endif
-
       if (CS%Leith_Ah) then
-        CS%BIHARM5_CONST_xy(I,J) = Leith_bi_const * (grid_sp_q2 * grid_sp_q3)
+         CS%biharm6_const_xy(i,j) = Leith_bi_const * (grid_sp_q3**2)
       endif
 
       CS%Ah_bg_xy(I,J) = MAX(Ah, Ah_vel_scale * grid_sp_q2 * sqrt(grid_sp_q2))
@@ -1602,10 +2037,39 @@ subroutine hor_visc_init(Time, G, US, param_file, diag, CS)
 
     CS%id_Kh_q = register_diag_field('ocean_model', 'Khq', diag%axesBL, Time, &
         'Laplacian Horizontal Viscosity at q Points', 'm2 s-1')
+
+    if (CS%Leith_Kh) then
+      CS%id_vort_xy_q = register_diag_field('ocean_model', 'vort_xy_q', diag%axesBL, Time, &
+        'Vertical vorticity at q Points', 's-1')
+
+      CS%id_div_xx_h = register_diag_field('ocean_model', 'div_xx_h', diag%axesTL, Time, &
+        'Horizontal divergence at h Points', 's-1')
+    endif
+
+  endif
+
+  if (CS%use_GME) then
+      CS%id_GME_coeff_h = register_diag_field('ocean_model', 'GME_coeff_h', diag%axesTL, Time, &
+        'GME coefficient at h Points', 'm^2 s-1')
+
+      CS%id_GME_coeff_q = register_diag_field('ocean_model', 'GME_coeff_q', diag%axesBL, Time, &
+        'GME coefficient at q Points', 'm^2 s-1')
+
+      CS%id_target_FrictWork_GME = register_diag_field('ocean_model','target_FrictWork_GME',diag%axesTL,Time,&
+      'Target for the amount of integral work done by lateral friction terms in GME', 'W m-2')
+
+      CS%id_FrictWork_GME = register_diag_field('ocean_model','FrictWork_GME',diag%axesTL,Time,&
+      'Integral work done by lateral friction terms in GME (excluding diffusion of energy)', 'W m-2')
   endif
 
   CS%id_FrictWork = register_diag_field('ocean_model','FrictWork',diag%axesTL,Time,&
       'Integral work done by lateral friction terms', 'W m-2')
+
+  CS%id_FrictWork_diss = register_diag_field('ocean_model','FrictWork_diss',diag%axesTL,Time,&
+      'Integral work done by lateral friction terms (excluding diffusion of energy)', 'W m-2')
+
+  CS%id_FrictWorkMax = register_diag_field('ocean_model','FrictWorkMax',diag%axesTL,Time,&
+      'Maximum possible integral work done by lateral friction terms', 'W m-2')
 
   CS%id_FrictWorkIntz = register_diag_field('ocean_model','FrictWorkIntz',diag%axesT1,Time,      &
       'Depth integrated work done by lateral friction', 'W m-2',                          &
@@ -1638,6 +2102,80 @@ subroutine align_aniso_tensor_to_grid(CS, n1, n2)
 
 end subroutine align_aniso_tensor_to_grid
 
+!> Apply a 1-1-4-1-1 Laplacian filter one time on GME diffusive flux to reduce any
+!! horizontal two-grid-point noise
+subroutine smooth_GME(CS,G,GME_flux_h,GME_flux_q)
+  ! Arguments
+  type(hor_visc_CS),                            pointer       :: CS        !< Control structure
+  type(ocean_grid_type),                        intent(in)    :: G         !< Ocean grid
+  real, dimension(SZI_(G),SZJ_(G)),   optional, intent(inout) :: GME_flux_h!< GME diffusive flux
+                                                              !! at h points
+  real, dimension(SZIB_(G),SZJB_(G)), optional, intent(inout) :: GME_flux_q!< GME diffusive flux
+                                                              !! at q points
+
+  ! local variables
+  real, dimension(SZI_(G),SZJ_(G)) :: GME_flux_h_original
+  real, dimension(SZIB_(G),SZJB_(G)) :: GME_flux_q_original
+  real :: wc, ww, we, wn, ws ! averaging weights for smoothing
+  integer :: i, j, k, s
+
+  !do s=1,CS%n_smooth
+  do s=1,1
+
+    ! Update halos
+    if (present(GME_flux_h)) then
+      call pass_var(GME_flux_h, G%Domain)
+      GME_flux_h_original = GME_flux_h
+      ! apply smoothing on GME
+      do j = G%jsc, G%jec
+        do i = G%isc, G%iec
+          ! skip land points
+          if (G%mask2dT(i,j)==0.) cycle
+
+          ! compute weights
+          ww = 0.125 * G%mask2dT(i-1,j)
+          we = 0.125 * G%mask2dT(i+1,j)
+          ws = 0.125 * G%mask2dT(i,j-1)
+          wn = 0.125 * G%mask2dT(i,j+1)
+          wc = 1.0 - (ww+we+wn+ws)
+
+          GME_flux_h(i,j) =  wc * GME_flux_h_original(i,j)   &
+                           + ww * GME_flux_h_original(i-1,j) &
+                           + we * GME_flux_h_original(i+1,j) &
+                           + ws * GME_flux_h_original(i,j-1) &
+                           + wn * GME_flux_h_original(i,j+1)
+      enddo; enddo
+    endif
+
+    ! Update halos
+    if (present(GME_flux_q)) then
+      call pass_var(GME_flux_q, G%Domain, position=CORNER, complete=.true.)
+      GME_flux_q_original = GME_flux_q
+      ! apply smoothing on GME
+      do J = G%JscB, G%JecB
+        do I = G%IscB, G%IecB
+          ! skip land points
+          if (G%mask2dBu(I,J)==0.) cycle
+
+          ! compute weights
+          ww = 0.125 * G%mask2dBu(I-1,J)
+          we = 0.125 * G%mask2dBu(I+1,J)
+          ws = 0.125 * G%mask2dBu(I,J-1)
+          wn = 0.125 * G%mask2dBu(I,J+1)
+          wc = 1.0 - (ww+we+wn+ws)
+
+          GME_flux_q(I,J) =  wc * GME_flux_q_original(I,J)   &
+                           + ww * GME_flux_q_original(I-1,J) &
+                           + we * GME_flux_q_original(I+1,J) &
+                           + ws * GME_flux_q_original(I,J-1) &
+                           + wn * GME_flux_q_original(I,J+1)
+      enddo; enddo
+    endif
+
+  enddo ! s-loop
+
+end subroutine smooth_GME
+
 !> Deallocates any variables allocated in hor_visc_init.
 subroutine hor_visc_end(CS)
   type(hor_visc_CS), pointer :: CS !< The control structure returned by a
@@ -1655,10 +2193,10 @@ subroutine hor_visc_end(CS)
       DEALLOC_(CS%Kh_Max_xx) ; DEALLOC_(CS%Kh_Max_xy)
     endif
     if (CS%Smagorinsky_Kh) then
-      DEALLOC_(CS%Laplac_Const_xx) ; DEALLOC_(CS%Laplac_Const_xy)
+      DEALLOC_(CS%Laplac2_const_xx) ; DEALLOC_(CS%Laplac2_const_xy)
     endif
     if (CS%Leith_Kh) then
-      DEALLOC_(CS%Laplac3_Const_xx) ; DEALLOC_(CS%Laplac3_Const_xy)
+      DEALLOC_(CS%Laplac3_const_xx) ; DEALLOC_(CS%Laplac3_const_xy)
     endif
   endif
 
@@ -1670,13 +2208,13 @@ subroutine hor_visc_end(CS)
       DEALLOC_(CS%Ah_Max_xx) ; DEALLOC_(CS%Ah_Max_xy)
     endif
     if (CS%Smagorinsky_Ah) then
-      DEALLOC_(CS%Biharm_Const_xx) ; DEALLOC_(CS%Biharm_Const_xy)
+      DEALLOC_(CS%Biharm5_const_xx) ; DEALLOC_(CS%Biharm5_const_xy)
       if (CS%bound_Coriolis) then
-        DEALLOC_(CS%Biharm_Const2_xx) ; DEALLOC_(CS%Biharm_Const2_xy)
+        DEALLOC_(CS%Biharm5_const2_xx) ; DEALLOC_(CS%Biharm5_const2_xy)
       endif
     endif
     if (CS%Leith_Ah) then
-      DEALLOC_(CS%Biharm5_Const_xx) ; DEALLOC_(CS%Biharm5_Const_xy)
+      DEALLOC_(CS%Biharm6_const_xx) ; DEALLOC_(CS%Biharm6_const_xy)
     endif
   endif
   if (CS%anisotropic) then

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -740,8 +740,8 @@ subroutine calc_QG_Leith_viscosity(CS, G, GV, h, k, div_xx_dx, div_xx_dy, vort_x
 !  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)  :: v !< Meridional flow (m s-1)
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout)  :: h !< Layer thickness (m or kg m-2)
   integer,                                   intent(in)  :: k !< Layer for which to calculate vorticity magnitude
-  real, dimension(SZIB_(G),SZJ_(G)),         intent(in) :: div_xx_dx  ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) (m-1 s-1)
-  real, dimension(SZI_(G),SZJB_(G)),         intent(in) :: div_xx_dy  ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) (m-1 s-1)
+  real, dimension(SZIB_(G),SZJ_(G)),         intent(in) :: div_xx_dx  !< x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) (m-1 s-1)
+  real, dimension(SZI_(G),SZJB_(G)),         intent(in) :: div_xx_dy  !< y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) (m-1 s-1)
   real, dimension(SZI_(G),SZJB_(G)),         intent(inout) :: vort_xy_dx !< x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) (m-1 s-1)
   real, dimension(SZIB_(G),SZJ_(G)),         intent(inout) :: vort_xy_dy !< y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) (m-1 s-1)
 !  real, dimension(SZI_(G),SZJ_(G)),          intent(out) :: Leith_Kh_h !< Leith Laplacian viscosity at h-points (m2 s-1)

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -8,7 +8,7 @@ use MOM_error_handler, only : MOM_error, FATAL, WARNING, MOM_mesg
 use MOM_diag_mediator, only : register_diag_field, safe_alloc_ptr, post_data
 use MOM_diag_mediator, only : diag_ctrl, time_type, query_averaging_enabled
 use MOM_domains,       only : create_group_pass, do_group_pass
-use MOM_domains,       only : group_pass_type, pass_var
+use MOM_domains,       only : group_pass_type, pass_var, pass_vector
 use MOM_file_parser, only : get_param, log_version, param_file_type
 use MOM_interface_heights, only : find_eta
 use MOM_isopycnal_slopes, only : calc_isoneutral_slopes
@@ -55,6 +55,8 @@ type, public :: VarMix_CS
                                   !! This parameter is set depending on other parameters.
   logical :: calculate_Eady_growth_rate !< If true, calculate all the Eady growth rate.
                                   !! This parameter is set depending on other parameters.
+  logical :: use_GME_VarMix       !< If true, calculates slopes and Brunt-Vaisala frequency for use with
+                                  !! the GME closure.
   real, dimension(:,:), pointer :: &
     SN_u => NULL(), &   !< S*N at u-points [s-1]
     SN_v => NULL(), &  !< S*N at v-points [s-1]
@@ -88,11 +90,25 @@ type, public :: VarMix_CS
     Rd_dx_h => NULL()     !< Deformation radius over grid spacing [nondim]
 
   real, dimension(:,:,:), pointer :: &
-    slope_x => NULL(), &  !< Zonal isopycnal slope [nondim]
-    slope_y => NULL(), &  !< Meridional isopycnal slope [nondim]
-    ebt_struct => NULL()  !< Vertical structure function to scale diffusivities with [nondim]
+    slope_x => NULL(), &  !< Zonal isopycnal slope (non-dimensional)
+    slope_y => NULL(), &  !< Meridional isopycnal slope (non-dimensional)
+    N2_u => NULL(), &     !< Brunt-Vaisala frequency at u-points (s-2)
+    N2_v => NULL(), &     !< Brunt-Vaisala frequency at v-points (s-2)
+    ebt_struct => NULL()  !< Vertical structure function to scale diffusivities with (non-dim)
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_) :: &
+    Laplac3_const_u       !< Laplacian  metric-dependent constants (nondim)
+
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_) :: &
+    Laplac3_const_v       !< Laplacian  metric-dependent constants (nondim)
+
+  real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEM_,NKMEM_) :: &
+    KH_u_QG               !< QG Leith GM coefficient at u-points (m2 s-1)
+
+  real ALLOCABLE_, dimension(NIMEM_,NJMEMB_PTR_,NKMEM_) :: &
+    KH_v_QG               !< QG Leith GM coefficient at v-points (m2 s-1)
 
   ! Parameters
+  logical :: use_Visbeck  !< Use Visbeck formulation for thickness diffusivity
   integer :: VarMix_Ktop  !< Top layer to start downward integrals
   real :: Visbeck_L_scale !< Fixed length scale in Visbeck formula
   real :: Res_coef_khth   !< A non-dimensional number that determines the function
@@ -110,12 +126,16 @@ type, public :: VarMix_CS
                                !! and especially 2 are coded to be more efficient.
   real :: Visbeck_S_max   !< Upper bound on slope used in Eady growth rate [nondim].
 
+  ! Leith parameters
+  logical :: use_QG_Leith_GM      !! If true, uses the QG Leith viscosity as the GM coefficient
+  logical :: use_beta_in_QG_Leith !! If true, includes the beta term in the QG Leith GM coefficient
+
   ! Diagnostics
   !>@{
   !! Diagnostic identifier
   integer :: id_SN_u=-1, id_SN_v=-1, id_L2u=-1, id_L2v=-1, id_Res_fn = -1
   integer :: id_N2_u=-1, id_N2_v=-1, id_S2_u=-1, id_S2_v=-1
-  integer :: id_Rd_dx=-1
+  integer :: id_Rd_dx=-1, id_KH_u_QG = -1, id_KH_v_QG = -1
   type(diag_ctrl), pointer :: diag !< A structure that is used to regulate the
                                    !! timing of diagnostic output.
   !>@}
@@ -126,6 +146,7 @@ type, public :: VarMix_CS
 end type VarMix_CS
 
 public VarMix_init, calc_slope_functions, calc_resoln_function
+public calc_QG_Leith_viscosity
 
 contains
 
@@ -395,12 +416,15 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS)
   if (.not. associated(CS)) call MOM_error(FATAL, "MOM_lateral_mixing_coeffs.F90, calc_slope_functions:"//&
          "Module must be initialized before it is used.")
 
-  if (CS%calculate_Eady_growth_rate) then
+  if (CS%calculate_Eady_growth_rate .or. CS%use_stored_slopes &
+      .or. CS%use_GME_VarMix) then
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
     if (CS%use_stored_slopes) then
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, &
-                                  CS%slope_x, CS%slope_y, N2_u, N2_v, 1)
-      call calc_Visbeck_coeffs(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, CS)
+                                  CS%slope_x, CS%slope_y, CS%N2_u, CS%N2_v, 1)
+      if (CS%calculate_Eady_growth_rate) then
+        call calc_Visbeck_coeffs(h, CS%slope_x, CS%slope_y, CS%N2_u, CS%N2_v, G, GV, CS)
+      endif
 !     call calc_slope_functions_using_just_e(h, G, CS, e, .false.)
     else
       !call calc_isoneutral_slopes(G, GV, h, e, tv, dt*CS%kappa_smooth, CS%slope_x, CS%slope_y)
@@ -409,12 +433,12 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS)
   endif
 
   if (query_averaging_enabled(CS%diag)) then
-    if (CS%id_SN_u > 0) call post_data(CS%id_SN_u, CS%SN_u, CS%diag)
-    if (CS%id_SN_v > 0) call post_data(CS%id_SN_v, CS%SN_v, CS%diag)
-    if (CS%id_L2u > 0) call post_data(CS%id_L2u, CS%L2u, CS%diag)
-    if (CS%id_L2v > 0) call post_data(CS%id_L2v, CS%L2v, CS%diag)
-    if (CS%id_N2_u > 0) call post_data(CS%id_N2_u, N2_u, CS%diag)
-    if (CS%id_N2_v > 0) call post_data(CS%id_N2_v, N2_v, CS%diag)
+    if (CS%id_SN_u > 0)     call post_data(CS%id_SN_u, CS%SN_u, CS%diag)
+    if (CS%id_SN_v > 0)     call post_data(CS%id_SN_v, CS%SN_v, CS%diag)
+    if (CS%id_L2u > 0)      call post_data(CS%id_L2u, CS%L2u, CS%diag)
+    if (CS%id_L2v > 0)      call post_data(CS%id_L2v, CS%L2v, CS%diag)
+    if (CS%id_N2_u > 0)     call post_data(CS%id_N2_u, CS%N2_u, CS%diag)
+    if (CS%id_N2_v > 0)     call post_data(CS%id_N2_v, CS%N2_v, CS%diag)
   endif
 
 end subroutine calc_slope_functions
@@ -707,6 +731,154 @@ subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e, calculate_slop
 
 end subroutine calc_slope_functions_using_just_e
 
+!> Calculates the Leith Laplacian and bi-harmonic viscosity coefficients
+subroutine calc_QG_Leith_viscosity(CS, G, GV, h, k, div_xx_dx, div_xx_dy, vort_xy_dx, vort_xy_dy)
+  type(VarMix_CS),                           pointer     :: CS !< Variable mixing coefficients
+  type(ocean_grid_type),                     intent(in)  :: G !< Ocean grid structure
+  type(verticalGrid_type),                   intent(in)  :: GV !< The ocean's vertical grid structure.
+!  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)), intent(in)  :: u !< Zonal flow (m s-1)
+!  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(in)  :: v !< Meridional flow (m s-1)
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)), intent(inout)  :: h !< Layer thickness (m or kg m-2)
+  integer,                                   intent(in)  :: k !< Layer for which to calculate vorticity magnitude
+  real, dimension(SZIB_(G),SZJ_(G)),         intent(in) :: div_xx_dx  ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) (m-1 s-1)
+  real, dimension(SZI_(G),SZJB_(G)),         intent(in) :: div_xx_dy  ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) (m-1 s-1)
+  real, dimension(SZI_(G),SZJB_(G)),         intent(inout) :: vort_xy_dx !< x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) (m-1 s-1)
+  real, dimension(SZIB_(G),SZJ_(G)),         intent(inout) :: vort_xy_dy !< y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) (m-1 s-1)
+!  real, dimension(SZI_(G),SZJ_(G)),          intent(out) :: Leith_Kh_h !< Leith Laplacian viscosity at h-points (m2 s-1)
+!  real, dimension(SZIB_(G),SZJB_(G)),        intent(out) :: Leith_Kh_q !< Leith Laplacian viscosity at q-points (m2 s-1)
+!  real, dimension(SZI_(G),SZJ_(G)),          intent(out) :: Leith_Ah_h !< Leith bi-harmonic viscosity at h-points (m4 s-1)
+!  real, dimension(SZIB_(G),SZJB_(G)),        intent(out) :: Leith_Ah_q !< Leith bi-harmonic viscosity at q-points (m4 s-1)
+
+  ! Local variables
+!  real, dimension(SZIB_(G),SZJB_(G)) :: vort_xy, & ! Vertical vorticity (dv/dx - du/dy) (s-1)
+!                                        dudy, & ! Meridional shear of zonal velocity (s-1)
+!                                        dvdx    ! Zonal shear of meridional velocity (s-1)
+  real, dimension(SZI_(G),SZJB_(G)) :: &
+!    vort_xy_dx, & ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) (m-1 s-1)
+!    div_xx_dy, &  ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) (m-1 s-1)
+    dslopey_dz, & ! z-derivative of y-slope at v-points (m-1)
+    h_at_v,     & ! Thickness at v-points (m or kg m-2)
+    beta_v,     & ! Beta at v-points (m-1 s-1)
+    grad_vort_mag_v, & ! mag. of vort. grad. at v-points (s-1)
+    grad_div_mag_v     ! mag. of div. grad. at v-points (s-1)
+
+  real, dimension(SZIB_(G),SZJ_(G)) :: &
+!    vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) (m-1 s-1)
+!    div_xx_dx, &  ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) (m-1 s-1)
+    dslopex_dz, & ! z-derivative of x-slope at u-points (m-1)
+    h_at_u,     & ! Thickness at u-points (m or kg m-2)
+    beta_u,     & ! Beta at u-points (m-1 s-1)
+    grad_vort_mag_u, & ! mag. of vort. grad. at u-points (s-1)
+    grad_div_mag_u     ! mag. of div. grad. at u-points (s-1)
+!  real, dimension(SZI_(G),SZJ_(G)) :: div_xx ! Estimate of horizontal divergence at h-points (s-1)
+!  real :: mod_Leith, DY_dxBu, DX_dyBu, vert_vort_mag
+  real :: h_at_slope_above, h_at_slope_below, Ih, f
+  integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq,nz
+  real :: inv_PI3
+
+  is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec
+  Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
+  nz = G%ke
+
+  inv_PI3 = 1.0/((4.0*atan(1.0))**3)
+
+  ! update halos
+  call pass_var(h, G%Domain)
+
+  if ((k > 1) .and. (k < nz)) then
+
+  ! Add in stretching term for the QG Leith vsicosity
+!  if (CS%use_QG_Leith) then
+!    do j=js-1,Jeq+1 ; do I=is-2,Ieq+1
+    do j=js-2,Jeq+2 ; do I=is-2,Ieq+1
+      h_at_slope_above = 2. * ( h(i,j,k-1) * h(i+1,j,k-1) ) * ( h(i,j,k) * h(i+1,j,k) ) / &
+                         ( ( h(i,j,k-1) * h(i+1,j,k-1) ) * ( h(i,j,k) + h(i+1,j,k) ) &
+                         + ( h(i,j,k) * h(i+1,j,k) ) * ( h(i,j,k-1) + h(i+1,j,k-1) ) + GV%H_subroundoff )
+      h_at_slope_below = 2. * ( h(i,j,k) * h(i+1,j,k) ) * ( h(i,j,k+1) * h(i+1,j,k+1) ) / &
+                         ( ( h(i,j,k) * h(i+1,j,k) ) * ( h(i,j,k+1) + h(i+1,j,k+1) ) &
+                         + ( h(i,j,k+1) * h(i+1,j,k+1) ) * ( h(i,j,k) + h(i+1,j,k) ) + GV%H_subroundoff )
+      Ih = 1./ ( ( h_at_slope_above + h_at_slope_below + GV%H_subroundoff ) * GV%H_to_m )
+      dslopex_dz(I,j) = 2. * ( CS%slope_x(i,j,k) - CS%slope_x(i,j,k+1) ) * Ih
+      h_at_u(I,j) = 2. * ( h_at_slope_above * h_at_slope_below ) * Ih
+    enddo ; enddo
+!    do J=js-2,Jeq+1 ; do i=is-1,Ieq+1
+    do J=js-2,Jeq+1 ; do i=is-2,Ieq+2
+      h_at_slope_above = 2. * ( h(i,j,k-1) * h(i,j+1,k-1) ) * ( h(i,j,k) * h(i,j+1,k) ) / &
+                         ( ( h(i,j,k-1) * h(i,j+1,k-1) ) * ( h(i,j,k) + h(i,j+1,k) ) &
+                         + ( h(i,j,k) * h(i,j+1,k) ) * ( h(i,j,k-1) + h(i,j+1,k-1) ) + GV%H_subroundoff )
+      h_at_slope_below = 2. * ( h(i,j,k) * h(i,j+1,k) ) * ( h(i,j,k+1) * h(i,j+1,k+1) ) / &
+                         ( ( h(i,j,k) * h(i,j+1,k) ) * ( h(i,j,k+1) + h(i,j+1,k+1) ) &
+                         + ( h(i,j,k+1) * h(i,j+1,k+1) ) * ( h(i,j,k) + h(i,j+1,k) ) + GV%H_subroundoff )
+      Ih = 1./ ( ( h_at_slope_above + h_at_slope_below + GV%H_subroundoff ) * GV%H_to_m )
+      dslopey_dz(i,J) = 2. * ( CS%slope_y(i,j,k) - CS%slope_y(i,j,k+1) ) * Ih
+      h_at_v(i,J) = 2. * ( h_at_slope_above * h_at_slope_below ) * Ih
+    enddo ; enddo
+
+    do J=js-2,Jeq+1 ; do i=is-1,Ieq+1
+      f = 0.5 * ( G%CoriolisBu(I,J) + G%CoriolisBu(I-1,J) )
+      vort_xy_dx(i,J) = vort_xy_dx(i,J) - f * &
+            ( ( h_at_u(I,j) * dslopex_dz(I,j) + h_at_u(I-1,j+1) * dslopex_dz(I-1,j+1) ) &
+            + ( h_at_u(I-1,j) * dslopex_dz(I-1,j) + h_at_u(I,j+1) * dslopex_dz(I,j+1) ) ) / &
+              ( ( h_at_u(I,j) + h_at_u(I-1,j+1) ) + ( h_at_u(I-1,j) + h_at_u(I,j+1) ) + GV%H_subroundoff)
+    enddo ; enddo
+
+    do j=js-1,Jeq+1 ; do I=is-2,Ieq+1
+      f = 0.5 * ( G%CoriolisBu(I,J) + G%CoriolisBu(I,J-1) )
+      vort_xy_dy(I,j) = vort_xy_dx(I,j) - f * &
+            ( ( h_at_v(i,J) * dslopey_dz(i,J) + h_at_v(i+1,J-1) * dslopey_dz(i+1,J-1) ) &
+            + ( h_at_v(i,J-1) * dslopey_dz(i,J-1) + h_at_v(i+1,J) * dslopey_dz(i+1,J) ) ) / &
+              ( ( h_at_v(i,J) + h_at_v(i+1,J-1) ) + ( h_at_v(i,J-1) + h_at_v(i+1,J) ) + GV%H_subroundoff)
+    enddo ; enddo
+  endif ! k > 1
+
+  call pass_vector(vort_xy_dy,vort_xy_dx,G%Domain)
+
+    if (CS%use_QG_Leith_GM) then
+      if (CS%use_beta_in_QG_Leith) then
+        do j=Jsq-1,Jeq+2 ; do I=is-2,Ieq+1
+          beta_u(I,j) = sqrt( (0.5*(G%dF_dx(i,j)+G%dF_dx(i+1,j))**2) + &
+                        (0.5*(G%dF_dy(i,j)+G%dF_dy(i+1,j))**2) )
+        enddo ; enddo
+        do J=js-2,Jeq+1 ; do i=Isq-1,Ieq+2
+          beta_v(i,J) = sqrt( (0.5*(G%dF_dx(i,j)+G%dF_dx(i,j+1))**2) + &
+                        (0.5*(G%dF_dy(i,j)+G%dF_dy(i,j+1))**2) )
+        enddo ; enddo
+      endif
+
+      do j=js-1,Jeq+1 ; do I=is-2,Ieq
+        grad_vort_mag_u(I,j) = SQRT(vort_xy_dy(I,j)**2  + (0.25*(vort_xy_dx(i,J) + vort_xy_dx(i+1,J) &
+                             + vort_xy_dx(i,J-1) + vort_xy_dx(i+1,J-1)))**2)
+        grad_div_mag_u(I,j) = SQRT(div_xx_dx(I,j)**2  + (0.25*(div_xx_dy(i,J) + div_xx_dy(i+1,J) &
+                             + div_xx_dy(i,J-1) + div_xx_dy(i+1,J-1)))**2)
+        if (CS%use_beta_in_QG_Leith) then
+          CS%KH_u_QG(I,j,k) = MIN(grad_vort_mag_u(I,j) + grad_div_mag_u(I,j), beta_u(I,j)*3) &
+               * CS%Laplac3_const_u(I,j) * inv_PI3
+        else
+          CS%KH_u_QG(I,j,k) = (grad_vort_mag_u(I,j) + grad_div_mag_u(I,j)) &
+               * CS%Laplac3_const_u(I,j) * inv_PI3
+        endif
+      enddo ; enddo
+
+      do J=js-2,Jeq ; do i=is-1,Ieq+1
+        grad_vort_mag_v(i,J) = SQRT(vort_xy_dx(i,J)**2  + (0.25*(vort_xy_dy(I,j) + vort_xy_dy(I-1,j) &
+                             + vort_xy_dy(I,j+1) + vort_xy_dy(I-1,j+1)))**2)
+        grad_div_mag_v(i,J) = SQRT(div_xx_dy(i,J)**2  + (0.25*(div_xx_dx(I,j) + div_xx_dx(I-1,j) &
+                             + div_xx_dx(I,j+1) + div_xx_dx(I-1,j+1)))**2)
+        if (CS%use_beta_in_QG_Leith) then
+          CS%KH_v_QG(i,J,k) = MIN(grad_vort_mag_v(i,J) + grad_div_mag_v(i,J), beta_v(i,J)*3) &
+               * CS%Laplac3_const_v(i,J) * inv_PI3
+        else
+          CS%KH_v_QG(i,J,k) = (grad_vort_mag_v(i,J) + grad_div_mag_v(i,J)) &
+               * CS%Laplac3_const_v(i,J) * inv_PI3
+        endif
+      enddo ; enddo
+      ! post diagnostics
+      if (CS%id_KH_v_QG > 0)  call post_data(CS%id_KH_v_QG, CS%KH_v_QG, CS%diag)
+      if (CS%id_KH_u_QG > 0)  call post_data(CS%id_KH_u_QG, CS%KH_u_QG, CS%diag)
+    endif
+
+end subroutine calc_QG_Leith_viscosity
+
 !> Initializes the variables mixing coefficients container
 subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
   type(time_type),            intent(in) :: Time !< Current model time
@@ -724,6 +896,9 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
              ! value is roughly (pi / (the age of the universe) )^2.
   logical :: Gill_equatorial_Ld, use_FGNV_streamfn, use_MEKE, in_use
   real :: MLE_front_length
+  real :: Leith_Lap_const      ! The non-dimensional coefficient in the Leith viscosity
+  real :: grid_sp_u2, grid_sp_u3
+  real :: grid_sp_v2, grid_sp_v3 ! Intermediate quantities for Leith metrics
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
   character(len=40)  :: mdl = "MOM_lateral_mixing_coeffs" ! This module's name.
@@ -757,6 +932,9 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
                  "not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0, \n"//&
                  "this is set to true regardless of what is in the \n"//&
                  "parameter file.", default=.false.)
+  call get_param(param_file, mdl, "USE_VISBECK", CS%use_Visbeck,&
+                 "If true, use the Visbeck et al. (1997) formulation for \n"//&
+                 "thickness diffusivity.", default=.false.)
   call get_param(param_file, mdl, "RESOLN_SCALED_KH", CS%Resoln_scaled_Kh, &
                  "If true, the Laplacian lateral viscosity is scaled away \n"//&
                  "when the first baroclinic deformation radius is well \n"//&
@@ -828,6 +1006,8 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     in_use = .true.
     allocate(CS%slope_x(IsdB:IedB,jsd:jed,G%ke+1)) ; CS%slope_x(:,:,:) = 0.0
     allocate(CS%slope_y(isd:ied,JsdB:JedB,G%ke+1)) ; CS%slope_y(:,:,:) = 0.0
+    allocate(CS%N2_u(IsdB:IedB,jsd:jed,G%ke+1)) ; CS%N2_u(:,:,:) = 0.0
+    allocate(CS%N2_v(isd:ied,JsdB:JedB,G%ke+1)) ; CS%N2_v(:,:,:) = 0.0
     call get_param(param_file, mdl, "KD_SMOOTH", CS%kappa_smooth, &
                  "A diapycnal diffusivity that is used to interpolate \n"//&
                  "more sensible values of T & S into thin layers.", &
@@ -944,6 +1124,14 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
       oneOrTwo = 2.0
     endif
 
+    call get_param(param_file, mdl, "USE_GME", CS%use_GME_VarMix, &
+                 "If true, use the GM+E backscatter scheme in association \n"//&
+                 "with the Gent and McWilliams parameterization.", default=.false.)
+
+    if (CS%use_GME_VarMix .and. .not. CS%use_stored_slopes) &
+              call MOM_error(FATAL,"ERROR: use_stored_slopes must be TRUE when "// &
+                                   "using GME.")
+
     do J=js-1,Jeq ; do I=is-1,Ieq
       CS%f2_dx2_q(I,J) = (G%dxBu(I,J)**2 + G%dyBu(I,J)**2) * &
                          max(US%s_to_T**2 * G%CoriolisBu(I,J)**2, absurdly_small_freq2)
@@ -1005,6 +1193,49 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     in_use = .true.
     allocate(CS%cg1(isd:ied,jsd:jed)); CS%cg1(:,:) = 0.0
     call wave_speed_init(CS%wave_speed_CSp, use_ebt_mode=CS%Resoln_use_ebt, mono_N2_depth=N2_filter_depth)
+  endif
+
+  ! Leith parameters
+  call get_param(param_file, mdl, "USE_QG_LEITH_GM", CS%use_QG_Leith_GM, &
+               "If true, use the QG Leith viscosity as the GM coefficient.", &
+               default=.false.)
+
+  if (CS%Use_QG_Leith_GM) then
+    call get_param(param_file, mdl, "LEITH_LAP_CONST", Leith_Lap_const, &
+               "The nondimensional Laplacian Leith constant, \n"//&
+               "often set to 1.0", units="nondim", default=0.0)
+
+    call get_param(param_file, mdl, "USE_BETA_IN_LEITH", CS%use_beta_in_QG_Leith, &
+               "If true, include the beta term in the Leith nonlinear eddy viscosity.", &
+               default=.true.)
+
+    allocate(CS%Laplac3_const_u(IsdB:IedB,jsd:jed)) ; CS%Laplac3_const_u(:,:) = 0.0
+    allocate(CS%Laplac3_const_v(isd:ied,JsdB:JedB)) ; CS%Laplac3_const_v(:,:) = 0.0
+    allocate(CS%KH_u_QG(IsdB:IedB,jsd:jed,G%ke)) ; CS%KH_u_QG(:,:,:) = 0.0
+    allocate(CS%KH_v_QG(isd:ied,JsdB:JedB,G%ke)) ; CS%KH_v_QG(:,:,:) = 0.0
+    ! register diagnostics
+
+    CS%id_KH_u_QG = register_diag_field('ocean_model', 'KH_u_QG', diag%axesCuL, Time, &
+       'Horizontal viscosity from Leith QG, at u-points', 'm2 s-1')
+    CS%id_KH_v_QG = register_diag_field('ocean_model', 'KH_v_QG', diag%axesCvL, Time, &
+       'Horizontal viscosity from Leith QG, at v-points', 'm2 s-1')
+
+    do j=Jsq,Jeq+1 ; do I=is-1,Ieq
+      ! Static factors in the Leith schemes
+      grid_sp_u2 = G%dyCu(I,j)*G%dxCu(I,j)
+      grid_sp_u3 = grid_sp_u2*sqrt(grid_sp_u2)
+      CS%Laplac3_const_u(I,j) = Leith_Lap_const * grid_sp_u3
+    enddo ; enddo
+    do j=js-1,Jeq ; do I=Isq,Ieq+1
+      ! Static factors in the Leith schemes
+      grid_sp_v2 = G%dyCv(i,J)*G%dxCu(i,J)
+      grid_sp_v3 = grid_sp_v2*sqrt(grid_sp_v2)
+      CS%Laplac3_const_v(i,J) = Leith_Lap_const * grid_sp_v3
+    enddo ; enddo
+
+    if (.not. CS%use_stored_slopes) call MOM_error(FATAL, &
+           "MOM_lateral_mixing_coeffs.F90, VarMix_init:"//&
+           "USE_STORED_SLOPES must be True when using QG Leith.")
   endif
 
   ! If nothing is being stored in this class then deallocate

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -416,15 +416,12 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS)
   if (.not. associated(CS)) call MOM_error(FATAL, "MOM_lateral_mixing_coeffs.F90, calc_slope_functions:"//&
          "Module must be initialized before it is used.")
 
-  if (CS%calculate_Eady_growth_rate .or. CS%use_stored_slopes &
-      .or. CS%use_GME_VarMix) then
+  if (CS%calculate_Eady_growth_rate) then
     call find_eta(h, tv, G, GV, US, e, halo_size=2)
     if (CS%use_stored_slopes) then
       call calc_isoneutral_slopes(G, GV, US, h, e, tv, dt*CS%kappa_smooth, &
-                                  CS%slope_x, CS%slope_y, CS%N2_u, CS%N2_v, 1)
-      if (CS%calculate_Eady_growth_rate) then
-        call calc_Visbeck_coeffs(h, CS%slope_x, CS%slope_y, CS%N2_u, CS%N2_v, G, GV, CS)
-      endif
+                                  CS%slope_x, CS%slope_y, N2_u, N2_v, 1)
+      call calc_Visbeck_coeffs(h, CS%slope_x, CS%slope_y, N2_u, N2_v, G, GV, CS)
 !     call calc_slope_functions_using_just_e(h, G, CS, e, .false.)
     else
       !call calc_isoneutral_slopes(G, GV, h, e, tv, dt*CS%kappa_smooth, CS%slope_x, CS%slope_y)

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -127,8 +127,8 @@ type, public :: VarMix_CS
   real :: Visbeck_S_max   !< Upper bound on slope used in Eady growth rate [nondim].
 
   ! Leith parameters
-  logical :: use_QG_Leith_GM      !! If true, uses the QG Leith viscosity as the GM coefficient
-  logical :: use_beta_in_QG_Leith !! If true, includes the beta term in the QG Leith GM coefficient
+  logical :: use_QG_Leith_GM      !< If true, uses the QG Leith viscosity as the GM coefficient
+  logical :: use_beta_in_QG_Leith !< If true, includes the beta term in the QG Leith GM coefficient
 
   ! Diagnostics
   !>@{

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -55,8 +55,6 @@ type, public :: VarMix_CS
                                   !! This parameter is set depending on other parameters.
   logical :: calculate_Eady_growth_rate !< If true, calculate all the Eady growth rate.
                                   !! This parameter is set depending on other parameters.
-  logical :: use_GME_VarMix       !< If true, calculates slopes and Brunt-Vaisala frequency for use with
-                                  !! the GME closure.
   real, dimension(:,:), pointer :: &
     SN_u => NULL(), &   !< S*N at u-points [s-1]
     SN_v => NULL(), &  !< S*N at v-points [s-1]
@@ -1120,14 +1118,6 @@ subroutine VarMix_init(Time, G, GV, US, param_file, diag, CS)
     if (Gill_equatorial_Ld) then
       oneOrTwo = 2.0
     endif
-
-    call get_param(param_file, mdl, "USE_GME", CS%use_GME_VarMix, &
-                 "If true, use the GM+E backscatter scheme in association \n"//&
-                 "with the Gent and McWilliams parameterization.", default=.false.)
-
-    if (CS%use_GME_VarMix .and. .not. CS%use_stored_slopes) &
-              call MOM_error(FATAL,"ERROR: use_stored_slopes must be TRUE when "// &
-                                   "using GME.")
 
     do J=js-1,Jeq ; do I=is-1,Ieq
       CS%f2_dx2_q(I,J) = (G%dxBu(I,J)**2 + G%dyBu(I,J)**2) * &

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -65,7 +65,7 @@ type, public :: thickness_diffuse_CS ; private
                                  !! framework (Marshall et al., 2012)
   real    :: MEKE_GEOMETRIC_alpha !< The nondimensional coefficient governing the efficiency of
                                  !! the GEOMETRIC thickness difussion [nondim]
-  logical :: Use_KH_in_MEKE      !! If true, uses the thickness diffusivity calculated here to diffuse MEKE.
+  logical :: Use_KH_in_MEKE      !< If true, uses the thickness diffusivity calculated here to diffuse MEKE.
   logical :: GM_src_alt          !< If true, use the GM energy conversion form S^2*N^2*kappa rather
                                  !! than the streamfunction for the GM source term.
   type(diag_ctrl), pointer :: diag => NULL() !< structure used to regulate timing of diagnostics

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1262,7 +1262,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
 
   !if (find_work) then ; do j=js,je ; do i=is,ie ; do k=nz,1,-1
-  if (find_work) then ; do j=js,je ; do i=is,ie 
+  if (find_work) then ; do j=js,je ; do i=is,ie
     ! Note that the units of Work_v and Work_u are W, while Work_h is W m-2.
     Work_h = 0.5 * G%IareaT(i,j) * &
       ((Work_u(I-1,j) + Work_u(I,j)) + (Work_v(i,J-1) + Work_v(i,J)))

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -1261,7 +1261,8 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   endif
 
 
-  if (find_work) then ; do j=js,je ; do i=is,ie ; do k=nz,1,-1
+  !if (find_work) then ; do j=js,je ; do i=is,ie ; do k=nz,1,-1
+  if (find_work) then ; do j=js,je ; do i=is,ie 
     ! Note that the units of Work_v and Work_u are W, while Work_h is W m-2.
     Work_h = 0.5 * G%IareaT(i,j) * &
       ((Work_u(I-1,j) + Work_u(I,j)) + (Work_v(i,J-1) + Work_v(i,J)))
@@ -1277,7 +1278,8 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
         MEKE%GM_src(i,j) = MEKE%GM_src(i,j) + Work_h
       endif
     endif ; endif
-  enddo ; enddo ; enddo ; endif
+  !enddo ; enddo ; enddo ; endif
+  enddo ; enddo ; endif
 
   if (CS%id_slope_x > 0) call post_data(CS%id_slope_x, CS%diagSlopeX, CS%diag)
   if (CS%id_slope_y > 0) call post_data(CS%id_slope_y, CS%diagSlopeY, CS%diag)

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -7,7 +7,8 @@ use MOM_debugging,             only : hchksum, uvchksum
 use MOM_diag_mediator,         only : post_data, query_averaging_enabled, diag_ctrl
 use MOM_diag_mediator,         only : register_diag_field, safe_alloc_ptr, time_type
 use MOM_diag_mediator,         only : diag_update_remap_grids
-use MOM_error_handler,         only : MOM_error, FATAL, WARNING
+use MOM_domains,               only : pass_var, CORNER, pass_vector
+use MOM_error_handler,         only : MOM_error, FATAL, WARNING, is_root_pe
 use MOM_EOS,                   only : calculate_density, calculate_density_derivs
 use MOM_file_parser,           only : get_param, log_version, param_file_type
 use MOM_grid,                  only : ocean_grid_type
@@ -23,7 +24,7 @@ implicit none ; private
 #include <MOM_memory.h>
 
 public thickness_diffuse, thickness_diffuse_init, thickness_diffuse_end
-public vert_fill_TS
+public vert_fill_TS, thickness_diffuse_get_KH
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
@@ -58,10 +59,18 @@ type, public :: thickness_diffuse_CS ; private
                                  !! longer than DT, or 0 (the default) to use DT.
   integer :: nkml                !< number of layers within mixed layer
   logical :: debug               !< write verbose checksums for debugging purposes
+  logical :: use_GME_thickness_diffuse !< If true, passes GM coefficients to MOM_hor_visc for use
+                                 !! with GME closure.
+  logical :: GM_src_alt          !< If true, use the GM energy conversion form S^2*N^2*kappa rather
+                                 !! than the streamfunction for the GM source term.
   type(diag_ctrl), pointer :: diag => NULL() !< structure used to regulate timing of diagnostics
   real, pointer :: GMwork(:,:)       => NULL()  !< Work by thickness diffusivity [W m-2]
   real, pointer :: diagSlopeX(:,:,:) => NULL()  !< Diagnostic: zonal neutral slope [nondim]
   real, pointer :: diagSlopeY(:,:,:) => NULL()  !< Diagnostic: zonal neutral slope [nondim]
+
+  real, dimension(:,:,:), pointer :: &
+    KH_u_GME => NULL(), &        !< interface height diffusivities in u-columns (m2 s-1)
+    KH_v_GME => NULL()           !< interface height diffusivities in v-columns (m2 s-1)
 
   !>@{
   !! Diagnostic identifier
@@ -121,9 +130,10 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   real :: Khth_Loc_u(SZIB_(G), SZJ_(G))
   real :: Khth_Loc(SZIB_(G), SZJB_(G))  ! locally calculated thickness diffusivity [m2 s-1]
   real :: h_neglect ! A thickness that is so small it is usually lost
-                    ! in roundoff and can be neglected [H ~> m or kg m-2].
-  real, dimension(:,:), pointer :: cg1 => null() !< Wave speed [m s-1]
-  logical :: use_VarMix, Resoln_scaled, use_stored_slopes, khth_use_ebt_struct
+                    ! in roundoff and can be neglected, in H.
+  real, dimension(:,:), pointer :: cg1 => null() !< Wave speed (m/s)
+  logical :: use_VarMix, Resoln_scaled, use_stored_slopes, khth_use_ebt_struct, use_Visbeck
+  logical :: use_QG_Leith
   integer :: i, j, k, is, ie, js, je, nz
   real :: hu(SZI_(G), SZJ_(G))       ! u-thickness [H ~> m or kg m-2]
   real :: hv(SZI_(G), SZJ_(G))       ! v-thickness [H ~> m or kg m-2]
@@ -146,12 +156,15 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
   endif
 
   use_VarMix = .false. ; Resoln_scaled = .false. ; use_stored_slopes = .false.
-  khth_use_ebt_struct = .false.
+  khth_use_ebt_struct = .false. ; use_Visbeck = .false. ; use_QG_Leith = .false.
+
   if (associated(VarMix)) then
     use_VarMix = VarMix%use_variable_mixing .and. (CS%KHTH_Slope_Cff > 0.)
     Resoln_scaled = VarMix%Resoln_scaled_KhTh
     use_stored_slopes = VarMix%use_stored_slopes
     khth_use_ebt_struct = VarMix%khth_use_ebt_struct
+    use_Visbeck = VarMix%use_Visbeck
+    use_QG_Leith = VarMix%use_QG_Leith_GM
     if (associated(VarMix%cg1)) cg1 => VarMix%cg1
   else
     cg1 => null()
@@ -183,9 +196,11 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
 
   if (use_VarMix) then
 !$OMP do
-    do j=js,je ; do I=is-1,ie
-      Khth_Loc_u(I,j) = Khth_Loc_u(I,j) + CS%KHTH_Slope_Cff*VarMix%L2u(I,j)*VarMix%SN_u(I,j)
-    enddo ; enddo
+    if (use_Visbeck) then
+      do j=js,je ; do I=is-1,ie
+        Khth_Loc_u(I,j) = Khth_Loc_u(I,j) + CS%KHTH_Slope_Cff*VarMix%L2u(I,j)*VarMix%SN_u(I,j)
+      enddo ; enddo
+    endif
   endif
 
   if (associated(MEKE)) then ; if (associated(MEKE%Kh)) then
@@ -230,6 +245,22 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
     enddo ; enddo ; enddo
   endif
 
+  if (use_VarMix) then
+!$OMP do
+    if (use_QG_Leith) then
+      do k=1,nz ; do j=js,je ; do I=is-1,ie
+        KH_u(I,j,k) = VarMix%KH_u_QG(I,j,k)
+      enddo ; enddo ; enddo
+    endif
+  endif
+
+!$OMP do
+  if (CS%use_GME_thickness_diffuse) then
+    do k=1,nz+1 ; do j=js,je ; do I=is-1,ie
+        CS%KH_u_GME(I,j,k) = KH_u(I,j,k)
+    enddo ; enddo ; enddo
+  endif
+
 !$OMP do
   do J=js-1,je ; do i=is,ie
     Khth_Loc(i,j) = CS%Khth
@@ -237,9 +268,11 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
 
   if (use_VarMix) then
 !$OMP do
-    do J=js-1,je ; do i=is,ie
-      Khth_Loc(i,j) = Khth_Loc(i,j) + CS%KHTH_Slope_Cff*VarMix%L2v(i,J)*VarMix%SN_v(i,J)
-    enddo ; enddo
+    if (use_Visbeck) then
+      do J=js-1,je ; do i=is,ie
+        Khth_Loc(i,j) = Khth_Loc(i,j) + CS%KHTH_Slope_Cff*VarMix%L2v(i,J)*VarMix%SN_v(i,J)
+      enddo ; enddo
+    endif
   endif
   if (associated(MEKE)) then ; if (associated(MEKE%Kh)) then
 !$OMP do
@@ -273,6 +306,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
       KH_v(i,J,1) = min(KH_v_CFL(i,J), Khth_Loc(i,j))
     enddo ; enddo
   endif
+
   if (khth_use_ebt_struct) then
 !$OMP do
     do K=2,nz+1 ; do J=js-1,je ; do i=is,ie
@@ -284,6 +318,23 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
       KH_v(i,J,K) = KH_v(i,J,1)
     enddo ; enddo ; enddo
   endif
+
+  if (use_VarMix) then
+!$OMP do
+    if (use_QG_Leith) then
+      do k=1,nz ; do J=js-1,je ; do i=is,ie
+        KH_v(i,J,k) = VarMix%KH_v_QG(i,J,k)
+      enddo ; enddo ; enddo
+    endif
+  endif
+
+!$OMP do
+  if (CS%use_GME_thickness_diffuse) then
+    do k=1,nz+1 ; do j=js-1,je ; do I=is,ie
+      CS%KH_v_GME(I,j,k) = KH_v(I,j,k)
+    enddo ; enddo ; enddo
+  endif
+
 !$OMP do
   do K=1,nz+1 ; do j=js,je ; do I=is-1,ie ; int_slope_u(I,j,K) = 0.0 ; enddo ; enddo ; enddo
 !$OMP do
@@ -364,6 +415,7 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
                        / (hu(I-1,j)+hu(I,j)+hv(i,J-1)+hv(i,J)+h_neglect)
         enddo ; enddo
       enddo
+
       if (CS%id_KH_t  > 0) call post_data(CS%id_KH_t,  KH_t,        CS%diag)
       if (CS%id_KH_t1 > 0) call post_data(CS%id_KH_t1, KH_t(:,:,1), CS%diag)
     endif
@@ -435,7 +487,6 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
                                                                      !! density gradients.
   real, dimension(SZIB_(G),SZJ_(G),SZK_(G)+1), optional, intent(in)  :: slope_x !< Isopycnal slope at u-points
   real, dimension(SZI_(G),SZJB_(G),SZK_(G)+1), optional, intent(in)  :: slope_y !< Isopycnal slope at v-points
-
   ! Local variables
   real, dimension(SZI_(G), SZJ_(G), SZK_(G)) :: &
     T, &          ! The temperature (or density) [degC], with the values in
@@ -447,7 +498,15 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
     h_avail, &    ! The mass available for diffusion out of each face, divided
                   ! by dt [H m2 s-1 ~> m3 s-1 or kg s-1].
     h_frac        ! The fraction of the mass in the column above the bottom
-                  ! interface of a layer that is within a layer [nondim]. 0<h_frac<=1
+                  ! interface of a layer that is within a layer, ND. 0<h_frac<=1
+  real, dimension(SZI_(G), SZJB_(G), SZK_(G)+1) :: &
+    Slope_y_PE, &  ! 3D array of neutral slopes at v-points, set equal to Slope (below, nondim)
+    hN2_y_PE       ! thickness in m times Brunt-Vaisala freqeuncy at v-points (m s-2),
+                   ! used for calculating PE release
+  real, dimension(SZIB_(G), SZJ_(G), SZK_(G)+1) :: &
+    Slope_x_PE, &  ! 3D array of neutral slopes at u-points, set equal to Slope (below, nondim)
+    hN2_x_PE       ! thickness in m times Brunt-Vaisala freqeuncy at u-points (m s-2)
+                   ! used for calculating PE release
   real, dimension(SZI_(G), SZJ_(G), SZK_(G)+1) :: &
     pres, &       ! The pressure at an interface [Pa].
     h_avail_rsum  ! The running sum of h_avail above an interface [H m2 s-1 ~> m3 s-1 or kg s-1].
@@ -468,9 +527,11 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
     S_v, &        ! Salinity on the interface at the v-point [ppt].
     pres_v        ! Pressure on the interface at the v-point [Pa].
   real :: Work_u(SZIB_(G), SZJ_(G)) ! The work being done by the thickness
-  real :: Work_v(SZI_(G), SZJB_(G)) ! diffusion integrated over a cell [W].
-  real :: Work_h        ! The work averaged over an h-cell [W m-2].
-  real :: I4dt          ! 1 / 4 dt [s-1].
+  real :: Work_v(SZI_(G), SZJB_(G)) ! diffusion integrated over a cell, in W.
+  real :: Work_h        ! The work averaged over an h-cell in W m-2.
+  real :: PE_release_h  ! The amount of potential energy released by GM, averaged over an h-cell in m3 s-3.
+                        ! The calculation is equal to h * S^2 * N^2 * kappa_GM.
+  real :: I4dt          ! 1 / 4 dt in s-1.
   real :: drdiA, drdiB  ! Along layer zonal- and meridional- potential density
   real :: drdjA, drdjB  ! gradients in the layers above (A) and below(B) the
                         ! interface times the grid spacing [kg m-3].
@@ -543,6 +604,11 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
   present_slope_y = PRESENT(slope_y)
 
   nk_linear = max(GV%nkml, 1)
+
+  Slope_x_PE(:,:,:) = 0.0
+  Slope_y_PE(:,:,:) = 0.0
+  hN2_x_PE(:,:,:) = 0.0
+  hN2_y_PE(:,:,:) = 0.0
 
   find_work = .false.
   if (associated(MEKE)) find_work = associated(MEKE%GM_src)
@@ -650,7 +716,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
         if (k > nk_linear) then
           if (use_EOS) then
-            if (CS%use_FGNV_streamfn .or. .not.present_slope_x) then
+            if (CS%use_FGNV_streamfn .or. find_work .or. .not.present_slope_x) then
               hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
               hg2R = h(i+1,j,k-1)*h(i+1,j,k) + h_neglect2
               haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
@@ -708,6 +774,9 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
                       int_slope_u(I,j,K) * US%Z_to_m*((e(i+1,j,K)-e(i,j,K)) * G%IdxCu(I,j))
               slope2_Ratio_u(I,K) = (1.0 - int_slope_u(I,j,K)) * slope2_Ratio_u(I,K)
             endif
+
+            Slope_x_PE(I,j,k) = MIN(Slope,CS%slope_max)
+            hN2_x_PE(I,j,k) = hN2_u(I,K) * US%m_to_Z
             if (CS%id_slope_x > 0) CS%diagSlopeX(I,j,k) = Slope
 
             ! Estimate the streamfunction at each interface [m3 s-1].
@@ -896,7 +965,7 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
 
         if (k > nk_linear) then
           if (use_EOS) then
-            if (CS%use_FGNV_streamfn .or. .not.present_slope_y) then
+            if (CS%use_FGNV_streamfn .or. find_work .or. .not. present_slope_y) then
               hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
               hg2R = h(i,j+1,k-1)*h(i,j+1,k) + h_neglect2
               haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
@@ -954,6 +1023,9 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
                       int_slope_v(i,J,K) * US%Z_to_m*((e(i,j+1,K)-e(i,j,K)) * G%IdyCv(i,J))
               slope2_Ratio_v(i,K) = (1.0 - int_slope_v(i,J,K)) * slope2_Ratio_v(i,K)
             endif
+
+            Slope_y_PE(i,J,k) = MIN(Slope,CS%slope_max)
+            hN2_y_PE(i,J,k) = hN2_v(i,K) * US%m_to_Z
             if (CS%id_slope_y > 0) CS%diagSlopeY(I,j,k) = Slope
 
             ! Estimate the streamfunction at each interface [m3 s-1].
@@ -1142,15 +1214,24 @@ subroutine thickness_diffuse_full(h, e, Kh_u, Kh_v, tv, uhD, vhD, cg1, dt, G, GV
     enddo
   endif
 
-  if (find_work) then ; do j=js,je ; do i=is,ie
+
+  if (find_work) then ; do j=js,je ; do i=is,ie ; do k=nz,1,-1
     ! Note that the units of Work_v and Work_u are W, while Work_h is W m-2.
     Work_h = 0.5 * G%IareaT(i,j) * &
       ((Work_u(I-1,j) + Work_u(I,j)) + (Work_v(i,J-1) + Work_v(i,J)))
+    PE_release_h = -0.25*(Kh_u(I,j,k)*(Slope_x_PE(I,j,k)**2) * hN2_x_PE(I,j,k) + &
+      Kh_u(I-1,j,k)*(Slope_x_PE(I-1,j,k)**2) * hN2_x_PE(I-1,j,k) + &
+      Kh_v(i,J,k)*(Slope_y_PE(i,J,k)**2) * hN2_y_PE(i,J,k) + &
+      Kh_v(i,J-1,k)*(Slope_y_PE(i,J-1,k)**2) * hN2_y_PE(i,J-1,k))
     if (associated(CS%GMwork)) CS%GMwork(i,j) = Work_h
     if (associated(MEKE)) then ; if (associated(MEKE%GM_src)) then
-      MEKE%GM_src(i,j) = MEKE%GM_src(i,j) + Work_h
+      if (CS%GM_src_alt) then
+        MEKE%GM_src(i,j) = MEKE%GM_src(i,j) + PE_release_h
+      else
+        MEKE%GM_src(i,j) = MEKE%GM_src(i,j) + Work_h
+      endif
     endif ; endif
-  enddo ; enddo ; endif
+  enddo ; enddo ; enddo ; endif
 
   if (CS%id_slope_x > 0) call post_data(CS%id_slope_x, CS%diagSlopeX, CS%diag)
   if (CS%id_slope_y > 0) call post_data(CS%id_slope_y, CS%diagSlopeY, CS%diag)
@@ -1739,6 +1820,11 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
                  "marginally unstable value in a pure layered model, but \n"//&
                  "much smaller numbers (e.g. 0.1) seem to work better for \n"//&
                  "ALE-based models.", units = "nondimensional", default=0.8)
+
+!  call get_param(param_file, mdl, "USE_QG_LEITH_GM", CS%QG_Leith_GM, &
+!               "If true, use the QG Leith viscosity as the GM coefficient.", &
+!               default=.false.)
+
   if (CS%max_Khth_CFL < 0.0) CS%max_Khth_CFL = 0.0
   call get_param(param_file, mdl, "DETANGLE_INTERFACES", CS%detangle_interfaces, &
                  "If defined add 3-d structured enhanced interface height \n"//&
@@ -1771,7 +1857,7 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
                  "streamfunction formulation.", &
                  default=0., units="m s-1", do_not_log=.not.CS%use_FGNV_streamfn)
   call get_param(param_file, mdl, "FGNV_STRAT_FLOOR", strat_floor, &
-                 "A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,\n"//&
+                 "A floor for Brunt-Vaisala frequency in the Ferrari et al., 2010,\n"//&
                  "streamfunction formulation, expressed as a fraction of planetary\n"//&
                  "rotation, OMEGA. This should be tiny but non-zero to avoid degeneracy.", &
                  default=1.e-15, units="nondim", do_not_log=.not.CS%use_FGNV_streamfn)
@@ -1783,6 +1869,16 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
                  "If true, write out verbose debugging data.", &
                  default=.false., debuggingParam=.true.)
 
+  call get_param(param_file, mdl, "USE_GME", CS%use_GME_thickness_diffuse, &
+                 "If true, use the GM+E backscatter scheme in association \n"//&
+                 "with the Gent and McWilliams parameterization.", default=.false.)
+  call get_param(param_file, mdl, "MEKE_GM_SRC_ALT", CS%GM_src_alt, &
+                 "If true, use the GM energy conversion form S^2*N^2*kappa rather \n"//&
+                 "than the streamfunction for the GM source term.", default=.false.)
+  if (CS%use_GME_thickness_diffuse) then
+    call safe_alloc_ptr(CS%KH_u_GME,G%IsdB,G%IedB,G%jsd,G%jed,G%ke+1)
+    call safe_alloc_ptr(CS%KH_v_GME,G%isd,G%ied,G%JsdB,G%JedB,G%ke+1)
+  endif
 
   if (GV%Boussinesq) then ; flux_to_kg_per_s = GV%Rho0
   else ; flux_to_kg_per_s = 1. ; endif
@@ -1839,6 +1935,28 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
            'm3 s-1', conversion=US%Z_to_m)
 
 end subroutine thickness_diffuse_init
+
+!> Copies ubtav and vbtav from private type into arrays
+subroutine thickness_diffuse_get_KH(CS, KH_u_GME, KH_v_GME, G)
+  type(thickness_diffuse_CS),          pointer     :: CS   !< Control structure for
+                                                   !! this module
+  type(ocean_grid_type),               intent(in)  :: G    !< Grid structure
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(G)+1), intent(inout) :: KH_u_GME!< interface height
+                                                   !! diffusivities in u-columns (m2 s-1)
+  real, dimension(SZI_(G),SZJB_(G),SZK_(G)+1), intent(inout) :: KH_v_GME!< interface height
+                                                   !! diffusivities in v-columns (m2 s-1)
+  ! Local variables
+  integer :: i,j,k
+
+  do k=1,G%ke+1 ; do j = G%jsc, G%jec ; do I = G%isc-1, G%iec
+    KH_u_GME(I,j,k) = CS%KH_u_GME(I,j,k)
+  enddo ; enddo ; enddo
+
+  do k=1,G%ke+1 ; do J = G%jsc-1, G%jec ; do i = G%isc, G%iec
+    KH_v_GME(i,J,k) = CS%KH_v_GME(i,J,k)
+  enddo ; enddo ; enddo
+
+end subroutine thickness_diffuse_get_KH
 
 !> Deallocate the thickness diffusion control structure
 subroutine thickness_diffuse_end(CS)


### PR DESCRIPTION
This PR adds the following capabilities:

* GME backscatter (Bachman, 2019). MEKE must be enabled for this parameterization to be used, as it uses MEKE to limit the amount of energy it adds.
* GEOMETRIC (Mak et al., 2017). This is an add-on to the MEKE package and is selected as a runtime parameter.  Presently the only difference between GEOMETRIC and MEKE is in the expression for the thickness diffusivity.
* Biharmonic option for MEKE viscosity.
* Ability to count GME as an energy sink for MEKE. This is switched off by default.
* Ability to count a non-MEKE thickness diffusivity as an energy source for MEKE. Also added the ability to use this thickness diffusivity to diffuse MEKE (previously it could only be used with the diffusivity diagnosed within MEKE).
* Proper expression for the Jansen et al. (2015) bottom drag into MEKE.
* Sign-definite way of accounting for the GM source term in MEKE.
* Sign-definite way of accounting for the frictional (viscous) source term in MEKE. 

All code added has been properly documented (doxygenized).

This PR does not change answers for the GFDL tests based on 'dev-master-candidate-2019-04-26'. It should also not change answers for NCAR (@alperaltuntas, please check that).


