### PR TITLE
Remove an omp parallel do directive due to thread-unsafe cpu_clock

### DIFF
--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -391,8 +391,6 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   ! set surface diffusivities (CS%bkgnd_mixing_csp%Kd_sfc)
   call sfc_bkgnd_mixing(G, US, CS%bkgnd_mixing_csp)
 
-  !$OMP parallel do default(shared) private(dRho_int, N2_lay, N2_int, N2_bot, KT_extra, &
-  !$OMP                                     KS_extra, TKE_to_Kd, maxTKE, dissip, kb)
   do j=js,je
 
     ! Set up variables related to the stratification.


### PR DESCRIPTION
This PR removes an omp parallel do directive from MOM_set_diffusivity.F90. This is because the do-loop includes thread-unsafe cpu_clock_begin and cpu_clock_end calls. An alternative solution is to divide the outer j-loop into three parts and isolate the thread-unsafe calls, which would arguably degrade clarity, and (perhaps) non-omp performance.

Fixes: #161 