### PR TITLE
* incorporated flux correction factors into nuopc cap

### DIFF
--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -1498,7 +1498,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
         do i = ocean_grid%isc, ocean_grid%iec
            k = k + 1 ! Increment position within gindex
            mesh_areas(k) = dataPtr_mesh_areas(k)
-           model_areas(k) = ocean_grid%AreaT(i,j) * L2_to_rad2
+           model_areas(k) = ocean_grid%AreaT(i,j) / ocean_grid%Rad_Earth**2
            mod2med_areacor(k) = model_areas(k) / mesh_areas(k)
            med2mod_areacor(k) = mesh_areas(k) / model_areas(k)
         enddo

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -38,6 +38,7 @@ use MOM_cap_time,             only: AlarmInit
 use MOM_cap_methods,          only: mom_import, mom_export, mom_set_geomtype, mod2med_areacor, med2mod_areacor
 #ifdef CESMCOUPLED
 use shr_file_mod,             only: shr_file_setLogUnit, shr_file_getLogUnit
+use shr_mpi_mod,              only : shr_mpi_min, shr_mpi_max
 #endif
 use time_utils_mod,           only: esmf2fms_time
 
@@ -71,7 +72,7 @@ use ESMF,  only: ESMF_TimePrint, ESMF_AlarmSet, ESMF_FieldGet, ESMF_Array
 use ESMF,  only: ESMF_FieldRegridGetArea
 use ESMF,  only: ESMF_ArrayCreate
 use ESMF,  only: ESMF_RC_FILE_OPEN, ESMF_RC_FILE_READ, ESMF_RC_FILE_WRITE
-use ESMF,  only: ESMF_VMBroadcast
+use ESMF,  only: ESMF_VMBroadcast, ESMF_VMReduce, ESMF_REDUCE_MAX, ESMF_REDUCE_MIN
 use ESMF,  only: ESMF_AlarmCreate, ESMF_ClockGetAlarmList, ESMF_AlarmList_Flag
 use ESMF,  only: ESMF_AlarmGet, ESMF_AlarmIsCreated, ESMF_ALARMLIST_ALL, ESMF_AlarmIsEnabled
 use ESMF,  only: ESMF_STATEITEM_NOTFOUND, ESMF_FieldWrite
@@ -903,6 +904,14 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
   real(ESMF_KIND_R8), allocatable            :: mesh_areas(:)
   real(ESMF_KIND_R8), allocatable            :: model_areas(:)
   real(ESMF_KIND_R8), pointer                :: dataPtr_mesh_areas(:)
+  real(ESMF_KIND_R8)                         :: max_mod2med_areacor
+  real(ESMF_KIND_R8)                         :: max_med2mod_areacor
+  real(ESMF_KIND_R8)                         :: min_mod2med_areacor
+  real(ESMF_KIND_R8)                         :: min_med2mod_areacor
+  real(ESMF_KIND_R8)                         :: max_mod2med_areacor_glob
+  real(ESMF_KIND_R8)                         :: max_med2mod_areacor_glob
+  real(ESMF_KIND_R8)                         :: min_mod2med_areacor_glob
+  real(ESMF_KIND_R8)                         :: min_med2mod_areacor_glob
   character(len=*), parameter                :: subname='(MOM_cap:InitializeRealize)'
   !--------------------------------
 
@@ -1458,7 +1467,6 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
   !---------------------------------
   ! determine flux area correction factors - module variables in mom_cap_methods
   !---------------------------------
-
   ! Area correction factors are ONLY valid for meshes that are read in - so do not need them for
   ! grids that are calculated internally
 
@@ -1467,6 +1475,13 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
      ! Determine mesh areas for regridding
      call ESMF_MeshGet(Emesh, numOwnedElements=numOwnedElements, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+     allocate (mod2med_areacor(numOwnedElements))
+     allocate (med2mod_areacor(numOwnedElements))
+     mod2med_areacor(:) = 1._ESMF_KIND_R8
+     med2mod_areacor(:) = 1._ESMF_KIND_R8
+
+#ifdef CESMCOUPLED 
      call ESMF_StateGet(exportState, itemName=trim(fldsFrOcn(2)%stdname), field=lfield, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
      call ESMF_FieldRegridGetArea(lfield, rc=rc)
@@ -1474,37 +1489,40 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
      call ESMF_FieldGet(lfield, farrayPtr=dataPtr_mesh_areas, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
      allocate(mesh_areas(numOwnedElements))
-     mesh_areas(:) = dataPtr_mesh_areas(:)
-
-     ! Determine model areas
      allocate(model_areas(numOwnedElements))
+
+     ! Determine model areas and flux correction factors (module variables in mom_)
      k = 0
      L2_to_rad2 = ocean_grid%US%L_to_m**2 / ocean_grid%Rad_Earth**2
      do j = ocean_grid%jsc, ocean_grid%jec
         do i = ocean_grid%isc, ocean_grid%iec
            k = k + 1 ! Increment position within gindex
+           mesh_areas(k) = dataPtr_mesh_areas(k)
            model_areas(k) = ocean_grid%AreaT(i,j) * L2_to_rad2
+           mod2med_areacor(k) = model_areas(k) / mesh_areas(k)
+           med2mod_areacor(k) = mesh_areas(k) / model_areas(k)
         enddo
      enddo
-
-     ! Determine flux correction factors (module variables in mom_)
-     allocate (mod2med_areacor(numOwnedElements))
-     allocate (med2mod_areacor(numOwnedElements))
-     do n = 1,numOwnedElements
-        if (model_areas(n) == mesh_areas(n)) then
-           mod2med_areacor(n) = 1._ESMF_KIND_R8
-           med2mod_areacor(n) = 1._ESMF_KIND_R8
-        else
-           mod2med_areacor(n) = model_areas(n) / mesh_areas(n)
-           med2mod_areacor(n) = mesh_areas(n) / model_areas(n)
-           if (abs(mod2med_areacor(n) - 1._ESMF_KIND_R8) > 1.e-13) then
-              write(6,'(a,i8,2x,d21.14,2x)')' AREACOR mom6: n, abs(mod2med_areacor(n)-1)', &
-                   n, abs(mod2med_areacor(n) - 1._ESMF_KIND_R8)
-           end if
-        end if
-     end do
-     deallocate(model_areas)
      deallocate(mesh_areas)
+     deallocate(model_areas)
+
+     ! Write diagnostic output for correction factors
+     min_mod2med_areacor = minval(mod2med_areacor)
+     max_mod2med_areacor = maxval(mod2med_areacor)
+     min_med2mod_areacor = minval(med2mod_areacor)
+     max_med2mod_areacor = maxval(med2mod_areacor)
+     call shr_mpi_max(max_mod2med_areacor, max_mod2med_areacor_glob, mpicom)
+     call shr_mpi_min(min_mod2med_areacor, min_mod2med_areacor_glob, mpicom)
+     call shr_mpi_max(max_med2mod_areacor, max_med2mod_areacor_glob, mpicom)
+     call shr_mpi_min(min_med2mod_areacor, min_med2mod_areacor_glob, mpicom)
+     if (localPet == 0) then
+        write(logunit,'(2A,2g23.15,A )') trim(subname),' :  min_mod2med_areacor, max_mod2med_areacor ',&
+             min_mod2med_areacor_glob, max_mod2med_areacor_glob, 'MOM6'
+        write(logunit,'(2A,2g23.15,A )') trim(subname),' :  min_med2mod_areacor, max_med2mod_areacor ',&
+             min_med2mod_areacor_glob, max_med2mod_areacor_glob, 'MOM6'
+     end if
+#endif
+
   end if
 
   !---------------------------------

--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -186,7 +186,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! sensible heat flux (W/m2)
   !----
   call state_getimport(importState, 'mean_sensi_heat_flx', &
-       isc, iec, jsc, jec, ice_ocean_boundary%t_flux, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%t_flux, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -196,7 +196,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! evaporation flux (W/m2)
   !----
   call state_getimport(importState, 'mean_evap_rate', &
-       isc, iec, jsc, jec, ice_ocean_boundary%q_flux, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%q_flux, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -206,7 +206,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! liquid precipitation (rain)
   !----
   call state_getimport(importState, 'mean_prec_rate', &
-       isc, iec, jsc, jec, ice_ocean_boundary%lprec, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%lprec, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -216,7 +216,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! frozen precipitation (snow)
   !----
   call state_getimport(importState, 'mean_fprec_rate', &
-       isc, iec, jsc, jec, ice_ocean_boundary%fprec, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%fprec, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -231,7 +231,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! liquid runoff
   ice_ocean_boundary%lrunoff (:,:) = 0._ESMF_KIND_R8
   call state_getimport(importState, 'Foxx_rofl',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%lrunoff, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%lrunoff, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -240,7 +240,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! ice runoff
   ice_ocean_boundary%frunoff (:,:) = 0._ESMF_KIND_R8
   call state_getimport(importState, 'Foxx_rofi',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%frunoff, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%frunoff, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -249,7 +249,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! heat content of lrunoff
   ice_ocean_boundary%lrunoff_hflx(:,:) = 0._ESMF_KIND_R8
   call state_getimport(importState, 'mean_runoff_heat_flx',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%lrunoff_hflx, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%lrunoff_hflx, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -258,7 +258,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   ! heat content of frunoff
   ice_ocean_boundary%frunoff_hflx(:,:) = 0._ESMF_KIND_R8
   call state_getimport(importState, 'mean_calving_heat_flx',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%frunoff_hflx, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%frunoff_hflx, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -269,7 +269,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   !----
   ice_ocean_boundary%salt_flux(:,:) = 0._ESMF_KIND_R8
   call state_getimport(importState, 'mean_salt_rate',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%salt_flux, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%salt_flux, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -280,7 +280,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   !----
   ice_ocean_boundary%seaice_melt_heat(:,:) = 0._ESMF_KIND_R8
   call state_getimport(importState, 'net_heat_flx_to_ocn',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_heat, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_heat, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -291,7 +291,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   !----
   ice_ocean_boundary%seaice_melt(:,:) = 0._ESMF_KIND_R8
   call state_getimport(importState, 'mean_fresh_water_to_ocean_rate',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt, areacor=mod2med_areacor, rc=rc)
+       isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -715,22 +715,23 @@ subroutine State_GetImport(state, fldname, isc, iec, jsc, jec, output, do_sum, a
         call state_getfldptr(state, trim(fldname), dataptr1d, rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return  ! bail out
 
-        ! option to apply area correction
-        if (present(areacor)) then
-           do n = 1,size(dataPtr1d)
-              dataPtr1d(n) = dataPtr1d(n) * areacor(n)
-           end do
-        end if
-
-        ! determine output array
+        ! determine output array and apply area correction if present
         n = 0
         do j = jsc,jec
            do i = isc,iec
               n = n + 1
               if (present(do_sum)) then
-                 output(i,j)  = output(i,j) + dataPtr1d(n)
+                 if (present(areacor)) then
+                    output(i,j)  = output(i,j) + dataPtr1d(n) * areacor(n)
+                 else
+                    output(i,j)  = output(i,j) + dataPtr1d(n)
+                 end if
               else
-                 output(i,j)  = dataPtr1d(n)
+                 if (present(areacor)) then
+                    output(i,j)  = dataPtr1d(n) * areacor(n)
+                 else
+                    output(i,j)  = dataPtr1d(n)
+                 end if
               endif
            enddo
         enddo

--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -19,7 +19,6 @@ use MOM_ocean_model_nuopc,     only: ocean_public_type, ocean_state_type
 use MOM_surface_forcing_nuopc, only: ice_ocean_boundary_type
 use MOM_grid,                  only: ocean_grid_type
 use MOM_domains,               only: pass_var
-use MOM_error_handler,         only: MOM_error, FATAL, is_root_pe
 use mpp_domains_mod,           only: mpp_get_compute_domain
 
 ! By default make data private
@@ -102,7 +101,6 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   !----
   ! near-IR, direct shortwave  (W/m2)
   !----
-
   call state_getimport(importState, 'mean_net_sw_ir_dir_flx', &
        isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dir, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &


### PR DESCRIPTION
This implements flux area correction factors into the nuopc cap.
@gustavo-marques, @alperaltuntas - I have done a preliminary test with the compset ERS_Vnuopc_Ld5.T62_t061.CMOM.cheyenne_intel - and if you look at the cesm.log file there - you will see that the area correction factors will have an impact. area_model/area_mesh for most points is on the order of 1.-03. Just search for the string 
AREACOR. You will see output like the following:
`AREACOR mom6: n, abs(mod2med_areacor(n)-1)     136   0.21240886749745D-02`
My mom6 was a much older version from 10 months ago - but I have verified that without triggering the area correction factors everything was bfb.