### PR TITLE
* Remove volume flux contribution due to sea ice melt via salt flux 

### DIFF
--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -505,17 +505,6 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, US, CS, &
       net_FW(i,j) = (((fluxes%lprec(i,j)   + fluxes%fprec(i,j) + fluxes%seaice_melt(i,j)) + &
           (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j))) + &
           (fluxes%evap(i,j)    + fluxes%vprec(i,j)) ) * G%areaT(i,j)
-      !   The following contribution appears to be calculating the volume flux of sea-ice
-      ! melt. This calculation is clearly WRONG if either sea-ice has variable
-      ! salinity or the sea-ice is completely fresh.
-      !   Bob thinks this is trying ensure the net fresh-water of the ocean + sea-ice system
-      ! is constant.
-      !   To do this correctly we will need a sea-ice melt field added to IOB. -AJA
-      ! GMM: as stated above, the following is wrong. CIME deals with volume/mass and
-      ! heat from sea ice/snow via seaice_melt and seaice_melt_heat, respectively.
-      !if (associated(fluxes%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
-      !    net_FW(i,j) = net_FW(i,j) + G%areaT(i,j) * &
-      !    (fluxes%salt_flux(i,j) / CS%ice_salt_concentration)
 
       net_FW2(i,j) = net_FW(i,j)/G%areaT(i,j)
     enddo; enddo

--- a/config_src/mct_driver/MOM_surface_forcing.F90
+++ b/config_src/mct_driver/MOM_surface_forcing.F90
@@ -513,9 +513,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, Time, G, US, CS, &
       !   To do this correctly we will need a sea-ice melt field added to IOB. -AJA
       ! GMM: as stated above, the following is wrong. CIME deals with volume/mass and
       ! heat from sea ice/snow via seaice_melt and seaice_melt_heat, respectively.
-      if (associated(fluxes%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
-          net_FW(i,j) = net_FW(i,j) + G%areaT(i,j) * &
-          (fluxes%salt_flux(i,j) / CS%ice_salt_concentration)
+      !if (associated(fluxes%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
+      !    net_FW(i,j) = net_FW(i,j) + G%areaT(i,j) * &
+      !    (fluxes%salt_flux(i,j) / CS%ice_salt_concentration)
 
       net_FW2(i,j) = net_FW(i,j)/G%areaT(i,j)
     enddo; enddo

--- a/config_src/nuopc_driver/MOM_surface_forcing.F90
+++ b/config_src/nuopc_driver/MOM_surface_forcing.F90
@@ -552,9 +552,10 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, US, CS, &
       !   To do this correctly we will need a sea-ice melt field added to IOB. -AJA
       ! GMM: as stated above, the following is wrong. CIME deals with volume/mass and
       ! heat from sea ice/snow via seaice_melt and seaice_melt_heat, respectively.
-      if (associated(IOB%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
-        net_FW(i,j) = net_FW(i,j) + sign_for_net_FW_bug * G%areaT(i,j) * &
-                     (IOB%salt_flux(i-i0,j-j0) / CS%ice_salt_concentration)
+      !if (associated(IOB%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
+      !  net_FW(i,j) = net_FW(i,j) + sign_for_net_FW_bug * G%areaT(i,j) * &
+      !               (IOB%salt_flux(i-i0,j-j0) / CS%ice_salt_concentration)
+
       net_FW2(i,j) = net_FW(i,j) / G%areaT(i,j)
     enddo ; enddo
 

--- a/config_src/nuopc_driver/MOM_surface_forcing.F90
+++ b/config_src/nuopc_driver/MOM_surface_forcing.F90
@@ -544,18 +544,6 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, US, CS, &
                       (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j))) + &
                       (fluxes%evap(i,j)    + fluxes%vprec(i,j)) ) * G%areaT(i,j)
 
-      !   The following contribution appears to be calculating the volume flux of sea-ice
-      ! melt. This calculation is clearly WRONG if either sea-ice has variable
-      ! salinity or the sea-ice is completely fresh.
-      !   Bob thinks this is trying ensure the net fresh-water of the ocean + sea-ice system
-      ! is constant.
-      !   To do this correctly we will need a sea-ice melt field added to IOB. -AJA
-      ! GMM: as stated above, the following is wrong. CIME deals with volume/mass and
-      ! heat from sea ice/snow via seaice_melt and seaice_melt_heat, respectively.
-      !if (associated(IOB%salt_flux) .and. (CS%ice_salt_concentration>0.0)) &
-      !  net_FW(i,j) = net_FW(i,j) + sign_for_net_FW_bug * G%areaT(i,j) * &
-      !               (IOB%salt_flux(i-i0,j-j0) / CS%ice_salt_concentration)
-
       net_FW2(i,j) = net_FW(i,j) / G%areaT(i,j)
     enddo ; enddo
 


### PR DESCRIPTION
A volume flux due to sea ice melt was being [added](https://github.com/NCAR/MOM6/blob/91d0e26ea0e32e8c73245f9f60a764db57779ae8/config_src/mct_driver/MOM_surface_forcing.F90#L516-L518) by assuming that sea ice has a constant salinity (`CS%ice_salt_concentration`). In addition to the fact that this calculation is wrong, as the [comments](https://github.com/NCAR/MOM6/blob/dev/ncar/config_src/mct_driver/MOM_surface_forcing.F90#L508-L515) in the code describe, CESM already provides a flux (`seaice_melt`) that accounts for sea ice melt. This PR comments out the additional volume flux due to sea ice melt computed via ice_salt_concentration in both MCT and NUOPC caps. By doing so, a globally constant sea level is maintained in C- and G-compsets when `adjust_net_fresh_water_to_zero = True`. 

This change answers in all tests where `adjust_net_fresh_water_to_zero = True`.