### PR TITLE
Fix latest travis errors

### DIFF
--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1058,18 +1058,16 @@ logical function MEKE_init(Time, G, US, param_file, diag, CS, MEKE, restart_CS)
   call get_param(param_file, mdl, "MEKE_EQUILIBRIUM_ALT", CS%MEKE_equilibrium_alt, &
                  "If true, use an alternative formula for computing the (equilibrium)"//&
                  "initial value of MEKE.", default=.false.)
-  if (CS%MEKE_equilibrium_alt) then
-    call get_param(param_file, mdl, "MEKE_EQUILIBRIUM_RESTORING", CS%MEKE_equilibrium_restoring, &
-                   "If true, restore MEKE back to its equilibrium value, which is calculated at"//&
-                   "each time step.", default=.false.)
-    if (CS%MEKE_equilibrium_restoring) then
-      call get_param(param_file, mdl, "MEKE_RESTORING_TIMESCALE", MEKE_restoring_timescale, &
-                     "The timescale used to nudge MEKE toward its equilibrium value.", units="s", &
-                     default=1e6, scale=US%T_to_s)
-      CS%MEKE_restoring_rate = 1.0 / MEKE_restoring_timescale
-    endif
-
+  call get_param(param_file, mdl, "MEKE_EQUILIBRIUM_RESTORING", CS%MEKE_equilibrium_restoring, &
+                 "If true, restore MEKE back to its equilibrium value, which is calculated at"//&
+                 "each time step.", default=CS%MEKE_equilibrium_alt)
+  if (CS%MEKE_equilibrium_restoring) then
+    call get_param(param_file, mdl, "MEKE_RESTORING_TIMESCALE", MEKE_restoring_timescale, &
+                   "The timescale used to nudge MEKE toward its equilibrium value.", units="s", &
+                   default=1e6, scale=US%T_to_s)
+    CS%MEKE_restoring_rate = 1.0 / MEKE_restoring_timescale
   endif
+
   call get_param(param_file, mdl, "MEKE_FRCOEFF", CS%MEKE_FrCoeff, &
                  "The efficiency of the conversion of mean energy into "//&
                  "MEKE.  If MEKE_FRCOEFF is negative, this conversion "//&

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -1060,7 +1060,7 @@ logical function MEKE_init(Time, G, US, param_file, diag, CS, MEKE, restart_CS)
                  "initial value of MEKE.", default=.false.)
   call get_param(param_file, mdl, "MEKE_EQUILIBRIUM_RESTORING", CS%MEKE_equilibrium_restoring, &
                  "If true, restore MEKE back to its equilibrium value, which is calculated at"//&
-                 "each time step.", default=CS%MEKE_equilibrium_alt)
+                 "each time step.", default=.false.)
   if (CS%MEKE_equilibrium_restoring) then
     call get_param(param_file, mdl, "MEKE_RESTORING_TIMESCALE", MEKE_restoring_timescale, &
                    "The timescale used to nudge MEKE toward its equilibrium value.", units="s", &

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -201,7 +201,8 @@ subroutine thickness_diffuse(h, uhtr, vhtr, tv, dt, G, GV, US, MEKE, VarMix, CDp
 !$OMP parallel default(none) shared(is,ie,js,je,Khth_Loc_u,CS,use_VarMix,VarMix,    &
 !$OMP                               MEKE,Resoln_scaled,KH_u,G,use_QG_Leith,use_Visbeck,&
 !$OMP                               KH_u_CFL,nz,Khth_Loc,KH_v,KH_v_CFL,int_slope_u, &
-!$OMP                               int_slope_v,khth_use_ebt_struct)
+!$OMP                               int_slope_v,khth_use_ebt_struct, Depth_scaled, &
+!$OMP                               Khth_loc_v)
 !$OMP do
   do j=js,je; do I=is-1,ie
     Khth_loc_u(I,j) = CS%Khth

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -640,7 +640,12 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
 
   buoy_scale = US%L_to_m**2*US%s_to_T**3
 
-  !$OMP parallel do default(shared) firstprivate(nonLocalTrans)
+  !$OMP parallel do default(none) firstprivate(nonLocalTrans)                               &
+  !$OMP                           private(surfFricVel, iFaceHeight, hcorr, dh, cellHeight,  &
+  !$OMP                           surfBuoyFlux, Kdiffusivity, Kviscosity, LangEnhK, sigma,  &
+  !$OMP                           sigmaRatio)                                               &
+  !$OMP                           shared(G, GV, CS, US, uStar, h, buoy_scale, buoyFlux, Kt, &
+  !$OMP                           Ks, Kv, nonLocalTransHeat, nonLocalTransScalar, waves)
   ! loop over horizontal points on processor
   do j = G%jsc, G%jec
     do i = G%isc, G%iec
@@ -957,7 +962,16 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, EOS, uStar, buoyF
   buoy_scale = US%L_to_m**2*US%s_to_T**3
 
   ! loop over horizontal points on processor
-  !$OMP parallel do default(shared)
+  !$OMP parallel do default(none) private(surfFricVel, iFaceHeight, hcorr, dh, cellHeight,  &
+  !$OMP                           surfBuoyFlux, U_H, V_H, u, v, Coriolis, pRef, SLdepth_0d, &
+  !$OMP                           ksfc, surfHtemp, surfHsalt, surfHu, surfHv, surfHuS,      &
+  !$OMP                           surfHvS, hTot, delH, surftemp, surfsalt, surfu, surfv,    &
+  !$OMP                           surfUs, surfVs, Uk, Vk, deltaU2, km1, kk, pres_1D,        &
+  !$OMP                           Temp_1D, salt_1D, surfBuoyFlux2, MLD_GUESS, LA, rho_1D,   &
+  !$OMP                           deltarho, N2_1d, ws_1d, LangEnhVT2, enhvt2, wst,          &
+  !$OMP                           BulkRi_1d, zBottomMinusOffset) &
+  !$OMP                           shared(G, GV, CS, US, uStar, h, buoy_scale, buoyFlux,     &
+  !$OMP                           Temp, Salt, waves, EOS, GoRho)
   do j = G%jsc, G%jec
     do i = G%isc, G%iec
 
@@ -1463,7 +1477,7 @@ subroutine KPP_NonLocalTransport_temp(CS, G, GV, h, nonLocalTrans, surfFlux, &
 
 
   dtracer(:,:,:) = 0.0
-  !$OMP parallel do default(shared)
+  !$OMP parallel do default(none) shared(dtracer, nonLocalTrans, h, G, GV, surfFlux)
   do k = 1, G%ke
     do j = G%jsc, G%jec
       do i = G%isc, G%iec
@@ -1522,7 +1536,7 @@ subroutine KPP_NonLocalTransport_saln(CS, G, GV, h, nonLocalTrans, surfFlux, dt,
 
 
   dtracer(:,:,:) = 0.0
-  !$OMP parallel do default(shared)
+  !$OMP parallel do default(none) shared(dtracer, nonLocalTrans, h, G, GV, surfFlux)
   do k = 1, G%ke
     do j = G%jsc, G%jec
       do i = G%isc, G%iec


### PR DESCRIPTION
Fixes two main issues caught by the latest travis tests:
 - erroneous OpenMP directives in MOM_thickness_diffuse.F90 and MOM_CVMix_KPP.F90 
 - an unitialized logical variable in MOM_MEKE (```CS%MEKE_equilibrium_restoring```), which was causing undefined behavior resulting in different behaviors in symmetric vs non-symmetric builds.