### PR TITLE
Introduce the legacy CESM WW3 coupling option (VR12-MA)

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -708,7 +708,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   call query_ocean_state(ocean_state, use_waves=use_waves, wave_method=wave_method)
   if (use_waves) then
     call query_ocean_state(ocean_state, NumWaveBands=Ice_ocean_boundary%num_stk_bands)
-    if (wave_method == "VR12-MA") then
+    if (wave_method == "EFACTOR") then
       allocate( Ice_ocean_boundary%lamult(isc:iec,jsc:jec) )
       Ice_ocean_boundary%lamult          = 0.0
     else
@@ -761,7 +761,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_runoff_heat_flx"        , "will provide")
   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_calving_heat_flx"       , "will provide")
   if (use_waves) then
-    if (wave_method == "VR12-MA") then
+    if (wave_method == "EFACTOR") then
       call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_lamult"                 , "will provide")
     else
       if (Ice_ocean_boundary%num_stk_bands > 3) then

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -697,7 +697,8 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
 
   if (ocean_state%use_waves) then
     if (ocean_state%wave_method == "VR12-MA") then
-      continue
+      allocate( Ice_ocean_boundary%lamult(isc:iec,jsc:jec) )
+      Ice_ocean_boundary%lamult          = 0.0
     else
       Ice_ocean_boundary%num_stk_bands=ocean_state%Waves%NumBands
       allocate ( Ice_ocean_boundary% ustk0 (isc:iec,jsc:jec),         &
@@ -722,15 +723,6 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
    call fld_list_add(fldsFrOcn_num, fldsFrOcn, trim(scalar_field_name), "will_provide")
   end if
 
-  if (cesm_coupled) then
-    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_lamult"                 , "will provide")
-    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_ustokes"                , "will provide")
-    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_vstokes"                , "will provide")
-    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_hstokes"                , "will provide")
-  else
-    !call fld_list_add(fldsToOcn_num, fldsToOcn, "mass_of_overlying_sea_ice" , "will provide")
-    !call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_lev"                   , "will provide")
-  endif
 
   !--------- import fields -------------
   call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_salt_rate"             , "will provide") ! from ice
@@ -755,7 +747,10 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_calving_heat_flx"       , "will provide")
   if (ocean_state%use_waves) then
     if (ocean_state%wave_method == "VR12-MA") then
-      continue
+      call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_lamult"                 , "will provide")
+      !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_ustokes"                , "will provide")
+      !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_vstokes"                , "will provide")
+      !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_hstokes"                , "will provide")
     else
       if (Ice_ocean_boundary%num_stk_bands > 3) then
         call MOM_error(FATAL, "Number of Stokes Bands > 3, NUOPC cap not set up for this")

--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -696,17 +696,21 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   Ice_ocean_boundary%frunoff         = 0.0
 
   if (ocean_state%use_waves) then
-    Ice_ocean_boundary%num_stk_bands=ocean_state%Waves%NumBands
-    allocate ( Ice_ocean_boundary% ustk0 (isc:iec,jsc:jec),         &
-               Ice_ocean_boundary% vstk0 (isc:iec,jsc:jec),         &
-               Ice_ocean_boundary% ustkb (isc:iec,jsc:jec,Ice_ocean_boundary%num_stk_bands), &
-               Ice_ocean_boundary% vstkb (isc:iec,jsc:jec,Ice_ocean_boundary%num_stk_bands), &
-               Ice_ocean_boundary%stk_wavenumbers (Ice_ocean_boundary%num_stk_bands))
-    Ice_ocean_boundary%ustk0           = 0.0
-    Ice_ocean_boundary%vstk0           = 0.0
-    Ice_ocean_boundary%stk_wavenumbers = ocean_state%Waves%WaveNum_Cen
-    Ice_ocean_boundary%ustkb           = 0.0
-    Ice_ocean_boundary%vstkb           = 0.0
+    if (ocean_state%wave_method == "VR12-MA") then
+      continue
+    else
+      Ice_ocean_boundary%num_stk_bands=ocean_state%Waves%NumBands
+      allocate ( Ice_ocean_boundary% ustk0 (isc:iec,jsc:jec),         &
+                  Ice_ocean_boundary% vstk0 (isc:iec,jsc:jec),         &
+                  Ice_ocean_boundary% ustkb (isc:iec,jsc:jec,Ice_ocean_boundary%num_stk_bands), &
+                  Ice_ocean_boundary% vstkb (isc:iec,jsc:jec,Ice_ocean_boundary%num_stk_bands), &
+                  Ice_ocean_boundary%stk_wavenumbers (Ice_ocean_boundary%num_stk_bands))
+      Ice_ocean_boundary%ustk0           = 0.0
+      Ice_ocean_boundary%vstk0           = 0.0
+      Ice_ocean_boundary%stk_wavenumbers = ocean_state%Waves%WaveNum_Cen
+      Ice_ocean_boundary%ustkb           = 0.0
+      Ice_ocean_boundary%vstkb           = 0.0
+    endif
   endif
 
   ocean_internalstate%ptr%ocean_state_type_ptr => ocean_state
@@ -723,9 +727,6 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
     !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_ustokes"                , "will provide")
     !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_vstokes"                , "will provide")
     !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_hstokes"                , "will provide")
-    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_melth"                , "will provide")
-    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_meltw"                , "will provide")
-    !call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_fswpen"                 , "will provide")
   else
     !call fld_list_add(fldsToOcn_num, fldsToOcn, "mass_of_overlying_sea_ice" , "will provide")
     !call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_lev"                   , "will provide")
@@ -753,15 +754,19 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_runoff_heat_flx"        , "will provide")
   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_calving_heat_flx"       , "will provide")
   if (ocean_state%use_waves) then
-    if (Ice_ocean_boundary%num_stk_bands > 3) then
-      call MOM_error(FATAL, "Number of Stokes Bands > 3, NUOPC cap not set up for this")
+    if (ocean_state%wave_method == "VR12-MA") then
+      continue
+    else
+      if (Ice_ocean_boundary%num_stk_bands > 3) then
+        call MOM_error(FATAL, "Number of Stokes Bands > 3, NUOPC cap not set up for this")
+      endif
+      call fld_list_add(fldsToOcn_num, fldsToOcn, "eastward_partitioned_stokes_drift_1" , "will provide")
+      call fld_list_add(fldsToOcn_num, fldsToOcn, "northward_partitioned_stokes_drift_1", "will provide")
+      call fld_list_add(fldsToOcn_num, fldsToOcn, "eastward_partitioned_stokes_drift_2" , "will provide")
+      call fld_list_add(fldsToOcn_num, fldsToOcn, "northward_partitioned_stokes_drift_2", "will provide")
+      call fld_list_add(fldsToOcn_num, fldsToOcn, "eastward_partitioned_stokes_drift_3" , "will provide")
+      call fld_list_add(fldsToOcn_num, fldsToOcn, "northward_partitioned_stokes_drift_3", "will provide")
     endif
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "eastward_partitioned_stokes_drift_1" , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "northward_partitioned_stokes_drift_1", "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "eastward_partitioned_stokes_drift_2" , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "northward_partitioned_stokes_drift_2", "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "eastward_partitioned_stokes_drift_3" , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "northward_partitioned_stokes_drift_3", "will provide")
   endif
 
   !--------- export fields -------------

--- a/config_src/drivers/nuopc_cap/mom_cap_methods.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_methods.F90
@@ -257,6 +257,14 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   !----
+  ! Langmuir enhancement factor
+  !----
+  ice_ocean_boundary%lamult (:,:) = 0._ESMF_KIND_R8
+  call state_getimport(importState, 'Sw_lamult',  &
+       isc, iec, jsc, jec, ice_ocean_boundary%lamult, rc=rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  !----
   ! Partitioned Stokes Drift Components
   !----
   if ( associated(ice_ocean_boundary%ustkb) ) then

--- a/config_src/drivers/nuopc_cap/mom_cap_methods.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_methods.F90
@@ -274,10 +274,12 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   !----
   ! Langmuir enhancement factor
   !----
-  ice_ocean_boundary%lamult (:,:) = 0._ESMF_KIND_R8
-  call state_getimport(importState, 'Sw_lamult',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%lamult, rc=rc)
-  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  if ( associated(ice_ocean_boundary%lamult) ) then
+   ice_ocean_boundary%lamult (:,:) = 0._ESMF_KIND_R8
+   call state_getimport(importState, 'Sw_lamult',  &
+        isc, iec, jsc, jec, ice_ocean_boundary%lamult, rc=rc)
+   if (ChkErr(rc,__LINE__,u_FILE_u)) return
+   endif
 
   !----
   ! Partitioned Stokes Drift Components

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -396,6 +396,9 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   call allocate_forcing_type(OS%grid, OS%fluxes, waves=.true.)
   call get_param(param_file, mdl, "USE_WAVES", OS%Use_Waves, &
        "If true, enables surface wave modules.", default=.false.)
+  if (OS%Use_Waves) then
+    call get_param(param_file, mdl, "WAVE_METHOD", OS%wave_method, default="EMPTY", do_not_log=.true.)
+  endif
   ! MOM_wave_interface_init is called regardless of the value of USE_WAVES because
   ! it also initializes statistical waves.
   call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -145,6 +145,7 @@ type, public :: ocean_state_type ; private
   integer :: nstep = 0        !< The number of calls to update_ocean.
   logical :: use_ice_shelf    !< If true, the ice shelf model is enabled.
   logical,public :: use_waves !< If true use wave coupling.
+  character(len=40),public :: wave_method !< Wave coupling method.
 
   logical :: icebergs_alter_ocean !< If true, the icebergs can change ocean the
                               !! ocean dynamics and forcing fluxes.
@@ -387,10 +388,15 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   call get_param(param_file, mdl, "USE_WAVES", OS%Use_Waves, &
        "If true, enables surface wave modules.", default=.false.)
   if (OS%use_waves) then
+    call get_param(param_file, mdl, "WAVE_METHOD", OS%wave_method, default="EMPTY", do_not_log=.true.)
     call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
-    call get_param(param_file,mdl,"SURFBAND_WAVENUMBERS",OS%Waves%WaveNum_Cen, &
-           "Central wavenumbers for surface Stokes drift bands.",units='rad/m', &
-           default=0.12566)
+    if (OS%wave_method == "VR12-MA") then
+      continue
+    else
+      call get_param(param_file,mdl,"SURFBAND_WAVENUMBERS",OS%Waves%WaveNum_Cen, &
+             "Central wavenumbers for surface Stokes drift bands.",units='rad/m', &
+             default=0.12566)
+    endif
   else
     call MOM_wave_interface_init_lite(param_file)
   endif
@@ -575,7 +581,9 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   call set_net_mass_forcing(OS%fluxes, OS%forces, OS%grid, OS%US)
 
   if (OS%use_waves) then
-    call Update_Surface_Waves(OS%grid, OS%GV, OS%US, OS%time, ocean_coupling_time_step, OS%waves, OS%forces)
+    if (OS%wave_method /= "VR12-MA") then
+      call Update_Surface_Waves(OS%grid, OS%GV, OS%US, OS%time, ocean_coupling_time_step, OS%waves, OS%forces)
+    endif
   endif
 
   if (OS%nstep==0) then

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -585,7 +585,7 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   call set_net_mass_forcing(OS%fluxes, OS%forces, OS%grid, OS%US)
 
   if (OS%use_waves) then
-    if (OS%wave_method /= "VR12-MA") then
+    if (OS%wave_method /= "EFACTOR") then
       call Update_Surface_Waves(OS%grid, OS%GV, OS%US, OS%time, ocean_coupling_time_step, OS%waves, OS%forces)
     endif
   endif

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -367,13 +367,16 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
     use_melt_pot=.false.
   endif
 
+  call get_param(param_file, mdl, "USE_WAVES", OS%use_waves, &
+       "If true, enables surface wave modules.", default=.false.)
+
   !   Consider using a run-time flag to determine whether to do the diagnostic
   ! vertical integrals, since the related 3-d sums are not negligible in cost.
   call allocate_surface_state(OS%sfc_state, OS%grid, use_temperature, &
                               do_integrals=.true., gas_fields_ocn=gas_fields_ocn, use_meltpot=use_melt_pot)
 
   call surface_forcing_init(Time_in, OS%grid, OS%US, param_file, OS%diag, &
-                            OS%forcing_CSp, OS%restore_salinity, OS%restore_temp)
+                            OS%forcing_CSp, OS%restore_salinity, OS%restore_temp, OS%use_waves)
 
   if (OS%use_ice_shelf)  then
     call initialize_ice_shelf(param_file, OS%grid, OS%Time, OS%ice_shelf_CSp, &
@@ -385,8 +388,6 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
       call allocate_forcing_type(OS%grid, OS%fluxes, shelf=.true.)
   endif
 
-  call get_param(param_file, mdl, "USE_WAVES", OS%Use_Waves, &
-       "If true, enables surface wave modules.", default=.false.)
   if (OS%use_waves) then
     call get_param(param_file, mdl, "WAVE_METHOD", OS%wave_method, default="EMPTY", do_not_log=.true.)
     call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -395,6 +395,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   endif
 
   if (OS%use_waves) then
+    call allocate_forcing_type(OS%grid, OS%fluxes, waves=.true.)
     call get_param(param_file, mdl, "WAVE_METHOD", OS%wave_method, default="EMPTY", do_not_log=.true.)
     call MOM_wave_interface_init(OS%Time, OS%grid, OS%GV, OS%US, param_file, OS%Waves, OS%diag)
     if (OS%wave_method == "VR12-MA") then

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -554,6 +554,18 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   enddo ; enddo
 
+  ! wave to ocean coupling
+  if ( associated(IOB%lamult)) then
+    do j=js,je; do i=is,ie
+      if (IOB%ice_fraction(i-i0,j-j0) <= 0.05 ) then
+        fluxes%lamult(i,j) = IOB%lamult(i-i0,j-j0)
+      else
+        fluxes%lamult(i,j) = 1.0
+      endif
+    enddo ; enddo
+    call pass_var(fluxes%lamult, G%domain, halo=1 )
+  endif
+
   ! applied surface pressure from atmosphere and cryosphere
   if (associated(IOB%p)) then
      if (CS%max_p_surf >= 0.0) then
@@ -875,18 +887,6 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
     enddo ; enddo
 
   endif   ! endif for wind related fields
-
-  ! wave to ocean coupling
-  if ( associated(IOB%lamult)) then
-    do j=js,je; do i=is,ie
-      if (IOB%ice_fraction(i-i0,j-j0) <= 0.05 ) then
-        forces%lamult(i,j) = IOB%lamult(i-i0,j-j0)
-      else
-        forces%lamult(i,j) = 1.0
-      endif
-    enddo ; enddo
-    call pass_var(forces%lamult, G%domain, halo=1 )
-  endif
 
   if ( associated(IOB%ustkb) ) then
 

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -183,6 +183,7 @@ type, public :: ice_ocean_boundary_type
                                                               !! ice-shelves, expressed as a coefficient
                                                               !! for divergence damping, as determined
                                                               !! outside of the ocean model in [m3/s]
+  real, pointer, dimension(:,:)   :: lamult          => NULL() !< Langmuir enhancement factor [nondim]
   real, pointer, dimension(:,:)   :: ustk0           => NULL() !< Surface Stokes drift, zonal [m/s]
   real, pointer, dimension(:,:)   :: vstk0           => NULL() !< Surface Stokes drift, meridional [m/s]
   real, pointer, dimension(:)     :: stk_wavenumbers => NULL() !< The central wave number of Stokes bands [rad/m]
@@ -688,8 +689,11 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
   if (associated(forces%rigidity_ice_u)) forces%rigidity_ice_u(:,:) = 0.0
   if (associated(forces%rigidity_ice_v)) forces%rigidity_ice_v(:,:) = 0.0
 
-  if ( associated(IOB%ustkb) ) &
+  if ( associated(IOB%lamult) ) then
+    call allocate_mech_forcing(G, forces, waves=.true., num_stk_bands=0)
+  elseif ( associated(IOB%ustkb) ) then
     call allocate_mech_forcing(G, forces, waves=.true., num_stk_bands=IOB%num_stk_bands)
+  endif
 
   ! applied surface pressure from atmosphere and cryosphere
   if (CS%use_limited_P_SSH) then
@@ -849,6 +853,13 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
   endif   ! endif for wind related fields
 
   ! wave to ocean coupling
+  if ( associated(IOB%lamult)) then
+    do j=js,je; do i=is,ie
+      forces%lamult(i,j) = IOB%lamult(i-i0,j-j0)
+    enddo ; enddo
+    call pass_var(forces%lamult, G%domain, halo=1 )
+  endif
+
   if ( associated(IOB%ustkb) ) then
 
     forces%stk_wavenumbers(:) = IOB%stk_wavenumbers
@@ -1041,7 +1052,7 @@ subroutine forcing_save_restart(CS, G, Time, directory, time_stamped, &
 end subroutine forcing_save_restart
 
 !> Initialize the surface forcing, including setting parameters and allocating permanent memory.
-subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt, restore_temp)
+subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt, restore_temp, use_waves)
   type(time_type),          intent(in)    :: Time !< The current model time
   type(ocean_grid_type),    intent(in)    :: G    !< The ocean's grid structure
   type(unit_scale_type),    intent(in)    :: US   !< A dimensional unit scaling type
@@ -1054,6 +1065,8 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                                                   !! restoring will be applied in this model.
   logical, optional,        intent(in)    :: restore_temp !< If present and true surface temperature
                                                   !! restoring will be applied in this model.
+  logical, optional,        intent(in)    :: use_waves !< If present and true, use waves and activate
+                                                  !! the corresponding wave forcing diagnostics
 
   ! Local variables
   real :: utide  ! The RMS tidal velocity [Z T-1 ~> m s-1].
@@ -1321,7 +1334,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                  "If true, makes available diagnostics of fluxes from icebergs "//&
                  "as seen by MOM6.", default=.false.)
   call register_forcing_type_diags(Time, diag, US, CS%use_temperature, CS%handles, &
-                                   use_berg_fluxes=iceberg_flux_diags)
+                                   use_berg_fluxes=iceberg_flux_diags, use_waves=use_waves)
 
   call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
                  "If true, allows flux adjustments to specified via the "//&

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -879,7 +879,11 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
   ! wave to ocean coupling
   if ( associated(IOB%lamult)) then
     do j=js,je; do i=is,ie
-      forces%lamult(i,j) = IOB%lamult(i-i0,j-j0)
+      if (IOB%ice_fraction(i-i0,j-j0) <= 0.05 ) then
+        forces%lamult(i,j) = IOB%lamult(i-i0,j-j0)
+      else
+        forces%lamult(i,j) = 1.0
+      endif
     enddo ; enddo
     call pass_var(forces%lamult, G%domain, halo=1 )
   endif

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -545,18 +545,14 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     fluxes%sw(i,j) = fluxes%sw_vis_dir(i,j) + fluxes%sw_vis_dif(i,j) + &
                      fluxes%sw_nir_dir(i,j) + fluxes%sw_nir_dif(i,j)
 
-  enddo ; enddo
+    ! sea ice fraction [nondim]
+    if (associated(IOB%ice_fraction) .and. associated(fluxes%ice_fraction)) &
+         fluxes%ice_fraction(i,j) = G%mask2dT(i,j) * IOB%ice_fraction(i-i0,j-j0)
+    ! 10-m wind speed squared [m2/s2]
+    if (associated(IOB%u10_sqr) .and. associated(fluxes%u10_sqr)) &
+         fluxes%u10_sqr(i,j) = US%m_to_L**2 * US%T_to_s**2 * G%mask2dT(i,j) * IOB%u10_sqr(i-i0,j-j0)
 
-  if (CS%use_CFC) then
-    do j=js,je ; do i=is,ie
-      ! sea ice fraction [nondim]
-      if (associated(IOB%ice_fraction)) &
-           fluxes%ice_fraction(i,j) = G%mask2dT(i,j) * IOB%ice_fraction(i-i0,j-j0)
-      ! 10-m wind speed squared [m2/s2]
-      if (associated(IOB%u10_sqr)) &
-           fluxes%u10_sqr(i,j) = US%m_to_L**2 * US%T_to_s**2 * G%mask2dT(i,j) * IOB%u10_sqr(i-i0,j-j0)
-    enddo ; enddo
-  endif
+  enddo ; enddo
 
   ! applied surface pressure from atmosphere and cryosphere
   if (associated(IOB%p)) then

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -2948,7 +2948,7 @@ end subroutine forcing_diagnostics
 
 !> Conditionally allocate fields within the forcing type
 subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
-                                     shelf, iceberg, salt, fix_accum_bug, cfc)
+                                     shelf, iceberg, salt, fix_accum_bug, cfc, waves)
   type(ocean_grid_type), intent(in) :: G       !< Ocean grid structure
   type(forcing),      intent(inout) :: fluxes  !< A structure containing thermodynamic forcing fields
   logical, optional,     intent(in) :: water   !< If present and true, allocate water fluxes
@@ -2961,6 +2961,7 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
   logical, optional,     intent(in) :: fix_accum_bug !< If present and true, avoid using a bug in
                                                !! accumulation of ustar_gustless
   logical, optional,     intent(in) :: cfc     !< If present and true, allocate cfc fluxes
+  logical, optional,     intent(in) :: waves   !< If present and true, allocate wave fields
 
   ! Local variables
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -3021,6 +3022,9 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
   call myAlloc(fluxes%cfc12_flux,isd,ied,jsd,jed, cfc)
   call myAlloc(fluxes%ice_fraction,isd,ied,jsd,jed, cfc)
   call myAlloc(fluxes%u10_sqr,isd,ied,jsd,jed, cfc)
+
+  !These fields should only on allocated when wave coupling is activated.
+  call myAlloc(fluxes%ice_fraction,isd,ied,jsd,jed, waves)
 
   if (present(fix_accum_bug)) fluxes%gustless_accum_bug = .not.fix_accum_bug
 end subroutine allocate_forcing_by_group

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -679,7 +679,7 @@ subroutine KPP_calculate(CS, G, GV, US, h, uStar, &
   !$OMP                           surfBuoyFlux, Kdiffusivity, Kviscosity, LangEnhK, sigma,  &
   !$OMP                           sigmaRatio)                                               &
   !$OMP                           shared(G, GV, CS, US, uStar, h, buoy_scale, buoyFlux, Kt, &
-  !$OMP                           Ks, Kv, nonLocalTransHeat, nonLocalTransScalar, waves)
+  !$OMP                           Ks, Kv, nonLocalTransHeat, nonLocalTransScalar, waves, lamult)
   ! loop over horizontal points on processor
   do j = G%jsc, G%jec
     do i = G%isc, G%iec
@@ -1027,7 +1027,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   !$OMP                           deltarho, N2_1d, ws_1d, LangEnhVT2, enhvt2, wst,          &
   !$OMP                           BulkRi_1d, zBottomMinusOffset) &
   !$OMP                           shared(G, GV, CS, US, uStar, h, buoy_scale, buoyFlux,     &
-  !$OMP                           Temp, Salt, waves, tv, GoRho, u, v)
+  !$OMP                           Temp, Salt, waves, tv, GoRho, u, v, lamult)
   do j = G%jsc, G%jec
     do i = G%isc, G%iec
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1190,11 +1190,19 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
                                  CS%KPP_buoy_flux, CS%KPP_temp_flux, CS%KPP_salt_flux)
 
     ! The KPP scheme calculates boundary layer diffusivities and non-local transport.
-    call KPP_compute_BLD(CS%KPP_CSp, G, GV, US, h, tv%T, tv%S, u, v, tv, &
-                         fluxes%ustar, CS%KPP_buoy_flux, Waves=Waves)
+    if ( associated(fluxes%lamult) ) then
+      call KPP_compute_BLD(CS%KPP_CSp, G, GV, US, h, tv%T, tv%S, u, v, tv, &
+                           fluxes%ustar, CS%KPP_buoy_flux, Waves=Waves, lamult=fluxes%lamult)
 
-    call KPP_calculate(CS%KPP_CSp, G, GV, US, h, fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, &
+      call KPP_calculate(CS%KPP_CSp, G, GV, US, h, fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, &
+                       Kd_salt, visc%Kv_shear, CS%KPP_NLTheat, CS%KPP_NLTscalar, Waves=Waves, lamult=fluxes%lamult)
+    else
+      call KPP_compute_BLD(CS%KPP_CSp, G, GV, US, h, tv%T, tv%S, u, v, tv, &
+                           fluxes%ustar, CS%KPP_buoy_flux, Waves=Waves)
+
+      call KPP_calculate(CS%KPP_CSp, G, GV, US, h, fluxes%ustar, CS%KPP_buoy_flux, Kd_heat, &
                        Kd_salt, visc%Kv_shear, CS%KPP_NLTheat, CS%KPP_NLTscalar, Waves=Waves)
+    endif
 
     if (associated(Hml)) then
       call KPP_get_BLD(CS%KPP_CSp, Hml(:,:), G, US)

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -39,6 +39,7 @@ public CoriolisStokes ! NOT READY - Public interface to add Coriolis-Stokes acce
                       ! serious consideration of the full 3d wave-averaged Navier-Stokes
                       ! CL2 effects.
 public Waves_end ! public interface to deallocate and free wave related memory.
+public get_wave_method ! public interface to obtain the wave method string
 
 ! A note on unit descriptions in comments: MOM6 uses units that can be rescaled for dimensional
 ! consistency testing. These are noted in comments with units like Z, H, L, and T, along with
@@ -179,6 +180,14 @@ integer, parameter :: TESTPROF = 0, SURFBANDS = 1, DHH85 = 2, LF17 = 3, VR12MA =
 integer, parameter :: DATAOVR = 1, COUPLER = 2, INPUT = 3
 !>@}
 
+! Strings for the wave method
+character*(5), parameter  :: NULL_STRING      = "EMPTY"
+character*(12), parameter :: TESTPROF_STRING  = "TEST_PROFILE"
+character*(13), parameter :: SURFBANDS_STRING = "SURFACE_BANDS"
+character*(5), parameter  :: DHH85_STRING     = "DHH85"
+character*(4), parameter  :: LF17_STRING      = "LF17"
+character*(7), parameter  :: VR12MA_STRING    = "VR12-MA"
+
 contains
 
 !> Initializes parameters related to MOM_wave_interface
@@ -196,12 +205,6 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character*(13) :: TMPSTRING1, TMPSTRING2
-  character*(5), parameter  :: NULL_STRING      = "EMPTY"
-  character*(12), parameter :: TESTPROF_STRING  = "TEST_PROFILE"
-  character*(13), parameter :: SURFBANDS_STRING = "SURFACE_BANDS"
-  character*(5), parameter  :: DHH85_STRING     = "DHH85"
-  character*(4), parameter  :: LF17_STRING      = "LF17"
-  character*(7), parameter  :: VR12MA_STRING    = "VR12-MA"
   character*(12), parameter :: DATAOVR_STRING   = "DATAOVERRIDE"
   character*(7), parameter  :: COUPLER_STRING   = "COUPLER"
   character*(5), parameter  :: INPUT_STRING     = "INPUT"
@@ -1054,6 +1057,31 @@ subroutine get_Langmuir_Number( LA, G, GV, US, HBL, ustar, i, j, &
   endif
 
 end subroutine get_Langmuir_Number
+
+!> function to return the wave method string set in the param file
+function get_wave_method(CS)
+  character(:), allocatable :: get_wave_method
+  type(wave_parameters_CS), pointer :: CS !< Control structure
+
+  if (associated(CS)) then
+    select case(CS%WaveMethod)
+      case (Null_WaveMethod)
+        get_wave_method = NULL_STRING
+      case (TESTPROF)
+        get_wave_method = TESTPROF_STRING
+      case (SURFBANDS)
+        get_wave_method = SURFBANDS_STRING
+      case (DHH85)
+        get_wave_method = DHH85_STRING
+      case (LF17)
+        get_wave_method = LF17_STRING
+      case (VR12MA)
+        get_wave_method = VR12MA_STRING
+    end select
+  else
+    get_wave_method = NULL_STRING
+  endif
+end function get_wave_method
 
 !> Get SL averaged Stokes drift from Li/FK 17 method
 !!

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -181,12 +181,12 @@ integer, parameter :: DATAOVR = 1, COUPLER = 2, INPUT = 3
 !>@}
 
 ! Strings for the wave method
-character*(5), parameter  :: NULL_STRING      = "EMPTY"
-character*(12), parameter :: TESTPROF_STRING  = "TEST_PROFILE"
-character*(13), parameter :: SURFBANDS_STRING = "SURFACE_BANDS"
-character*(5), parameter  :: DHH85_STRING     = "DHH85"
-character*(4), parameter  :: LF17_STRING      = "LF17"
-character*(7), parameter  :: VR12MA_STRING    = "VR12-MA"
+character*(5), parameter  :: NULL_STRING      = "EMPTY"         !< null wave method string
+character*(12), parameter :: TESTPROF_STRING  = "TEST_PROFILE"  !< test profile string
+character*(13), parameter :: SURFBANDS_STRING = "SURFACE_BANDS" !< surface bands string
+character*(5), parameter  :: DHH85_STRING     = "DHH85"         !< DHH85 wave method string
+character*(4), parameter  :: LF17_STRING      = "LF17"          !< LF17 wave method string
+character*(7), parameter  :: VR12MA_STRING    = "VR12-MA"       !< VR12-MA wave method string
 
 contains
 

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -141,6 +141,7 @@ integer :: WaveMethod=-99 !< Options for including wave information
                           !!   1 - Surface Stokes Drift Bands
                           !!   2 - DHH85
                           !!   3 - LF17
+                          !!   4 - VR12MA
                           !! -99 - No waves computed, but empirical Langmuir number used.
                           !! \todo Module variable! Move into a control structure.
 
@@ -178,7 +179,7 @@ character(len=40)  :: mdl = "MOM_wave_interface" !< This module's name.
 !! into a control structure.
 ! Switches needed in import_stokes_drift
 integer, parameter :: TESTPROF = 0, SURFBANDS = 1, &
-                      DHH85 = 2, LF17 = 3, NULL_WaveMethod=-99, &
+                      DHH85 = 2, LF17 = 3, VR12MA = 4, NULL_WaveMethod=-99, &
                       DATAOVR = 1, COUPLER = 2, INPUT = 3
 
 ! Options For Test Prof
@@ -208,6 +209,7 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
   character*(13), parameter :: SURFBANDS_STRING = "SURFACE_BANDS"
   character*(5), parameter  :: DHH85_STRING     = "DHH85"
   character*(4), parameter  :: LF17_STRING      = "LF17"
+  character*(7), parameter  :: VR12MA_STRING    = "VR12-MA"
   character*(12), parameter :: DATAOVR_STRING   = "DATAOVERRIDE"
   character*(7), parameter  :: COUPLER_STRING   = "COUPLER"
   character*(5), parameter  :: INPUT_STRING     = "INPUT"
@@ -268,7 +270,11 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
        " DHH85         - Uses Donelan et al. 1985 empirical \n"//     &
        "                 wave spectrum with prescribed values. \n"//  &
        " LF17          - Infers Stokes drift profile from wind \n"//  &
-       "                 speed following Li and Fox-Kemper 2017.\n",  &
+       "                 speed following Li and Fox-Kemper 2017.\n"// &
+       " VR12-MA       - Applies an enhancement factor to the KPP\n"//&
+       "                 turbulent velocity scale received from \n"// &
+       "                 WW3 and is based on the surface layer \n"//  &
+       "                 and projected Langmuir number. (Li 2016)\n", &
        units='', default=NULL_STRING)
   select case (TRIM(TMPSTRING1))
   case (NULL_STRING)! No Waves
@@ -363,6 +369,8 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
           default=.false.)
   case (LF17_STRING)!Li and Fox-Kemper 17 wind-sea Langmuir number
     WaveMethod = LF17
+  case (VR12MA_STRING)!Li and Fox-Kemper 16
+    WaveMethod = VR12MA
   case default
     call MOM_error(FATAL,'Check WAVE_METHOD.')
   end select
@@ -732,6 +740,8 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar)
       enddo
       DHH85_is_set = .true.
     endif
+  elseif (WaveMethod==VR12MA) then
+    return ! todo
   else! Keep this else, fallback to 0 Stokes drift
     do kk= 1,GV%ke
       do jj = G%jsd,G%jed

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -174,7 +174,7 @@ end type wave_parameters_CS
 
 ! Switches needed in import_stokes_drift
 !>@{ Enumeration values for the wave method
-integer, parameter :: TESTPROF = 0, SURFBANDS = 1, DHH85 = 2, LF17 = 3, VR12MA = 4, NULL_WaveMethod = -99
+integer, parameter :: TESTPROF = 0, SURFBANDS = 1, DHH85 = 2, LF17 = 3, EFACTOR = 4, NULL_WaveMethod = -99
 !>@}
 !>@{ Enumeration values for the wave data source
 integer, parameter :: DATAOVR = 1, COUPLER = 2, INPUT = 3
@@ -186,7 +186,7 @@ character*(12), parameter :: TESTPROF_STRING  = "TEST_PROFILE"  !< test profile 
 character*(13), parameter :: SURFBANDS_STRING = "SURFACE_BANDS" !< surface bands string
 character*(5), parameter  :: DHH85_STRING     = "DHH85"         !< DHH85 wave method string
 character*(4), parameter  :: LF17_STRING      = "LF17"          !< LF17 wave method string
-character*(7), parameter  :: VR12MA_STRING    = "VR12-MA"       !< VR12-MA wave method string
+character*(7), parameter  :: EFACTOR_STRING   = "EFACTOR"       !< EFACTOR (based on vr12-ma) wave method string
 
 contains
 
@@ -288,10 +288,11 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
        "                 wave spectrum with prescribed values. \n"//  &
        " LF17          - Infers Stokes drift profile from wind \n"//  &
        "                 speed following Li and Fox-Kemper 2017.\n"// &
-       " VR12-MA       - Applies an enhancement factor to the KPP\n"//&
-       "                 turbulent velocity scale received from \n"// &
-       "                 WW3 and is based on the surface layer \n"//  &
-       "                 and projected Langmuir number. (Li 2016)\n", &
+       " EFACTOR       - Applies an enhancement factor to the KPP\n"//&
+       "                 turbulent velocity scale received \n"//      &
+       "                 directly from WW3 and is based on the \n"//  &
+       "                 surface layer and projected Langmuir \n"//   &
+       "                 number (Li 2016)\n", &
        units='', default=NULL_STRING)
   select case (TRIM(TMPSTRING1))
   case (NULL_STRING)! No Waves
@@ -390,8 +391,8 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag )
           default=.false.)
   case (LF17_STRING)!Li and Fox-Kemper 17 wind-sea Langmuir number
     CS%WaveMethod = LF17
-  case (VR12MA_STRING)!Li and Fox-Kemper 16
-    CS%WaveMethod = VR12MA
+  case (EFACTOR_STRING)!Li and Fox-Kemper 16
+    CS%WaveMethod = EFACTOR
   case default
     call MOM_error(FATAL,'Check WAVE_METHOD.')
   end select
@@ -770,8 +771,8 @@ subroutine Update_Stokes_Drift(G, GV, US, CS, h, ustar)
       enddo
       CS%DHH85_is_set = .true.
     endif
-  elseif (CS%WaveMethod==VR12MA) then
-    return ! todo
+  elseif (CS%WaveMethod==EFACTOR) then
+    return ! pass
   else! Keep this else, fallback to 0 Stokes drift
     do kk= 1,GV%ke
       do jj = G%jsd,G%jed
@@ -1075,8 +1076,8 @@ function get_wave_method(CS)
         get_wave_method = DHH85_STRING
       case (LF17)
         get_wave_method = LF17_STRING
-      case (VR12MA)
-        get_wave_method = VR12MA_STRING
+      case (EFACTOR)
+        get_wave_method = EFACTOR_STRING
     end select
   else
     get_wave_method = NULL_STRING


### PR DESCRIPTION
This PR introduces the legacy OCN+WAV coupling approach of CESM to MOM6 (via nuopc cap only). The approach is based on receiving an enhancement factor directly from WW3 and passing it to CVMix (Li et al. 2016). In addition to this new wave coupling method, which is activated by setting WAVE_METHOD = "EFACTOR", the KPP CVMix module has also been refactored such that: (1) When the enhancement factor is not received from WW3, we let CVmix compute the enhancement factor for the existing wave method options as well. (2) Instead of explicitly multiplying diffusivities and viscosities with the enhancement factor, we let CVMix handle enhancement internally.

Tests: aux_mom.cheyenne b4b