### PR TITLE
Introduce a controllable stdout unit in MOM_io

### DIFF
--- a/config_src/mct_driver/mom_ocean_model_mct.F90
+++ b/config_src/mct_driver/mom_ocean_model_mct.F90
@@ -56,7 +56,7 @@ use coupler_types_mod,        only : coupler_type_initialized, coupler_type_copy
 use coupler_types_mod,        only : coupler_type_set_diags, coupler_type_send_data
 use mpp_domains_mod,          only : domain2d, mpp_get_layout, mpp_get_global_domain
 use mpp_domains_mod,          only : mpp_define_domains, mpp_get_compute_domain, mpp_get_data_domain
-use fms_mod,                  only : stdout
+use MOM_io,                   only : stdout
 use mpp_mod,                  only : mpp_chksum
 use MOM_EOS,                  only : gsw_sp_from_sr, gsw_pt_from_ct
 use MOM_wave_interface,       only : wave_parameters_CS, MOM_wave_interface_init
@@ -409,10 +409,6 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
 
   call close_param_file(param_file)
   call diag_mediator_close_registration(OS%diag)
-
-  if (is_root_pe()) &
-    write(*,'(/12x,a/)') '======== COMPLETED MOM INITIALIZATION ========'
-
   call callTree_leave("ocean_model_init(")
 end subroutine ocean_model_init
 
@@ -1053,20 +1049,18 @@ subroutine ocean_public_type_chksum(id, timestep, ocn)
   integer,                 intent(in) :: timestep !< The number of elapsed timesteps
   type(ocean_public_type), intent(in) :: ocn !< A structure containing various publicly
                                              !! visible ocean surface fields.
-  integer :: n, m, outunit
+  integer :: n, m
 
-  outunit = stdout()
+  write(stdout,*) "BEGIN CHECKSUM(ocean_type):: ", id, timestep
+  write(stdout,100) 'ocean%t_surf   ',mpp_chksum(ocn%t_surf )
+  write(stdout,100) 'ocean%s_surf   ',mpp_chksum(ocn%s_surf )
+  write(stdout,100) 'ocean%u_surf   ',mpp_chksum(ocn%u_surf )
+  write(stdout,100) 'ocean%v_surf   ',mpp_chksum(ocn%v_surf )
+  write(stdout,100) 'ocean%sea_lev  ',mpp_chksum(ocn%sea_lev)
+  write(stdout,100) 'ocean%frazil   ',mpp_chksum(ocn%frazil )
+  write(stdout,100) 'ocean%melt_potential  ',mpp_chksum(ocn%melt_potential)
 
-  write(outunit,*) "BEGIN CHECKSUM(ocean_type):: ", id, timestep
-  write(outunit,100) 'ocean%t_surf   ',mpp_chksum(ocn%t_surf )
-  write(outunit,100) 'ocean%s_surf   ',mpp_chksum(ocn%s_surf )
-  write(outunit,100) 'ocean%u_surf   ',mpp_chksum(ocn%u_surf )
-  write(outunit,100) 'ocean%v_surf   ',mpp_chksum(ocn%v_surf )
-  write(outunit,100) 'ocean%sea_lev  ',mpp_chksum(ocn%sea_lev)
-  write(outunit,100) 'ocean%frazil   ',mpp_chksum(ocn%frazil )
-  write(outunit,100) 'ocean%melt_potential  ',mpp_chksum(ocn%melt_potential)
-
-  call coupler_type_write_chksums(ocn%fields, outunit, 'ocean%')
+  call coupler_type_write_chksums(ocn%fields, stdout, 'ocean%')
 100 FORMAT("   CHECKSUM::",A20," = ",Z20)
 
 end subroutine ocean_public_type_chksum

--- a/config_src/mct_driver/mom_surface_forcing_mct.F90
+++ b/config_src/mct_driver/mom_surface_forcing_mct.F90
@@ -34,10 +34,10 @@ use coupler_types_mod,    only : coupler_2d_bc_type, coupler_type_write_chksums
 use coupler_types_mod,    only : coupler_type_initialized, coupler_type_spawn
 use coupler_types_mod,    only : coupler_type_copy_data
 use data_override_mod,    only : data_override_init, data_override
-use fms_mod,              only : stdout
 use mpp_mod,              only : mpp_chksum
 use time_interp_external_mod, only : init_external_field, time_interp_external
 use time_interp_external_mod, only : time_interp_external_init
+use MOM_io,               only: stdout
 
 implicit none ; private
 
@@ -1361,37 +1361,35 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
                                          !! ocean in a coupled model whose checksums are reported
 
   ! local variables
-  integer ::   n,m, outunit
+  integer ::   n,m
 
-  outunit = stdout()
-
-  write(outunit,*) "BEGIN CHECKSUM(ice_ocean_boundary_type):: ", id, timestep
-  write(outunit,100) 'iobt%u_flux         '   , mpp_chksum( iobt%u_flux         )
-  write(outunit,100) 'iobt%v_flux         '   , mpp_chksum( iobt%v_flux         )
-  write(outunit,100) 'iobt%t_flux         '   , mpp_chksum( iobt%t_flux         )
-  write(outunit,100) 'iobt%q_flux         '   , mpp_chksum( iobt%q_flux         )
-  write(outunit,100) 'iobt%salt_flux      '   , mpp_chksum( iobt%salt_flux      )
-  write(outunit,100) 'iobt%seaice_melt_heat'  , mpp_chksum( iobt%seaice_melt_heat)
-  write(outunit,100) 'iobt%seaice_melt    '   , mpp_chksum( iobt%seaice_melt    )
-  write(outunit,100) 'iobt%lw_flux        '   , mpp_chksum( iobt%lw_flux        )
-  write(outunit,100) 'iobt%sw_flux_vis_dir'   , mpp_chksum( iobt%sw_flux_vis_dir)
-  write(outunit,100) 'iobt%sw_flux_vis_dif'   , mpp_chksum( iobt%sw_flux_vis_dif)
-  write(outunit,100) 'iobt%sw_flux_nir_dir'   , mpp_chksum( iobt%sw_flux_nir_dir)
-  write(outunit,100) 'iobt%sw_flux_nir_dif'   , mpp_chksum( iobt%sw_flux_nir_dif)
-  write(outunit,100) 'iobt%lprec          '   , mpp_chksum( iobt%lprec          )
-  write(outunit,100) 'iobt%fprec          '   , mpp_chksum( iobt%fprec          )
-  write(outunit,100) 'iobt%runoff         '   , mpp_chksum( iobt%runoff         )
-  write(outunit,100) 'iobt%calving        '   , mpp_chksum( iobt%calving        )
-  write(outunit,100) 'iobt%p              '   , mpp_chksum( iobt%p              )
+  write(stdout,*) "BEGIN CHECKSUM(ice_ocean_boundary_type):: ", id, timestep
+  write(stdout,100) 'iobt%u_flux         '   , mpp_chksum( iobt%u_flux         )
+  write(stdout,100) 'iobt%v_flux         '   , mpp_chksum( iobt%v_flux         )
+  write(stdout,100) 'iobt%t_flux         '   , mpp_chksum( iobt%t_flux         )
+  write(stdout,100) 'iobt%q_flux         '   , mpp_chksum( iobt%q_flux         )
+  write(stdout,100) 'iobt%salt_flux      '   , mpp_chksum( iobt%salt_flux      )
+  write(stdout,100) 'iobt%seaice_melt_heat'  , mpp_chksum( iobt%seaice_melt_heat)
+  write(stdout,100) 'iobt%seaice_melt    '   , mpp_chksum( iobt%seaice_melt    )
+  write(stdout,100) 'iobt%lw_flux        '   , mpp_chksum( iobt%lw_flux        )
+  write(stdout,100) 'iobt%sw_flux_vis_dir'   , mpp_chksum( iobt%sw_flux_vis_dir)
+  write(stdout,100) 'iobt%sw_flux_vis_dif'   , mpp_chksum( iobt%sw_flux_vis_dif)
+  write(stdout,100) 'iobt%sw_flux_nir_dir'   , mpp_chksum( iobt%sw_flux_nir_dir)
+  write(stdout,100) 'iobt%sw_flux_nir_dif'   , mpp_chksum( iobt%sw_flux_nir_dif)
+  write(stdout,100) 'iobt%lprec          '   , mpp_chksum( iobt%lprec          )
+  write(stdout,100) 'iobt%fprec          '   , mpp_chksum( iobt%fprec          )
+  write(stdout,100) 'iobt%runoff         '   , mpp_chksum( iobt%runoff         )
+  write(stdout,100) 'iobt%calving        '   , mpp_chksum( iobt%calving        )
+  write(stdout,100) 'iobt%p              '   , mpp_chksum( iobt%p              )
   if (associated(iobt%ustar_berg)) &
-    write(outunit,100) 'iobt%ustar_berg     ' , mpp_chksum( iobt%ustar_berg )
+    write(stdout,100) 'iobt%ustar_berg     ' , mpp_chksum( iobt%ustar_berg )
   if (associated(iobt%area_berg)) &
-    write(outunit,100) 'iobt%area_berg      ' , mpp_chksum( iobt%area_berg  )
+    write(stdout,100) 'iobt%area_berg      ' , mpp_chksum( iobt%area_berg  )
   if (associated(iobt%mass_berg)) &
-    write(outunit,100) 'iobt%mass_berg      ' , mpp_chksum( iobt%mass_berg  )
+    write(stdout,100) 'iobt%mass_berg      ' , mpp_chksum( iobt%mass_berg  )
 100 FORMAT("   CHECKSUM::",A20," = ",Z20)
 
-  call coupler_type_write_chksums(iobt%fluxes, outunit, 'iobt%')
+  call coupler_type_write_chksums(iobt%fluxes, stdout, 'iobt%')
 
 end subroutine ice_ocn_bnd_type_chksum
 

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -13,8 +13,7 @@ use PCM_functions, only : PCM_reconstruction
 use PLM_functions, only : PLM_reconstruction, PLM_boundary_extrapolation
 use PPM_functions, only : PPM_reconstruction, PPM_boundary_extrapolation
 use PQM_functions, only : PQM_reconstruction, PQM_boundary_extrapolation_v1
-
-use iso_fortran_env, only : stdout=>output_unit, stderr=>error_unit
+use MOM_io, only : stdout, stderr
 
 implicit none ; private
 
@@ -1636,7 +1635,7 @@ logical function remapping_unit_tests(verbose)
   h_neglect = hNeglect_dflt
   h_neglect_edge = hNeglect_dflt ; if (answers_2018) h_neglect_edge = 1.0e-10
 
-  write(*,*) '==== MOM_remapping: remapping_unit_tests ================='
+  write(stdout,*) '==== MOM_remapping: remapping_unit_tests ================='
   remapping_unit_tests = .false. ! Normally return false
 
   thisTest = .false.
@@ -1645,19 +1644,19 @@ logical function remapping_unit_tests(verbose)
     err=x0(i)-0.75*real(i-1)
     if (abs(err)>real(i-1)*epsilon(err)) thisTest = .true.
   enddo
-  if (thisTest) write(*,*) 'remapping_unit_tests: Failed buildGridFromH() 1'
+  if (thisTest) write(stdout,*) 'remapping_unit_tests: Failed buildGridFromH() 1'
   remapping_unit_tests = remapping_unit_tests .or. thisTest
   call buildGridFromH(n1, h1, x1)
   do i=1,n1+1
     err=x1(i)-real(i-1)
     if (abs(err)>real(i-1)*epsilon(err)) thisTest = .true.
   enddo
-  if (thisTest) write(*,*) 'remapping_unit_tests: Failed buildGridFromH() 2'
+  if (thisTest) write(stdout,*) 'remapping_unit_tests: Failed buildGridFromH() 2'
   remapping_unit_tests = remapping_unit_tests .or. thisTest
 
   thisTest = .false.
   call initialize_remapping(CS, 'PPM_H4', answers_2018=answers_2018)
-  if (verbose) write(*,*) 'h0 (test data)'
+  if (verbose) write(stdout,*) 'h0 (test data)'
   if (verbose) call dumpGrid(n0,h0,x0,u0)
 
   call dzFromH1H2( n0, h0, n1, h1, dx1 )
@@ -1666,9 +1665,9 @@ logical function remapping_unit_tests(verbose)
     err=u1(i)-8.*(0.5*real(1+n1)-real(i))
     if (abs(err)>real(n1-1)*epsilon(err)) thisTest = .true.
   enddo
-  if (verbose) write(*,*) 'h1 (by projection)'
+  if (verbose) write(stdout,*) 'h1 (by projection)'
   if (verbose) call dumpGrid(n1,h1,x1,u1)
-  if (thisTest) write(*,*) 'remapping_unit_tests: Failed remapping_core_w()'
+  if (thisTest) write(stdout,*) 'remapping_unit_tests: Failed remapping_core_w()'
   remapping_unit_tests = remapping_unit_tests .or. thisTest
 
   thisTest = .false.
@@ -1690,7 +1689,7 @@ logical function remapping_unit_tests(verbose)
     err=u1(i)-8.*(0.5*real(1+n1)-real(i))
     if (abs(err)>2.*epsilon(err)) thisTest = .true.
   enddo
-  if (thisTest) write(*,*) 'remapping_unit_tests: Failed remapByProjection()'
+  if (thisTest) write(stdout,*) 'remapping_unit_tests: Failed remapByProjection()'
   remapping_unit_tests = remapping_unit_tests .or. thisTest
 
   thisTest = .false.
@@ -1698,14 +1697,14 @@ logical function remapping_unit_tests(verbose)
   call remapByDeltaZ( n0, h0, u0, ppoly0_E, ppoly0_coefs, &
                       n1, x1-x0(1:n1+1), &
                       INTEGRATION_PPM, u1, hn1, h_neglect )
-  if (verbose) write(*,*) 'h1 (by delta)'
+  if (verbose) write(stdout,*) 'h1 (by delta)'
   if (verbose) call dumpGrid(n1,h1,x1,u1)
   hn1=hn1-h1
   do i=1,n1
     err=u1(i)-8.*(0.5*real(1+n1)-real(i))
     if (abs(err)>2.*epsilon(err)) thisTest = .true.
   enddo
-  if (thisTest) write(*,*) 'remapping_unit_tests: Failed remapByDeltaZ() 1'
+  if (thisTest) write(stdout,*) 'remapping_unit_tests: Failed remapByDeltaZ() 1'
   remapping_unit_tests = remapping_unit_tests .or. thisTest
 
   thisTest = .false.
@@ -1715,19 +1714,19 @@ logical function remapping_unit_tests(verbose)
   call remapByDeltaZ( n0, h0, u0, ppoly0_E, ppoly0_coefs, &
                       n2, dx2, &
                       INTEGRATION_PPM, u2, hn2, h_neglect )
-  if (verbose) write(*,*) 'h2'
+  if (verbose) write(stdout,*) 'h2'
   if (verbose) call dumpGrid(n2,h2,x2,u2)
-  if (verbose) write(*,*) 'hn2'
+  if (verbose) write(stdout,*) 'hn2'
   if (verbose) call dumpGrid(n2,hn2,x2,u2)
 
   do i=1,n2
     err=u2(i)-8./2.*(0.5*real(1+n2)-real(i))
     if (abs(err)>2.*epsilon(err)) thisTest = .true.
   enddo
-  if (thisTest) write(*,*) 'remapping_unit_tests: Failed remapByDeltaZ() 2'
+  if (thisTest) write(stdout,*) 'remapping_unit_tests: Failed remapByDeltaZ() 2'
   remapping_unit_tests = remapping_unit_tests .or. thisTest
 
-  if (verbose) write(*,*) 'Via sub-cells'
+  if (verbose) write(stdout,*) 'Via sub-cells'
   thisTest = .false.
   call remap_via_sub_cells( n0, h0, u0, ppoly0_E, ppoly0_coefs, &
                             n2, h2, INTEGRATION_PPM, .false., u2, err )
@@ -1737,7 +1736,7 @@ logical function remapping_unit_tests(verbose)
     err=u2(i)-8./2.*(0.5*real(1+n2)-real(i))
     if (abs(err)>2.*epsilon(err)) thisTest = .true.
   enddo
-  if (thisTest) write(*,*) 'remapping_unit_tests: Failed remap_via_sub_cells() 2'
+  if (thisTest) write(stdout,*) 'remapping_unit_tests: Failed remap_via_sub_cells() 2'
   remapping_unit_tests = remapping_unit_tests .or. thisTest
 
   call remap_via_sub_cells( n0, h0, u0, ppoly0_E, ppoly0_coefs, &
@@ -1748,9 +1747,9 @@ logical function remapping_unit_tests(verbose)
                             3, (/2.25,1.5,1./), INTEGRATION_PPM, .false., u2, err )
   if (verbose) call dumpGrid(3,h2,x2,u2)
 
-  if (.not. remapping_unit_tests) write(*,*) 'Pass'
+  if (.not. remapping_unit_tests) write(stdout,*) 'Pass'
 
-  write(*,*) '===== MOM_remapping: new remapping_unit_tests =================='
+  write(stdout,*) '===== MOM_remapping: new remapping_unit_tests =================='
 
   deallocate(ppoly0_E, ppoly0_S, ppoly0_coefs)
   allocate(ppoly0_coefs(5,6))
@@ -1879,7 +1878,7 @@ logical function remapping_unit_tests(verbose)
 
   deallocate(ppoly0_E, ppoly0_S, ppoly0_coefs)
 
-  if (.not. remapping_unit_tests) write(*,*) 'Pass'
+  if (.not. remapping_unit_tests) write(stdout,*) 'Pass'
 
 end function remapping_unit_tests
 

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -12,7 +12,7 @@ use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing
 use MOM_grid, only : ocean_grid_type
 use MOM_interface_heights, only : find_eta
-use MOM_io, only : create_file, fieldtype, flush_file, open_file, reopen_file
+use MOM_io, only : create_file, fieldtype, flush_file, open_file, reopen_file, stdout
 use MOM_io, only : file_exists, slasher, vardesc, var_desc, write_field, get_filename_appendix
 use MOM_io, only : APPEND_FILE, ASCII_FILE, SINGLE_FILE, WRITEONLY_FILE
 use MOM_open_boundary, only : ocean_OBC_type, OBC_segment_type
@@ -827,11 +827,11 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, OBC, dt_
 
   if (is_root_pe()) then
     if (CS%use_temperature) then
-        write(*,'(A," ",A,": En ",ES12.6, ", MaxCFL ", F8.5, ", Mass ", &
+        write(stdout,'(A," ",A,": En ",ES12.6, ", MaxCFL ", F8.5, ", Mass ", &
                 & ES18.12, ", Salt ", F15.11,", Temp ", F15.11)') &
           trim(date_str), trim(n_str), En_mass, max_CFL(1), mass_tot, salin, temp
     else
-        write(*,'(A," ",A,": En ",ES12.6, ", MaxCFL ", F8.5, ", Mass ", &
+        write(stdout,'(A," ",A,": En ",ES12.6, ", MaxCFL ", F8.5, ", Mass ", &
                 & ES18.12)') &
           trim(date_str), trim(n_str), En_mass, max_CFL(1), mass_tot
     endif
@@ -853,39 +853,39 @@ subroutine write_energy(u, v, h, tv, day, n, G, GV, US, CS, tracer_CSp, OBC, dt_
     endif
 
     if (CS%ntrunc > 0) then
-      write(*,'(A," Energy/Mass:",ES12.5," Truncations ",I0)') &
+      write(stdout,'(A," Energy/Mass:",ES12.5," Truncations ",I0)') &
         trim(date_str), En_mass, CS%ntrunc
     endif
 
     if (CS%write_stocks) then
-      write(*,'("    Total Energy: ",Z16.16,ES24.16)') toten, toten
-      write(*,'("    Total Mass: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5," (",ES8.1,")")') &
+      write(stdout,'("    Total Energy: ",Z16.16,ES24.16)') toten, toten
+      write(stdout,'("    Total Mass: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5," (",ES8.1,")")') &
             mass_tot, mass_chg, mass_anom, mass_anom/mass_tot
       if (CS%use_temperature) then
         if (Salt == 0.) then
-          write(*,'("    Total Salt: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5)') &
+          write(stdout,'("    Total Salt: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5)') &
               Salt*0.001, Salt_chg*0.001, Salt_anom*0.001
         else
-          write(*,'("    Total Salt: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5," (",ES8.1,")")') &
+          write(stdout,'("    Total Salt: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5," (",ES8.1,")")') &
               Salt*0.001, Salt_chg*0.001, Salt_anom*0.001, Salt_anom/Salt
         endif
         if (Heat == 0.) then
-          write(*,'("    Total Heat: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5)') &
+          write(stdout,'("    Total Heat: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5)') &
               Heat, Heat_chg, Heat_anom
         else
-          write(*,'("    Total Heat: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5," (",ES8.1,")")') &
+          write(stdout,'("    Total Heat: ",ES24.16,", Change: ",ES24.16," Error: ",ES12.5," (",ES8.1,")")') &
               Heat, Heat_chg, Heat_anom, Heat_anom/Heat
         endif
       endif
       do m=1,nTr_stocks
 
-         write(*,'("      Total ",a,": ",ES24.16,X,a)') &
+         write(stdout,'("      Total ",a,": ",ES24.16,X,a)') &
               trim(Tr_names(m)), Tr_stocks(m), trim(Tr_units(m))
 
          if (Tr_minmax_got(m)) then
-           write(*,'(64X,"Global Min:",ES24.16,X,"at: (", f7.2,","f7.2,","f8.2,")"  )') &
+           write(stdout,'(64X,"Global Min:",ES24.16,X,"at: (", f7.2,","f7.2,","f8.2,")"  )') &
                 Tr_min(m),Tr_min_x(m),Tr_min_y(m),Tr_min_z(m)
-           write(*,'(64X,"Global Max:",ES24.16,X,"at: (", f7.2,","f7.2,","f8.2,")"  )') &
+           write(stdout,'(64X,"Global Max:",ES24.16,X,"at: (", f7.2,","f7.2,","f8.2,")"  )') &
                 Tr_max(m),Tr_max_x(m),Tr_max_y(m),Tr_max_z(m)
         endif
 

--- a/src/framework/MOM_diag_vkernels.F90
+++ b/src/framework/MOM_diag_vkernels.F90
@@ -4,7 +4,7 @@ module MOM_diag_vkernels
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
-use iso_fortran_env, only : stdout=>output_unit, stderr=>error_unit
+use MOM_io, only : stdout, stderr
 
 implicit none ; private
 

--- a/src/framework/MOM_io.F90
+++ b/src/framework/MOM_io.F90
@@ -33,6 +33,7 @@ use mpp_io_mod,           only : get_file_info=>mpp_get_info, get_file_atts=>mpp
 use mpp_io_mod,           only : get_file_fields=>mpp_get_fields, get_file_times=>mpp_get_times
 use mpp_io_mod,           only : io_infra_init=>mpp_io_init
 
+use iso_fortran_env,      only : stdout_iso=>output_unit, stderr_iso=>error_unit
 use netcdf
 
 implicit none ; private
@@ -83,6 +84,9 @@ interface MOM_read_vector
   module procedure MOM_read_vector_3d
   module procedure MOM_read_vector_2d
 end interface
+
+integer, public :: stdout = stdout_iso  !< standard output unit
+integer, public :: stderr = stderr_iso  !< standard output unit
 
 contains
 

--- a/src/framework/MOM_random.F90
+++ b/src/framework/MOM_random.F90
@@ -11,7 +11,7 @@ use MersenneTwister_mod, only : new_RandomNumberSequence ! Constructor/initializ
 use MersenneTwister_mod, only : getRandomReal ! Generates a random number
 use MersenneTwister_mod, only : getRandomPositiveInt ! Generates a random positive integer
 
-use iso_fortran_env, only : stdout=>output_unit, stderr=>error_unit
+use MOM_io, only : stdout, stderr
 
 implicit none ; private
 

--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -14,7 +14,7 @@ use MOM_dyn_horgrid, only : dyn_horgrid_type, set_derived_dyn_horgrid
 use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
-use MOM_io, only : MOM_read_data, read_data, slasher, file_exists
+use MOM_io, only : MOM_read_data, read_data, slasher, file_exists, stdout
 use MOM_io, only : CORNER, NORTH_FACE, EAST_FACE
 use MOM_unit_scaling, only : unit_scale_type
 
@@ -806,14 +806,14 @@ subroutine set_grid_metrics_mercator(G, param_file, US)
     y_q = find_root(Int_dj_dy, dy_dj, GP, jd, 0.0, -1.0*PI_2, PI_2, itt2)
     G%gridLatB(J) = y_q*180.0/PI
     ! if (is_root_pe()) &
-    !   write(*, '("J, y_q = ",I4,ES14.4," itts = ",I4)')  j, y_q, itt2
+    !   write(stdout, '("J, y_q = ",I4,ES14.4," itts = ",I4)')  j, y_q, itt2
   enddo
   do j=G%jsg,G%jeg
     jd = fnRef + (j - jRef) - 0.5
     y_h = find_root(Int_dj_dy, dy_dj, GP, jd, 0.0, -1.0*PI_2, PI_2, itt1)
     G%gridLatT(j) = y_h*180.0/PI
     ! if (is_root_pe()) &
-    !   write(*, '("j, y_h = ",I4,ES14.4," itts = ",I4)')  j, y_h, itt1
+    !   write(stdout, '("j, y_h = ",I4,ES14.4," itts = ",I4)')  j, y_h, itt1
   enddo
   do J=JsdB+J_off,JedB+J_off
     jd = fnRef + (J - jRef)

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -11,7 +11,7 @@ use MOM_dyn_horgrid, only : dyn_horgrid_type
 use MOM_error_handler, only : MOM_mesg, MOM_error, FATAL, WARNING, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave, callTree_waypoint
 use MOM_file_parser, only : get_param, log_param, param_file_type, log_version
-use MOM_io, only : close_file, create_file, fieldtype, file_exists
+use MOM_io, only : close_file, create_file, fieldtype, file_exists, stdout
 use MOM_io, only : MOM_read_data, MOM_read_vector, SINGLE_FILE, MULTIPLE
 use MOM_io, only : slasher, vardesc, write_field, var_desc
 use MOM_string_functions, only : uppercase
@@ -282,7 +282,7 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
     j = jg(n) - G%jsd_global + 2
     if (i>=G%isc .and. i<=G%iec .and. j>=G%jsc .and. j<=G%jec) then
       if (new_depth(n)/=0.) then
-        write(*,'(a,3i5,f8.2,a,f8.2,2i4)') &
+        write(stdout,'(a,3i5,f8.2,a,f8.2,2i4)') &
           'Ocean topography edit: ',n,ig(n),jg(n),D(i,j)/m_to_Z,'->',abs(new_depth(n)),i,j
         D(i,j) = abs(m_to_Z*new_depth(n)) ! Allows for height-file edits (i.e. converts negatives)
       else
@@ -995,10 +995,10 @@ subroutine reset_face_lengths_list(G, param_file, US)
         G%dy_Cu(I,j) = G%mask2dCu(I,j) * m_to_L*min(L_to_m*G%dyCu(I,j), max(u_width(npt), 0.0))
         if (j>=G%jsc .and. j<=G%jec .and. I>=G%isc .and. I<=G%iec) then ! Limit messages/checking to compute domain
           if ( G%mask2dCu(I,j) == 0.0 )  then
-            write(*,'(A,2F8.2,A,4F8.2,A)') "read_face_lengths_list : G%mask2dCu=0 at ",lat,lon," (",&
+            write(stdout,'(A,2F8.2,A,4F8.2,A)') "read_face_lengths_list : G%mask2dCu=0 at ",lat,lon," (",&
                 u_lat(1,npt), u_lat(2,npt), u_lon(1,npt), u_lon(2,npt),") so grid metric is unmodified."
           else
-            write(*,'(A,2F8.2,A,4F8.2,A5,F9.2,A1)') &
+            write(stdout,'(A,2F8.2,A,4F8.2,A5,F9.2,A1)') &
                   "read_face_lengths_list : Modifying dy_Cu gridpoint at ",lat,lon," (",&
                   u_lat(1,npt), u_lat(2,npt), u_lon(1,npt), u_lon(2,npt),") to ",L_to_m*G%dy_Cu(I,j),"m"
           endif
@@ -1024,10 +1024,10 @@ subroutine reset_face_lengths_list(G, param_file, US)
         G%dx_Cv(i,J) = G%mask2dCv(i,J) * m_to_L*min(L_to_m*G%dxCv(i,J), max(v_width(npt), 0.0))
         if (i>=G%isc .and. i<=G%iec .and. J>=G%jsc .and. J<=G%jec) then ! Limit messages/checking to compute domain
           if ( G%mask2dCv(i,J) == 0.0 )  then
-            write(*,'(A,2F8.2,A,4F8.2,A)') "read_face_lengths_list : G%mask2dCv=0 at ",lat,lon," (",&
+            write(stdout,'(A,2F8.2,A,4F8.2,A)') "read_face_lengths_list : G%mask2dCv=0 at ",lat,lon," (",&
                   v_lat(1,npt), v_lat(2,npt), v_lon(1,npt), v_lon(2,npt),") so grid metric is unmodified."
           else
-            write(*,'(A,2F8.2,A,4F8.2,A5,F9.2,A1)') &
+            write(stdout,'(A,2F8.2,A,4F8.2,A5,F9.2,A1)') &
                   "read_face_lengths_list : Modifying dx_Cv gridpoint at ",lat,lon," (",&
                   v_lat(1,npt), v_lat(2,npt), v_lon(1,npt), v_lon(2,npt),") to ",L_to_m*G%dx_Cv(I,j),"m"
           endif

--- a/src/tracer/MOM_lateral_boundary_diffusion.F90
+++ b/src/tracer/MOM_lateral_boundary_diffusion.F90
@@ -23,7 +23,7 @@ use MOM_verticalGrid,          only : verticalGrid_type
 use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
 use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
 use MOM_diabatic_driver,       only : diabatic_CS, extract_diabatic_member
-use iso_fortran_env,           only : stdout=>output_unit, stderr=>error_unit
+use MOM_io,                    only : stdout, stderr
 
 implicit none ; private
 
@@ -1111,16 +1111,15 @@ logical function test_layer_fluxes(verbose, nk, test_name, F_calc, F_ans)
   real, dimension(nk),        intent(in) :: F_ans     !< Fluxes of the unitless tracer calculated by hand [s^-1]
   ! Local variables
   integer :: k
-  integer, parameter :: stdunit = stdout
 
   test_layer_fluxes = .false.
   do k=1,nk
     if ( F_calc(k) /= F_ans(k) ) then
       test_layer_fluxes = .true.
-      write(stdunit,*) "MOM_lateral_boundary_diffusion, UNIT TEST FAILED: ", test_name
-      write(stdunit,10) k, F_calc(k), F_ans(k)
+      write(stdout,*) "MOM_lateral_boundary_diffusion, UNIT TEST FAILED: ", test_name
+      write(stdout,10) k, F_calc(k), F_ans(k)
     elseif (verbose) then
-      write(stdunit,10) k, F_calc(k), F_ans(k)
+      write(stdout,10) k, F_calc(k), F_ans(k)
     endif
   enddo
 
@@ -1141,19 +1140,17 @@ logical function test_boundary_k_range(k_top, zeta_top, k_bot, zeta_bot, k_top_a
   character(len=80) :: test_name !< Name of the unit test
   logical :: verbose             !< If true always print output
 
-  integer, parameter :: stdunit = stdout
-
   test_boundary_k_range = k_top .ne. k_top_ans
   test_boundary_k_range = test_boundary_k_range .or. (zeta_top .ne. zeta_top_ans)
   test_boundary_k_range = test_boundary_k_range .or. (k_bot .ne. k_bot_ans)
   test_boundary_k_range = test_boundary_k_range .or. (zeta_bot .ne. zeta_bot_ans)
 
-  if (test_boundary_k_range) write(stdunit,*) "UNIT TEST FAILED: ", test_name
+  if (test_boundary_k_range) write(stdout,*) "UNIT TEST FAILED: ", test_name
   if (test_boundary_k_range .or. verbose) then
-    write(stdunit,20) "k_top", k_top, "k_top_ans", k_top_ans
-    write(stdunit,20) "k_bot", k_bot, "k_bot_ans", k_bot_ans
-    write(stdunit,30) "zeta_top", zeta_top, "zeta_top_ans", zeta_top_ans
-    write(stdunit,30) "zeta_bot", zeta_bot, "zeta_bot_ans", zeta_bot_ans
+    write(stdout,20) "k_top", k_top, "k_top_ans", k_top_ans
+    write(stdout,20) "k_bot", k_bot, "k_bot_ans", k_bot_ans
+    write(stdout,30) "zeta_top", zeta_top, "zeta_top_ans", zeta_top_ans
+    write(stdout,30) "zeta_bot", zeta_bot, "zeta_bot_ans", zeta_bot_ans
   endif
 
   20 format(A,"=",i3,X,A,"=",i3)

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -28,8 +28,7 @@ use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
 use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
 use MOM_diabatic_driver,       only : diabatic_CS, extract_diabatic_member
 use MOM_lateral_boundary_diffusion, only : boundary_k_range, SURFACE, BOTTOM
-
-use iso_fortran_env, only : stdout=>output_unit, stderr=>error_unit
+use MOM_io,                    only : stdout, stderr
 
 implicit none ; private
 


### PR DESCRIPTION
This PR adds two public integers, `stdout` and `stderr`, in MOM_io module to be used in write statements throughout the MOM6 source code. Changes:

- In MOM_io module, add two public module data, `stdout` and `stderr`, of type integer. Module data are not allowed in MOM6. In this case, however, adding a module data was deemed the best option at a MOM6 dev call, and is therefore an exception. By default, `stdout` and `stderr` are set to values from `iso_fortran_env`, which may be overridden as done in MCT cap.
- In MCT cap, set stdout to the value assigned by the CESM driver.
- Replace all instances of `write(*` with `write(stdout`
- Replace all instances of iso_fortran_env::stdout with MOM_io::stdout.

testing: aux_mom/cheyenne intel & gnu