### PR TITLE
add if clause to a set_diffusivity OMP block.

### DIFF
--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -417,7 +417,8 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   ! parameterization of Kd.
 
   !$OMP parallel do default(shared) private(dRho_int,N2_lay,Kd_lay_2d,Kd_int_2d,Kv_bkgnd,N2_int,&
-  !$OMP                                     N2_bot,KT_extra,KS_extra,TKE_to_Kd,maxTKE,dissip,kb)
+  !$OMP                                     N2_bot,KT_extra,KS_extra,TKE_to_Kd,maxTKE,dissip,kb)&
+  !$OMP                             if(.not. CS%use_CVMix_ddiff)
   do j=js,je
 
     ! Set up variables related to the stratification.


### PR DESCRIPTION
This PR adds an if clause to a set_diffusivity OMP block, which includes clock_begin and clock_end calls. These calls are thread unsafe, but are called only when use_CVMix_ddiff. Hence the if clause for the encompassing OMP do directive.

testing: PET.TL319_t061.GMOM_JRA