### PR TITLE
Make long character variables deferred length

### DIFF
--- a/src/framework/MOM_document.F90
+++ b/src/framework/MOM_document.F90
@@ -661,7 +661,7 @@ end function real_string
 !> Returns a character string of a comma-separated, compact formatted, reals
 !> e.g. "1., 2., 5*3., 5.E2", that give the list of values.
 function real_array_string(vals, sep)
-  character(len=1320)    :: real_array_string !< The output string listing vals
+  character(len=:) ,allocatable :: real_array_string !< The output string listing vals
   real,      intent(in)  :: vals(:) !< The array of values to record
   character(len=*), &
     optional, intent(in) :: sep     !< The separator between successive values,
@@ -669,10 +669,10 @@ function real_array_string(vals, sep)
 ! Returns a character string of a comma-separated, compact formatted, reals
 ! e.g. "1., 2., 5*3., 5.E2"
   ! Local variables
-  integer :: j, n, b, ns
+  integer :: j, n, ns
   logical :: doWrite
   character(len=10) :: separator
-  n=1 ; doWrite=.true. ; real_array_string='' ; b=1
+  n=1 ; doWrite=.true. ; real_array_string=''
   if (present(sep)) then
     separator=sep ; ns=len(sep)
   else
@@ -687,16 +687,15 @@ function real_array_string(vals, sep)
       endif
     endif
     if (doWrite) then
-      if (b>1) then ! Write separator if a number has already been written
-        write(real_array_string(b:),'(A)') separator
-        b=b+ns
+      if(len(real_array_string)>0) then ! Write separator if a number has already been written
+        real_array_string = real_array_string // separator(1:ns)
       endif
       if (n>1) then
-        write(real_array_string(b:),'(A,"*",A)') trim(int_string(n)),trim(real_string(vals(j)))
+        real_array_string = real_array_string // trim(int_string(n)) // "*" // trim(real_string(vals(j)))
       else
-        write(real_array_string(b:),'(A)') trim(real_string(vals(j)))
+        real_array_string = real_array_string // trim(real_string(vals(j)))
       endif
-      n=1 ; b=len_trim(real_array_string)+1
+      n=1
     endif
   enddo
 end function real_array_string

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -1406,14 +1406,13 @@ subroutine log_param_real_array(CS, modulename, varname, value, desc, &
   logical,          optional, intent(in) :: like_default !< If present and true, log this parameter as
                                          !! though it has the default value, even if there is no default.
 
-  character(len=1320) :: mesg
+  character(len=:), allocatable :: mesg
   character(len=240) :: myunits
 
  !write(mesg, '("  ",a," ",a,": ",ES19.12,99(",",ES19.12))') &
  !write(mesg, '("  ",a," ",a,": ",G,99(",",G))') &
  !  trim(modulename), trim(varname), value
-  write(mesg, '("  ",a," ",a,": ",a)') &
-    trim(modulename), trim(varname), trim(left_reals(value))
+  mesg = "  " // trim(modulename) // " " // trim(varname) // ": " // trim(left_reals(value))
   if (is_root_pe()) then
     if (CS%log_open) write(CS%stdlog,'(a)') trim(mesg)
     if (CS%log_to_stdout) write(CS%stdout,'(a)') trim(mesg)

--- a/src/framework/MOM_string_functions.F90
+++ b/src/framework/MOM_string_functions.F90
@@ -142,13 +142,13 @@ function left_reals(r,sep)
   real, intent(in) :: r(:) !< The array of real variables to convert to a string
   character(len=*), optional, intent(in) :: sep !< The separator between
                                     !! successive values, by default it is ', '.
-  character(len=1320) :: left_reals !< The output string
+  character(len=:), allocatable :: left_reals !< The output string
 
-  integer :: j, n, b, ns
+  integer :: j, n, ns
   logical :: doWrite
   character(len=10) :: separator
 
-  n=1 ; doWrite=.true. ; left_reals='' ; b=1
+  n=1 ; doWrite=.true. ; left_reals=''
   if (present(sep)) then
     separator=sep ; ns=len(sep)
   else
@@ -163,16 +163,15 @@ function left_reals(r,sep)
       endif
     endif
     if (doWrite) then
-      if (b>1) then ! Write separator if a number has already been written
-        write(left_reals(b:),'(A)') separator
-        b=b+ns
+      if (len(left_reals)>0) then ! Write separator if a number has already been written
+        left_reals = left_reals // separator(1:ns)
       endif
       if (n>1) then
-        write(left_reals(b:),'(A,"*",A)') trim(left_int(n)),trim(left_real(r(j)))
+        left_reals = left_reals // trim(left_int(n)) // "*" // trim(left_real(r(j)))
       else
-        write(left_reals(b:),'(A)') trim(left_real(r(j)))
+        left_reals = left_reals // trim(left_real(r(j)))
       endif
-      n=1 ; b=len_trim(left_reals)+1
+      n=1
     endif
   enddo
 end function left_reals


### PR DESCRIPTION
When using large number of vertical layers (84),  some of the framework string functions suffer from character length overflow. While the traditional solution in MOM6 has been to increase the hardcoded character lengths, this PR implements a more sustainable solution: deferred character lengths for the variables prone to overflow. 

Testing: aux_mom.cheyenne_intel and gmom.e22.GJRAv3.TL319_t061_hycom1_N84