### PR TITLE
Added a counter-based PRNG to MOM_random

### DIFF
--- a/src/framework/MOM_random.F90
+++ b/src/framework/MOM_random.F90
@@ -51,8 +51,9 @@ end function random_01
 !! See https://arxiv.org/abs/2004.06278. Not an exact reproduction of "squares" because Fortran
 !! doesn't have a uint64 type, and not all compilers provide integers with > 64 bits...
 real function random_01_CB(ctr, key)
-  integer, parameter   :: int64 = selected_int_kind(10) ! Integer with >= 64 bits
-  integer, intent(in)  :: ctr, key ! counter & key inputs, standard integer kind
+  use iso_fortran_env, only : int64
+  integer, intent(in)  :: ctr !< ctr should be incremented each time you call the function
+  integer, intent(in)  :: key !< key is like a seed: use a different key for each random stream
   integer(kind=int64) :: x, y, z ! Follows "Squares" naming convention
 
   x = (ctr + 1) * (key + 65536) ! 65536 added because keys below that don't work.

--- a/src/framework/MOM_random.F90
+++ b/src/framework/MOM_random.F90
@@ -17,6 +17,7 @@ implicit none ; private
 
 public :: random_0d_constructor
 public :: random_01
+public :: random_01_CB
 public :: random_norm
 public :: random_2d_constructor
 public :: random_2d_01
@@ -45,6 +46,28 @@ real function random_01(CS)
   random_01 = getRandomReal(CS%stream0d)
 
 end function random_01
+
+!> Returns a random number between 0 and 1
+!! See https://arxiv.org/abs/2004.06278. Not an exact reproduction of "squares" because Fortran
+!! doesn't have a uint64 type, and not all compilers provide integers with > 64 bits...
+real function random_01_CB(ctr, key)
+  integer, parameter   :: int64 = selected_int_kind(10) ! Integer with >= 64 bits
+  integer, intent(in)  :: ctr, key ! counter & key inputs, standard integer kind
+  integer(kind=int64) :: x, y, z ! Follows "Squares" naming convention
+
+  x = (ctr + 1) * (key + 65536) ! 65536 added because keys below that don't work.
+  y = (ctr + 1) * (key + 65536)
+  z = y + (key + 65536)
+  x = x*x + y
+  x = ior(ishft(x,32),ishft(x,-32))
+  x = x*x + z
+  x = ior(ishft(x,32),ishft(x,-32))
+  x = x*x + y
+  x = ior(ishft(x,32),ishft(x,-32))
+  x = x*x + z
+  random_01_CB = .5*(1. + .5*real(int(ishft(x,-32)))/real(2**30))
+
+end function
 
 !> Returns an approximately normally distributed random number with mean 0 and variance 1
 real function random_norm(CS)


### PR DESCRIPTION
The current MOM6 random number generator is based on the Mersenne twister (MT), which is sub-optimal in many ways. A single MT requires about 2.5kB of memory, and you need one for each independent random number stream (e.g. one per horizontal grid cell). You also need to initialize the MT. Rather than save the internal state of the MT, users have resorted to changing the seed manually every time the MT is called, but this is not the way the MT was designed to be used.

Counter-based pseudo-random number generators (CB-PRNGs) have no internal state, so they are easy to restart exactly, do not need to be initialized, and have a small memory footprint. With CB-PRNGs a single random number stream is defined by its key, and the random number stream is generated by calling the CB-PRNG with a sequence of integers (a counter) as an argument. There is no need to initialize, and you can exactly restart the sequence of random numbers at any point using only the key and the counter.

The CB-PRNG implemented here is from an algorithm called "Squares"; see https://arxiv.org/abs/2004.06278. The version here is not an exact reproduction of "Squares" because Fortran doesn't have a uint64 type. An exact reproduction is possible using integers with > 64 bits, but not all Fortran compilers provide integers with > 64 bits (I'm looking at you, ifort)...