### PR TITLE
Add med2mod_areacor and move where area correction is applied

### DIFF
--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -19,7 +19,6 @@ use MOM_ocean_model_nuopc,     only: ocean_public_type, ocean_state_type
 use MOM_surface_forcing_nuopc, only: ice_ocean_boundary_type
 use MOM_grid,                  only: ocean_grid_type
 use MOM_domains,               only: pass_var
-use MOM_error_handler,         only: MOM_error, FATAL, is_root_pe
 use mpp_domains_mod,           only: mpp_get_compute_domain
 
 ! By default make data private
@@ -102,7 +101,6 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   !----
   ! near-IR, direct shortwave  (W/m2)
   !----
-
   call state_getimport(importState, 'mean_net_sw_ir_dir_flx', &
        isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dir, areacor=med2mod_areacor, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &


### PR DESCRIPTION
1) med2mod_areacor was missing if a few calls to state_getimport

2) the option to apply area correction was being done after setting the output array. It should be done before that.