### PR TITLE
Improvements when applying lateral boundary diffusion

### DIFF
--- a/src/tracer/MOM_lateral_boundary_diffusion.F90
+++ b/src/tracer/MOM_lateral_boundary_diffusion.F90
@@ -23,8 +23,7 @@ use MOM_verticalGrid,          only : verticalGrid_type
 use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
 use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
 use MOM_diabatic_driver,       only : diabatic_CS, extract_diabatic_member
-
-use iso_fortran_env, only : stdout=>output_unit, stderr=>error_unit
+use iso_fortran_env,           only : stdout=>output_unit, stderr=>error_unit
 
 implicit none ; private
 
@@ -38,15 +37,18 @@ integer, public, parameter :: BOTTOM  = 1  !< Set a value that corresponds to th
 
 !> Sets parameters for lateral boundary mixing module.
 type, public :: lateral_boundary_diffusion_CS ; private
-  integer :: method                                               !< Determine which of the three methods calculate
-                                                                  !! and apply near boundary layer fluxes
-                                                                  !! 1. Bulk-layer approach
-                                                                  !! 2. Along layer
-  integer :: deg                                                  !< Degree of polynomial reconstruction
-  integer :: surface_boundary_scheme                              !< Which boundary layer scheme to use
-                                                                  !! 1. ePBL; 2. KPP
-  logical :: limiter                                              !< Controls wether a flux limiter is applied.
-                                                                  !! Only valid when method = 1.
+  integer :: method                          !< Determine which of the three methods calculate
+                                             !! and apply near boundary layer fluxes
+                                             !! 1. Bulk-layer approach
+                                             !! 2. Along layer
+  integer :: deg                             !< Degree of polynomial reconstruction
+  integer :: surface_boundary_scheme         !< Which boundary layer scheme to use
+                                             !! 1. ePBL; 2. KPP
+  logical :: limiter                         !< Controls wether a flux limiter is applied.
+                                             !! Only valid when method = 1.
+  logical :: linear                          !< If True, apply a linear transition at the base/top of the boundary.
+                                             !! The flux will be fully applied at k=k_min and zero at k=k_max.
+
   type(remapping_CS)              :: remap_CS                     !< Control structure to hold remapping configuration
   type(KPP_CS),           pointer :: KPP_CSp => NULL()            !< KPP control structure needed to get BLD
   type(energetic_PBL_CS), pointer :: energetic_PBL_CSp => NULL()  !< ePBL control structure needed to get BLD
@@ -110,6 +112,9 @@ logical function lateral_boundary_diffusion_init(Time, G, param_file, diag, diab
                    "If True, apply a flux limiter in the LBD. This is only available \n"//&
                    "when LATERAL_BOUNDARY_METHOD=1.", default=.false.)
   endif
+  call get_param(param_file, mdl, "LBD_LINEAR_TRANSITION", CS%linear, &
+                 "If True, apply a linear transition at the base/top of the boundary. \n"//&
+                 "The flux will be fully applied at k=k_min and zero at k=k_max.", default=.false.)
   call get_param(param_file, mdl, "LBD_BOUNDARY_EXTRAP", boundary_extrap, &
                  "Use boundary extrapolation in LBD code", &
                  default=.false.)
@@ -179,6 +184,7 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
       call build_reconstructions_1d( CS%remap_CS, G%ke, h(i,j,:), tracer%t(i,j,:), ppoly0_coefs(i,j,:,:), &
                                      ppoly0_E(i,j,:,:), ppoly_S, remap_method, GV%H_subroundoff, GV%H_subroundoff)
     enddo ; enddo
+
     ! Diffusive fluxes in the i-direction
     uFlx(:,:,:) = 0.
     vFlx(:,:,:) = 0.
@@ -193,7 +199,8 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
             call fluxes_bulk_method(SURFACE, GV%ke, CS%deg, h(I,j,:), h(I+1,j,:), hbl(I,j), hbl(I+1,j), &
               G%areaT(I,j), G%areaT(I+1,j), tracer%t(I,j,:), tracer%t(I+1,j,:),                         &
               ppoly0_coefs(I,j,:,:), ppoly0_coefs(I+1,j,:,:), ppoly0_E(I,j,:,:),                        &
-              ppoly0_E(I+1,j,:,:), remap_method, Coef_x(I,j), uFlx_bulk(I,j), uFlx(I,j,:), CS%limiter)
+              ppoly0_E(I+1,j,:,:), remap_method, Coef_x(I,j), uFlx_bulk(I,j), uFlx(I,j,:), CS%limiter,  &
+              CS%linear)
           endif
         enddo
       enddo
@@ -203,7 +210,8 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
             call fluxes_bulk_method(SURFACE, GV%ke, CS%deg, h(i,J,:), h(i,J+1,:), hbl(i,J), hbl(i,J+1), &
               G%areaT(i,J), G%areaT(i,J+1), tracer%t(i,J,:), tracer%t(i,J+1,:),                         &
               ppoly0_coefs(i,J,:,:), ppoly0_coefs(i,J+1,:,:), ppoly0_E(i,J,:,:),                        &
-              ppoly0_E(i,J+1,:,:), remap_method, Coef_y(i,J), vFlx_bulk(i,J), vFlx(i,J,:), CS%limiter)
+              ppoly0_E(i,J+1,:,:), remap_method, Coef_y(i,J), vFlx_bulk(i,J), vFlx(i,J,:), CS%limiter,  &
+              CS%linear)
           endif
         enddo
       enddo
@@ -216,18 +224,20 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
       do j=G%jsc,G%jec
         do i=G%isc-1,G%iec
           if (G%mask2dCu(I,j)>0.) then
-            call fluxes_layer_method(SURFACE, GV%ke, CS%deg, h(I,j,:), h(I+1,j,:), hbl(I,j), hbl(I+1,j), &
-              G%areaT(I,j), G%areaT(I+1,j), tracer%t(I,j,:), tracer%t(I+1,j,:), ppoly0_coefs(I,j,:,:), &
-              ppoly0_coefs(I+1,j,:,:), ppoly0_E(I,j,:,:), ppoly0_E(I+1,j,:,:), remap_method, Coef_x(I,j), uFlx(I,j,:))
+            call fluxes_layer_method(SURFACE, GV%ke, CS%deg, h(I,j,:), h(I+1,j,:), hbl(I,j), hbl(I+1,j),  &
+              G%areaT(I,j), G%areaT(I+1,j), tracer%t(I,j,:), tracer%t(I+1,j,:), ppoly0_coefs(I,j,:,:),    &
+              ppoly0_coefs(I+1,j,:,:), ppoly0_E(I,j,:,:), ppoly0_E(I+1,j,:,:), remap_method, Coef_x(I,j), &
+              uFlx(I,j,:), CS%linear)
           endif
         enddo
       enddo
       do J=G%jsc-1,G%jec
         do i=G%isc,G%iec
           if (G%mask2dCv(i,J)>0.) then
-            call fluxes_layer_method(SURFACE, GV%ke, CS%deg, h(i,J,:), h(i,J+1,:), hbl(i,J), hbl(i,J+1), &
-              G%areaT(i,J), G%areaT(i,J+1), tracer%t(i,J,:), tracer%t(i,J+1,:), ppoly0_coefs(i,J,:,:), &
-              ppoly0_coefs(i,J+1,:,:), ppoly0_E(i,J,:,:), ppoly0_E(i,J+1,:,:), remap_method, Coef_y(i,J), vFlx(i,J,:))
+            call fluxes_layer_method(SURFACE, GV%ke, CS%deg, h(i,J,:), h(i,J+1,:), hbl(i,J), hbl(i,J+1),  &
+              G%areaT(i,J), G%areaT(i,J+1), tracer%t(i,J,:), tracer%t(i,J+1,:), ppoly0_coefs(i,J,:,:),    &
+              ppoly0_coefs(i,J+1,:,:), ppoly0_E(i,J,:,:), ppoly0_E(i,J+1,:,:), remap_method, Coef_y(i,J), &
+              vFlx(i,J,:), CS%linear)
           endif
         enddo
       enddo
@@ -298,26 +308,26 @@ end subroutine lateral_boundary_diffusion
 !< Calculate bulk layer value of a scalar quantity as the thickness weighted average
 real function bulk_average(boundary, nk, deg, h, hBLT, phi, ppoly0_E, ppoly0_coefs, method, k_top, zeta_top, k_bot, &
                            zeta_bot)
-  integer             :: boundary          !< SURFACE or BOTTOM                                         [nondim]
-  integer             :: nk                !< Number of layers                                          [nondim]
-  integer             :: deg               !< Degree of polynomial                                      [nondim]
-  real, dimension(nk) :: h                 !< Layer thicknesses                               [H ~> m or kg m-2]
-  real                :: hBLT              !< Depth of the boundary layer                     [H ~> m or kg m-2]
+  integer             :: boundary          !< SURFACE or BOTTOM                                     [nondim]
+  integer             :: nk                !< Number of layers                                      [nondim]
+  integer             :: deg               !< Degree of polynomial                                  [nondim]
+  real, dimension(nk) :: h                 !< Layer thicknesses                                     [H ~> m or kg m-2]
+  real                :: hBLT              !< Depth of the boundary layer                           [H ~> m or kg m-2]
   real, dimension(nk) :: phi               !< Scalar quantity
-  real, dimension(nk,2)     :: ppoly0_E     !< Edge value of polynomial
-  real, dimension(nk,deg+1) :: ppoly0_coefs !< Coefficients of polynomial
-  integer                   :: method       !< Remapping scheme to use
+  real, dimension(nk,2)    :: ppoly0_E(:,:)      !< Edge value of polynomial
+  real, dimension(nk,deg+1) :: ppoly0_coefs(:,:) !< Coefficients of polynomial
+  integer                   :: method            !< Remapping scheme to use
 
   integer             :: k_top             !< Index of the first layer within the boundary
   real                :: zeta_top          !< Fraction of the layer encompassed by the bottom boundary layer
                                            !! (0 if none, 1. if all). For the surface, this is always 0. because
-                                           !! integration starts at the surface                         [nondim]
+                                           !! integration starts at the surface                     [nondim]
   integer             :: k_bot             !< Index of the last layer within the boundary
   real                :: zeta_bot          !< Fraction of the layer encompassed by the surface boundary layer
                                            !! (0 if none, 1. if all). For the bottom boundary layer, this is always 1.
-                                           !! because integration starts at the bottom                  [nondim]
+                                           !! because integration starts at the bottom              [nondim]
   ! Local variables
-  real    :: htot !< Running sum of the thicknesses (top to bottom) [H ~> m or kg m-2]
+  real    :: htot !< Running sum of the thicknesses (top to bottom)
   integer :: k    !< k indice
 
 
@@ -428,43 +438,48 @@ end subroutine boundary_k_range
 !> Calculate the lateral boundary diffusive fluxes using the layer by layer method.
 !! See \ref section_method2
 subroutine fluxes_layer_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L, area_R, phi_L, phi_R, &
-                              ppoly0_coefs_L, ppoly0_coefs_R, ppoly0_E_L, ppoly0_E_R, method, khtr_u, F_layer)
+                              ppoly0_coefs_L, ppoly0_coefs_R, ppoly0_E_L, ppoly0_E_R, method, khtr_u, &
+                              F_layer, linear_decay)
 
   integer,                   intent(in   )       :: boundary !< Which boundary layer SURFACE or BOTTOM  [nondim]
   integer,                   intent(in   )       :: nk       !< Number of layers                        [nondim]
   integer,                   intent(in   )       :: deg      !< order of the polynomial reconstruction  [nondim]
-  real, dimension(nk),       intent(in   )       :: h_L      !< Layer thickness (left)        [H ~> m or kg m-2]
-  real, dimension(nk),       intent(in   )       :: h_R      !< Layer thickness (right)       [H ~> m or kg m-2]
+  real, dimension(nk),       intent(in   )       :: h_L      !< Layer thickness (left)              [H ~> m or kg m-2]
+  real, dimension(nk),       intent(in   )       :: h_R      !< Layer thickness (right)             [H ~> m or kg m-2]
   real,                      intent(in   )       :: hbl_L    !< Thickness of the boundary boundary
-                                                                       !! layer (left)        [H ~> m or kg m-2]
+                                                                       !! layer (left)              [H ~> m or kg m-2]
   real,                      intent(in   )       :: hbl_R    !< Thickness of the boundary boundary
-                                                             !! layer (right)                 [H ~> m or kg m-2]
-  real,                      intent(in   )       :: area_L   !< Area of the horizontal grid (left)    [L2 ~> m2]
-  real,                      intent(in   )       :: area_R   !< Area of the horizontal grid (right)   [L2 ~> m2]
-  real, dimension(nk),       intent(in   )       :: phi_L    !< Tracer values (left)                    [conc]
-  real, dimension(nk),       intent(in   )       :: phi_R    !< Tracer values (right)                   [conc]
-  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_L !< Tracer reconstruction (left)      [conc]
-  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_R !< Tracer reconstruction (right)     [conc]
-  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_L !< Polynomial edge values (left)         [ nondim ]
-  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_R !< Polynomial edge values (right)        [ nondim ]
-  integer,                   intent(in   )       :: method   !< Method of polynomial integration        [ nondim ]
+                                                             !! layer (right)                       [H ~> m or kg m-2]
+  real,                      intent(in   )       :: area_L   !< Area of the horizontal grid (left)  [L2 ~> m2]
+  real,                      intent(in   )       :: area_R   !< Area of the horizontal grid (right) [L2 ~> m2]
+  real, dimension(nk),       intent(in   )       :: phi_L    !< Tracer values (left)                [conc]
+  real, dimension(nk),       intent(in   )       :: phi_R    !< Tracer values (right)               [conc]
+  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_L !< Tracer reconstruction (left)  [conc]
+  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_R !< Tracer reconstruction (right) [conc]
+  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_L !< Polynomial edge values (left)     [nondim]
+  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_R !< Polynomial edge values (right)    [nondim]
+  integer,                   intent(in   )       :: method   !< Method of polynomial integration    [nondim]
   real,                      intent(in   )       :: khtr_u   !< Horizontal diffusivities times delta t
                                                              !! at a velocity point [L2 ~> m2]
   real, dimension(nk),       intent(  out)       :: F_layer  !< Layerwise diffusive flux at U- or V-point
                                                              !! [H L2 conc ~> m3 conc]
-
+  logical, optional,         intent(in   )       :: linear_decay !< If True, apply a linear transition at the base of
+                                                             !! the boundary layer
   ! Local variables
-  real, dimension(nk) :: h_means              !< Calculate the layer-wise harmonic means      [H ~> m or kg m-2]
-  real                :: khtr_avg             !< Thickness-weighted diffusivity at the u-point        [m^2 s^-1]
+  real, dimension(nk) :: h_means              !< Calculate the layer-wise harmonic means           [H ~> m or kg m-2]
+  real                :: khtr_avg             !< Thickness-weighted diffusivity at the u-point     [m^2 s^-1]
                                               !! This is just to remind developers that khtr_avg should be
                                               !! computed once khtr is 3D.
   real                :: heff                 !< Harmonic mean of layer thicknesses           [H ~> m or kg m-2]
   real                :: inv_heff             !< Inverse of the harmonic mean of layer thicknesses
                                               !!  [H-1 ~> m-1 or m2 kg-1]
   real                :: phi_L_avg, phi_R_avg !< Bulk, thickness-weighted tracer averages (left and right column)
-                                              !!                                                    [conc m^-3 ]
+                                              !!                                                   [conc m^-3 ]
   real    :: htot                      !< Total column thickness [H ~> m or kg m-2]
-  integer :: k, k_bot_min, k_top_max   !< k-indices, min and max for top and bottom, respectively
+  real    :: heff_tot                  !< Total effective column thickness in the transition layer [m]
+  integer :: k, k_bot_min, k_top_max   !< k-indices, min and max for bottom and top, respectively
+  integer :: k_bot_max, k_top_min      !< k-indices, max and min for bottom and top, respectively
+  integer :: k_bot_diff, k_top_diff    !< different between left and right k-indices for bottom and top, respectively
   integer :: k_top_L, k_bot_L          !< k-indices left
   integer :: k_top_R, k_bot_R          !< k-indices right
   real    :: zeta_top_L, zeta_top_R    !< distance from the top of a layer to the boundary
@@ -472,11 +487,19 @@ subroutine fluxes_layer_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L
   real    :: zeta_bot_L, zeta_bot_R    !< distance from the bottom of a layer to the boundary
                                        !!layer depth                                      [nondim]
   real    :: h_work_L, h_work_R  !< dummy variables
-  real    :: hbl_min             !< minimum BLD (left and right)                                   [m]
+  real    :: hbl_min             !< minimum BLD (left and right)                          [m]
+  real    :: wgt                 !< weight to be used in the linear transition to the interior [nondim]
+  real    :: a                   !< coefficient to be used in the linear transition to the interior [nondim]
+  logical :: linear              !< True if apply a linear transition
 
   F_layer(:) = 0.0
   if (hbl_L == 0. .or. hbl_R == 0.) then
     return
+  endif
+
+  linear = .false.
+  if (PRESENT(linear_decay)) then
+    linear = linear_decay
   endif
 
   ! Calculate vertical indices containing the boundary layer
@@ -485,6 +508,9 @@ subroutine fluxes_layer_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L
 
   if (boundary == SURFACE) then
     k_bot_min = MIN(k_bot_L, k_bot_R)
+    k_bot_max = MAX(k_bot_L, k_bot_R)
+    k_bot_diff = (k_bot_max - k_bot_min)
+
     ! make sure left and right k indices span same range
     if (k_bot_min .ne. k_bot_L) then
       k_bot_L = k_bot_min
@@ -503,15 +529,37 @@ subroutine fluxes_layer_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L
     heff = harmonic_mean(h_work_L, h_work_R)
     ! tracer flux where the minimum BLD intersets layer
     ! GMM, khtr_avg should be computed once khtr is 3D
-    F_layer(k_bot_min) = -(heff * khtr_u) * (phi_R_avg - phi_L_avg)
+    if ((linear) .and. (k_bot_diff .gt. 1)) then
+      ! apply linear decay at the base of hbl
+      do k = k_bot_min,1,-1
+        heff = harmonic_mean(h_L(k), h_R(k))
+        F_layer(k) = -(heff * khtr_u) * (phi_R(k) - phi_L(k))
+      enddo
+      ! heff_total
+      heff_tot = 0.0
+      do k = k_bot_min+1,k_bot_max, 1
+        heff_tot = heff_tot + harmonic_mean(h_L(k), h_R(k))
+      enddo
 
-    do k = k_bot_min-1,1,-1
-      heff = harmonic_mean(h_L(k), h_R(k))
-      F_layer(k) = -(heff * khtr_u) * (phi_R(k) - phi_L(k))
-    enddo
+      a = -1.0/heff_tot
+      heff_tot = 0.0
+      do k = k_bot_min+1,k_bot_max, 1
+        heff = harmonic_mean(h_L(k), h_R(k))
+        wgt = (a*(heff_tot + (heff * 0.5))) + 1.0
+        F_layer(k) = -(heff * khtr_u) * (phi_R(k) - phi_L(k)) * wgt
+        heff_tot = heff_tot + heff
+      enddo
+    else
+      F_layer(k_bot_min) = -(heff * khtr_u) * (phi_R_avg - phi_L_avg)
+      do k = k_bot_min-1,1,-1
+        heff = harmonic_mean(h_L(k), h_R(k))
+        F_layer(k) = -(heff * khtr_u) * (phi_R(k) - phi_L(k))
+      enddo
+    endif
   endif
 
   if (boundary == BOTTOM) then
+    ! TODO: GMM add option to apply linear decay
     k_top_max = MAX(k_top_L, k_top_R)
     ! make sure left and right k indices span same range
     if (k_top_max .ne. k_top_L) then
@@ -544,26 +592,27 @@ end subroutine fluxes_layer_method
 !> Apply the lateral boundary diffusive fluxes calculated from a 'bulk model'
 !! See \ref section_method1
 subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L, area_R, phi_L, phi_R, ppoly0_coefs_L, &
-                                   ppoly0_coefs_R, ppoly0_E_L, ppoly0_E_R, method, khtr_u, F_bulk, F_layer, F_limit)
+                              ppoly0_coefs_R, ppoly0_E_L, ppoly0_E_R, method, khtr_u, F_bulk, F_layer, F_limit, &
+                              linear_decay)
 
   integer,                   intent(in   )       :: boundary !< Which boundary layer SURFACE or BOTTOM  [nondim]
   integer,                   intent(in   )       :: nk       !< Number of layers                        [nondim]
   integer,                   intent(in   )       :: deg      !< order of the polynomial reconstruction  [nondim]
-  real, dimension(nk),       intent(in   )       :: h_L      !< Layer thickness (left)          [H ~> m or kg m-2]
-  real, dimension(nk),       intent(in   )       :: h_R      !< Layer thickness (right)         [H ~> m or kg m-2]
+  real, dimension(nk),       intent(in   )       :: h_L      !< Layer thickness (left)              [H ~> m or kg m-2]
+  real, dimension(nk),       intent(in   )       :: h_R      !< Layer thickness (right)             [H ~> m or kg m-2]
   real,                      intent(in   )       :: hbl_L    !< Thickness of the boundary boundary
-                                                                       !! layer (left)          [H ~> m or kg m-2]
+                                                                       !! layer (left)              [H ~> m or kg m-2]
   real,                      intent(in   )       :: hbl_R    !< Thickness of the boundary boundary
-                                                             !! layer (left)                    [H ~> m or kg m-2]
-  real,                      intent(in   )       :: area_L   !< Area of the horizontal grid (left)      [L2 ~> m2]
-  real,                      intent(in   )       :: area_R   !< Area of the horizontal grid (right)     [L2 ~> m2]
-  real, dimension(nk),       intent(in   )       :: phi_L    !< Tracer values (left)                    [conc]
-  real, dimension(nk),       intent(in   )       :: phi_R    !< Tracer values (right)                   [conc]
-  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_L !< Tracer reconstruction (left)      [conc]
-  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_R !< Tracer reconstruction (right)     [conc]
-  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_L !< Polynomial edge values (left)         [nondim]
-  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_R !< Polynomial edge values (right)        [nondim]
-  integer,                   intent(in   )       :: method   !< Method of polynomial integration        [nondim]
+                                                             !! layer (left)                        [H ~> m or kg m-2]
+  real,                      intent(in   )       :: area_L   !< Area of the horizontal grid (left)  [L2 ~> m2]
+  real,                      intent(in   )       :: area_R   !< Area of the horizontal grid (right) [L2 ~> m2]
+  real, dimension(nk),       intent(in   )       :: phi_L    !< Tracer values (left)                [conc]
+  real, dimension(nk),       intent(in   )       :: phi_R    !< Tracer values (right)               [conc]
+  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_L !< Tracer reconstruction (left)  [conc]
+  real, dimension(nk,deg+1), intent(in   )       :: ppoly0_coefs_R !< Tracer reconstruction (right) [conc]
+  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_L !< Polynomial edge values (left)     [nondim]
+  real, dimension(nk,2),     intent(in   )       :: ppoly0_E_R !< Polynomial edge values (right)    [nondim]
+  integer,                   intent(in   )       :: method   !< Method of polynomial integration    [nondim]
   real,                      intent(in   )       :: khtr_u   !< Horizontal diffusivities times delta t
                                                              !! at a velocity point [L2 ~> m2]
   real,                      intent(  out)       :: F_bulk   !< The bulk mixed layer lateral flux
@@ -571,6 +620,8 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
   real, dimension(nk),       intent(  out)       :: F_layer  !< Layerwise diffusive flux at U- or V-point
                                                              !! [H L2 conc ~> m3 conc]
   logical, optional,         intent(in   )       :: F_limit  !< If True, apply a limiter
+  logical, optional,         intent(in   )       :: linear_decay !< If True, apply a linear transition at the base of
+                                                             !! the boundary layer
 
   ! Local variables
   real, dimension(nk) :: h_means              !< Calculate the layer-wise harmonic means           [H ~> m or kg m-2]
@@ -578,12 +629,14 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
                                               !! This is just to remind developers that khtr_avg should be
                                               !! computed once khtr is 3D.
   real                :: heff                 !< Harmonic mean of layer thicknesses                [H ~> m or kg m-2]
+  real                :: heff_tot             !< Total effective column thickness in the transition layer [m]
   real                :: inv_heff             !< Inverse of the harmonic mean of layer thicknesses
                                               !! [H-1 ~> m-1 or m2 kg-1]
   real                :: phi_L_avg, phi_R_avg !< Bulk, thickness-weighted tracer averages (left and right column)
                                               !!                                                   [conc m^-3 ]
-  real    :: htot                             !< Total column thickness [H ~> m or kg m-2]
+  real    :: htot                             ! Total column thickness [H ~> m or kg m-2]
   integer :: k, k_min, k_max                  !< k-indices, min and max for top and bottom, respectively
+  integer :: k_diff                           !< difference between k_max and k_min
   integer :: k_top_L, k_bot_L                 !< k-indices left
   integer :: k_top_R, k_bot_R                 !< k-indices right
   real    :: zeta_top_L, zeta_top_R           !< distance from the top of a layer to the
@@ -594,18 +647,27 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
   real    :: F_max                            !< The maximum amount of flux that can leave a
                                               !! cell  [m^3 conc]
   logical :: limiter                          !< True if flux limiter should be applied
+  logical :: linear                           !< True if apply a linear transition
   real    :: hfrac                            !< Layer fraction wrt sum of all layers [nondim]
   real    :: dphi                             !< tracer gradient                      [conc m^-3]
+  real    :: wgt                              !< weight to be used in the linear transition to the
+                                              !! interior [nondim]
+  real    :: a                                !< coefficient to be used in the linear transition to the
+                                              !! interior [nondim]
 
+  F_bulk = 0.
+  F_layer(:) = 0.
   if (hbl_L == 0. .or. hbl_R == 0.) then
-    F_bulk = 0.
-    F_layer(:) = 0.
     return
   endif
 
   limiter = .false.
   if (PRESENT(F_limit)) then
     limiter = F_limit
+  endif
+  linear = .false.
+  if (PRESENT(linear_decay)) then
+    linear = linear_decay
   endif
 
   ! Calculate vertical indices containing the boundary layer
@@ -617,7 +679,6 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
                             zeta_top_L, k_bot_L, zeta_bot_L)
   phi_R_avg  = bulk_average(boundary, nk, deg, h_R, hbl_R, phi_R, ppoly0_E_R, ppoly0_coefs_R, method, k_top_R, &
                             zeta_top_R, k_bot_R, zeta_bot_R)
-
   ! Calculate the 'bulk' diffusive flux from the bulk averaged quantities
   ! GMM, khtr_avg should be computed once khtr is 3D
   heff = harmonic_mean(hbl_L, hbl_R)
@@ -625,31 +686,53 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
   ! Calculate the layerwise sum of the vertical effective thickness. This is different than the heff calculated
   ! above, but is used as a way to decompose the fluxes onto the individual layers
   h_means(:) = 0.
-
   if (boundary == SURFACE) then
     k_min = MIN(k_bot_L, k_bot_R)
+    k_max = MAX(k_bot_L, k_bot_R)
+    k_diff = (k_max - k_min)
+    if ((linear) .and. (k_diff .gt. 1)) then
+      do k=1,k_min
+        h_means(k) = harmonic_mean(h_L(k),h_R(k))
+      enddo
+      ! heff_total
+      heff_tot = 0.0
+      do k = k_min+1,k_max, 1
+        heff_tot = heff_tot + harmonic_mean(h_L(k), h_R(k))
+      enddo
 
-    ! left hand side
-    if (k_bot_L == k_min) then
-      h_work_L = h_L(k_min) * zeta_bot_L
+      a = -1.0/heff_tot
+      heff_tot = 0.0
+      ! fluxes will decay linearly at base of hbl
+      do k = k_min+1,k_max, 1
+        heff = harmonic_mean(h_L(k), h_R(k))
+        wgt = (a*(heff_tot + (heff * 0.5))) + 1.0
+        h_means(k) = harmonic_mean(h_L(k), h_R(k)) * wgt
+        heff_tot = heff_tot + heff
+      enddo
     else
-      h_work_L = h_L(k_min)
+      ! left hand side
+      if (k_bot_L == k_min) then
+        h_work_L = h_L(k_min) * zeta_bot_L
+      else
+        h_work_L = h_L(k_min)
+      endif
+
+      ! right hand side
+      if (k_bot_R == k_min) then
+        h_work_R = h_R(k_min) * zeta_bot_R
+      else
+        h_work_R = h_R(k_min)
+      endif
+
+      h_means(k_min) = harmonic_mean(h_work_L,h_work_R)
+
+      do k=1,k_min-1
+        h_means(k) = harmonic_mean(h_L(k),h_R(k))
+      enddo
     endif
-
-    ! right hand side
-    if (k_bot_R == k_min) then
-      h_work_R = h_R(k_min) * zeta_bot_R
-    else
-      h_work_R = h_R(k_min)
-    endif
-
-    h_means(k_min) = harmonic_mean(h_work_L,h_work_R)
-
-    do k=1,k_min-1
-      h_means(k) = harmonic_mean(h_L(k),h_R(k))
-    enddo
 
   elseif (boundary == BOTTOM) then
+    !TODO, GMM linear decay is not implemented here
     k_max = MAX(k_top_L, k_top_R)
     ! left hand side
     if (k_top_L == k_max) then
@@ -672,14 +755,14 @@ subroutine fluxes_bulk_method(boundary, nk, deg, h_L, h_R, hbl_L, hbl_R, area_L,
     enddo
   endif
 
-  if ( SUM(h_means) == 0. ) then
+  if ( SUM(h_means) == 0. .or. F_bulk == 0.) then
     return
- ! Decompose the bulk flux onto the individual layers
+  ! Decompose the bulk flux onto the individual layers
   else
     ! Initialize remaining thickness
     inv_heff = 1./SUM(h_means)
     do k=1,nk
-      if (h_means(k) > 0.) then
+      if ((h_means(k) > 0.) .and. (phi_L(k) /= phi_R(k))) then
         hfrac = h_means(k)*inv_heff
         F_layer(k) = F_bulk * hfrac
 
@@ -1035,10 +1118,6 @@ logical function test_layer_fluxes(verbose, nk, test_name, F_calc, F_ans)
       test_layer_fluxes = .true.
       write(stdunit,*) "MOM_lateral_boundary_diffusion, UNIT TEST FAILED: ", test_name
       write(stdunit,10) k, F_calc(k), F_ans(k)
-      ! ### Once these unit tests are passing, and failures are caught properly,
-      ! we will post failure notifications to both stdout and stderr.
-      !write(stderr,*) "MOM_lateral_boundary_diffusion, UNIT TEST FAILED: ", test_name
-      !write(stderr,10) k, F_calc(k), F_ans(k)
     elseif (verbose) then
       write(stdunit,10) k, F_calc(k), F_ans(k)
     endif

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -461,7 +461,7 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, CS, p_surf)
                 CS%Pint(i,j,:), CS%Tint(i,j,:), CS%Sint(i,j,:), CS%dRdT(i,j,:), CS%dRdS(i,j,:),            &
                 CS%Pint(i+1,j,:), CS%Tint(i+1,j,:), CS%Sint(i+1,j,:), CS%dRdT(i+1,j,:), CS%dRdS(i+1,j,:),  &
                 CS%uPoL(I,j,:), CS%uPoR(I,j,:), CS%uKoL(I,j,:), CS%uKoR(I,j,:), CS%uhEff(I,j,:),           &
-                k_bot(I,j), k_bot(I+1,j), 1.-zeta_bot(I,j), 1.-zeta_bot(I+1,j))
+                k_bot(I,j), k_bot(I+1,j), zeta_bot(I,j), zeta_bot(I+1,j))
       else
         call find_neutral_surface_positions_discontinuous(CS, G%ke, &
             CS%P_i(i,j,:,:), h(i,j,:), CS%T_i(i,j,:,:), CS%S_i(i,j,:,:), CS%ppoly_coeffs_T(i,j,:,:),           &
@@ -482,7 +482,7 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, CS, p_surf)
                 CS%Pint(i,j,:), CS%Tint(i,j,:), CS%Sint(i,j,:), CS%dRdT(i,j,:), CS%dRdS(i,j,:),           &
                 CS%Pint(i,j+1,:), CS%Tint(i,j+1,:), CS%Sint(i,j+1,:), CS%dRdT(i,j+1,:), CS%dRdS(i,j+1,:), &
                 CS%vPoL(i,J,:), CS%vPoR(i,J,:), CS%vKoL(i,J,:), CS%vKoR(i,J,:), CS%vhEff(i,J,:), &
-                k_bot(i,J), k_bot(i,J+1), 1.-zeta_bot(i,J), 1.-zeta_bot(i,J+1))
+                k_bot(i,J), k_bot(i,J+1), zeta_bot(i,J), zeta_bot(i,J+1))
       else
         call find_neutral_surface_positions_discontinuous(CS, G%ke, &
             CS%P_i(i,j,:,:), h(i,j,:), CS%T_i(i,j,:,:), CS%S_i(i,j,:,:), CS%ppoly_coeffs_T(i,j,:,:),           &

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -312,7 +312,7 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, CS, p_surf)
   pa_to_H = 1. / (GV%H_to_RZ * GV%g_Earth)
 
   k_top(:,:) = 1     ; k_bot(:,:) = 1
-  zeta_top(:,:) = 0. ; zeta_bot(:,:) = 1.
+  zeta_top(:,:) = 0. ; zeta_bot(:,:) = 0.
 
   ! Check if hbl needs to be extracted
   if (CS%interior_only) then


### PR DESCRIPTION
Summary:

* Fix a bug when applying neutral diffusion only in the ocean interior
* Add option to apply a linear decay at the base of the surface boundary layer

This PR does not change answers since we currently have USE_LATERAL_BOUNDARY_DIFFUSION = False.
