### PR TITLE
De-allocate Kd_bkgnd and Kv_bkgnd

### DIFF
--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -694,6 +694,8 @@ subroutine set_diffusivity(u, v, h, u_h, v_h, tv, fluxes, optics, visc, dt, &
   if (associated(dd%KS_extra)) deallocate(dd%KS_extra)
   if (associated(dd%drho_rat)) deallocate(dd%drho_rat)
   if (associated(dd%Kd_BBL)) deallocate(dd%Kd_BBL)
+  if (associated(dd%Kd_bkgnd)) deallocate(dd%Kd_bkgnd)
+  if (associated(dd%Kv_bkgnd)) deallocate(dd%Kv_bkgnd)
 
   if (showCallTree) call callTree_leave("set_diffusivity()")
 


### PR DESCRIPTION
When **Kd_bkgnd** or **Kv_bkgnd** are included in the diag_table,  a corresponding 3D array gets allocated every tracer time step so the requested diagnostic can be posted. However, this array was never deallocated which caused a memory leak. This patch fixes this issue by making sure both **Kd_bkgnd** or **Kv_bkgnd** are deallocated. 

Many thanks to @klindsay28 for helping to find this memory leak. 

This PR should not change answers. 