### PR TITLE
Fix bugs caught by GNU compiler

### DIFF
--- a/config_src/mct_driver/ocn_comp_mct.F90
+++ b/config_src/mct_driver/ocn_comp_mct.F90
@@ -36,7 +36,7 @@ use MOM_error_handler,    only: MOM_error, FATAL, is_root_pe, WARNING
 use MOM_time_manager,     only: time_type, set_date, set_time, set_calendar_type, NOLEAP
 use MOM_time_manager,     only: operator(+), operator(-), operator(*), operator(/)
 use MOM_time_manager,     only: operator(==), operator(/=), operator(>), get_time
-use MOM_file_parser,      only: get_param, log_version, param_file_type
+use MOM_file_parser,      only: get_param, log_version, param_file_type, close_param_file
 use MOM_get_input,        only: Get_MOM_Input, directories
 use MOM_EOS,              only: gsw_sp_from_sr, gsw_pt_from_ct
 use MOM_constants,        only: CELSIUS_KELVIN_OFFSET
@@ -280,6 +280,9 @@ subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )
   else
     glb%c1 = 0.0; glb%c2 = 0.0; glb%c3 = 0.0; glb%c4 = 0.0
   endif
+
+  ! Close param file before it gets opened by ocean_model_init again.
+  call close_param_file(param_file)
 
   ! Initialize the MOM6 model
   runtype = get_runtype()

--- a/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_ddiff.F90
@@ -145,8 +145,11 @@ logical function CVMix_ddiff_init(Time, G, GV, US, param_file, diag, CS)
 
   CS%id_R_rho = register_diag_field('ocean_model','R_rho',diag%axesTi,Time, &
          'Double-diffusion density ratio', 'nondim')
-  if (CS%id_R_rho > 0) &
-     allocate(CS%R_rho( SZI_(G), SZJ_(G), SZK_(G)+1)); CS%R_rho(:,:,:) = 0.0
+
+  if (CS%id_R_rho > 0) then
+     allocate(CS%R_rho( SZI_(G), SZJ_(G), SZK_(G)+1))
+     CS%R_rho(:,:,:) = 0.0
+  endif
 
   call cvmix_init_ddiff(strat_param_max=CS%strat_param_max,          &
                         kappa_ddiff_s=CS%kappa_ddiff_s,           &


### PR DESCRIPTION
Fixes a couple of bugs caught by GNU in NCAR configuration:
- In MCT cap, param_file was being opened multiple times without getting closed.
- In ```MOM_CVMix_ddiff.F90```, the allocatable array ```CS%R_rho``` was being assigned even when it is not allocated. This PR also fixes that.