### PR TITLE
 Adds time0 and timenow in MCT and NUOPC

### DIFF
--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -738,8 +738,8 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   type(ocean_internalstate_wrapper)      :: ocean_internalstate
   type(ocean_grid_type),         pointer :: ocean_grid => NULL()
   type(time_type)                        :: Run_len      !< length of experiment
-  type(time_type)                        :: time0        !< Model start time
-  type(time_type)                        :: timenow      !< Model current time
+  type(time_type)                        :: time0        !< Start time of coupled model's calendar.
+  type(time_type)                        :: time_start   !< The time at which to initialize the ocean model
   type(time_type)                        :: Time_restart
   type(time_type)                        :: DT
   integer                                :: DT_OCEAN
@@ -843,7 +843,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   ! this ocean connector will be driven at set interval
   DT = set_time (DT_OCEAN, 0)
   ! get current time
-  timenow = set_date (YEAR,MONTH,DAY,HOUR,MINUTE,SECOND)
+  time_start = set_date (YEAR,MONTH,DAY,HOUR,MINUTE,SECOND)
 
   if (is_root_pe()) then
     write(logunit,*) subname//'current time: y,m,d-',year,month,day,'h,m,s=',hour,minute,second
@@ -995,7 +995,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   endif
 
   ocean_public%is_ocean_pe = .true.
-  call ocean_model_init(ocean_public, ocean_state, time0, timenow, input_restart_file=trim(restartfile))
+  call ocean_model_init(ocean_public, ocean_state, time0, time_start, input_restart_file=trim(restartfile))
 
   call ocean_model_init_sfc(ocean_state, ocean_public)
 

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -995,7 +995,6 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   endif
 
   ocean_public%is_ocean_pe = .true.
-  
   call ocean_model_init(ocean_public, ocean_state, time0, timenow, input_restart_file=trim(restartfile))
 
   call ocean_model_init_sfc(ocean_state, ocean_public)

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -845,6 +845,10 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   ! get current time
   timenow = set_date (YEAR,MONTH,DAY,HOUR,MINUTE,SECOND)
 
+  if (is_root_pe()) then
+    write(logunit,*) subname//'current time: y,m,d-',year,month,day,'h,m,s=',hour,minute,second
+  endif
+
   ! get start/reference time
   call ESMF_ClockGet(CLOCK, refTime=MyTime, RC=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -859,6 +863,10 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
     return  ! bail out
 
   time0 = set_date (YEAR,MONTH,DAY,HOUR,MINUTE,SECOND)
+
+  if (is_root_pe()) then
+    write(logunit,*) subname//'start time: y,m,d-',year,month,day,'h,m,s=',hour,minute,second
+  endif
 
   ! rsd need to figure out how to get this without share code
   !call shr_nuopc_get_component_instance(gcomp, inst_suffix, inst_index)
@@ -987,11 +995,8 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   endif
 
   ocean_public%is_ocean_pe = .true.
-  if (len_trim(restartfile) > 0) then
-     call ocean_model_init(ocean_public, ocean_state, time0, timenow, input_restart_file=trim(restartfile))
-  else
-     call ocean_model_init(ocean_public, ocean_state, time0, timenow)
-  endif
+  
+  call ocean_model_init(ocean_public, ocean_state, time0, timenow, input_restart_file=trim(restartfile))
 
   call ocean_model_init_sfc(ocean_state, ocean_public)
 


### PR DESCRIPTION
This PR fixes the issue in ocean_stats (it used to be overwritten) during a continued run. Below are case examples for MCT and NUOPC, where STOP_N=1 and RESUBMIT= 4:

**MCT**
/glade/scratch/gmarques/c.c2b6.CNYF.T62_t061.PR/run

**NUOPC**
/glade/scratch/gmarques/c.c2b6.CNYF.T62_t061.nuopc.PR2/run

I've not tested whether this PR changes answers. 