### PR TITLE
Adds mask2dT checker to avoid calling boundary_k_range at land points

### DIFF
--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -320,7 +320,9 @@ subroutine neutral_diffusion_calc_coeffs(G, GV, US, h, T, S, CS, p_surf)
     call pass_var(hbl,G%Domain)
     ! get k-indices and zeta
     do j=G%jsc-1, G%jec+1 ; do i=G%isc-1,G%iec+1
-      call boundary_k_range(SURFACE, G%ke, h(i,j,:), hbl(i,j), k_top(i,j), zeta_top(i,j), k_bot(i,j), zeta_bot(i,j))
+      if (G%mask2dT(i,j) > 0.) then
+        call boundary_k_range(SURFACE, G%ke, h(i,j,:), hbl(i,j), k_top(i,j), zeta_top(i,j), k_bot(i,j), zeta_bot(i,j))
+      endif
     enddo; enddo
     ! TODO: add similar code for BOTTOM boundary layer
   endif


### PR DESCRIPTION
One of the aux_mom tests (SMS_D_Vnuopc.T62_t061.GMOM_IAF.cheyenne_intel) was failing with following message:
![image](https://user-images.githubusercontent.com/11339137/103954992-9108f580-5102-11eb-8c69-d2c7a48b4c14.png)

After running the same test with MCT instead of NUOPC, @alperaltuntas was able to identify that MOM6 was failing because of a missing `mask2dT` checker when calling `boundary_k_range` in the neutral diffusion module. This patch adds the missing cheker and now the test is passing again.

It is surprising that  the error messages shown above were not helpful to solve this issue, especially since DEBUG=True in the above test. Perhaps something needs to be changed in NUOPC, since the same test with MCT gave more meaningful error messages. @mvertens, any thoughts?

