### PR TITLE
 Obsolete ADD_KV_SLOW and remove visc%Kv_slow from restart files

### DIFF
--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -257,8 +257,6 @@ type, public :: vertvisc_type
   real, pointer, dimension(:,:,:) :: TKE_turb => NULL()
                 !< The turbulent kinetic energy per unit mass at the interfaces [m2 s-2].
                 !! This may be at the tracer or corner points
-  logical :: add_Kv_slow !< If True, add Kv_slow when calculating the 'coupling coefficient' (a_cpl)
-                         !! at the interfaces in find_coupling_coef.
 end type vertvisc_type
 
 !> Container for information about the summed layer transports

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -47,6 +47,9 @@ subroutine find_obsolete_params(param_file)
   call obsolete_logical(param_file, "BT_CONT_BT_THICK", &
        hint="Instead use BT_THICK_SCHEME='FROM_BT_CONT'.")
 
+  call obsolete_logical(param_file, "ADD_KV_SLOW", &
+       hint="This option is no longer needed, nor supported.")
+
   call obsolete_logical(param_file, "APPLY_OBC_U", &
        hint="Instead use OBC_NUMBER_SEGMENTS>0 and use the new segments protocol.")
   call obsolete_logical(param_file, "APPLY_OBC_V", &


### PR DESCRIPTION
This PR obsoletes ADD_KV_SLOW and eliminates visc%Kv_slow from restart files. 