### PR TITLE
ensure consistent budgets on diagnostic grids

### DIFF
--- a/src/ALE/MOM_ALE.F90
+++ b/src/ALE/MOM_ALE.F90
@@ -13,7 +13,7 @@ module MOM_ALE
 use MOM_debugging,        only : check_column_integrals
 use MOM_diag_mediator,    only : register_diag_field, post_data, diag_ctrl
 use MOM_diag_mediator,    only : time_type, diag_update_remap_grids
-use MOM_diag_mediator,    only : diag_store_h_extensive
+use MOM_diag_mediator,    only : diag_store_h_extensive, post_data_tend
 use MOM_diag_vkernels,    only : interpolate_column, reintegrate_column
 use MOM_domains,          only : create_group_pass, do_group_pass, group_pass_type
 use MOM_EOS,              only : calculate_density
@@ -925,11 +925,8 @@ subroutine remap_all_state_vars(CS_remapping, CS_ALE, G, GV, h_old, h_new, Reg, 
     h_extensive_prev_ind = 1
     call diag_update_remap_grids(CS_ALE%diag, update_intensive = .false., update_extensive = .true.)
 
-    do k = 1, nz ; do j = G%jsc,G%jec ; do i = G%isc,G%iec
-      work_cont(i,j,k) = (h_new(i,j,k) - h_old(i,j,k))*Idt
-    enddo ; enddo ; enddo
-    call post_data(CS_ALE%id_vert_remap_h_tendency, dt, work_cont, h_new, h_old, h_new, &
-                   h_extensive_prev_ind, CS_ALE%diag)
+    call post_data_tend(CS_ALE%id_vert_remap_h_tendency, dt, h_new, h_old, h_new, &
+                        h_extensive_prev_ind, CS_ALE%diag, field_prev=h_old)
 
     call diag_store_h_extensive(CS_ALE%diag, h_extensive_prev_ind)
   endif

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -39,6 +39,7 @@ implicit none ; private
 #define MAX_DSAMP_LEV 2
 
 public set_axes_info, post_data, register_diag_field, time_type
+public post_data_tend
 public set_masks_for_axes
 public post_data_1d_k
 public safe_alloc_ptr, safe_alloc_alloc
@@ -61,7 +62,7 @@ public found_in_diagtable
 
 !> Make a diagnostic available for averaging or output.
 interface post_data
-  module procedure post_data_3d, post_data_3d_tend, post_data_2d, post_data_1d_k, post_data_0d
+  module procedure post_data_3d, post_data_2d, post_data_1d_k, post_data_0d
 end interface post_data
 
 !> Down sample a field
@@ -497,7 +498,7 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
 
     ! Allocate these arrays since the size of the diagnostic array is now known
     allocate(diag_cs%diag_remap_cs(i)%h(G%isd:G%ied,G%jsd:G%jed, diag_cs%diag_remap_cs(i)%nz))
-    allocate(diag_cs%diag_remap_cs(i)%h_extensive_prev(2, G%isd:G%ied,G%jsd:G%jed, diag_cs%diag_remap_cs(i)%nz))
+    allocate(diag_cs%diag_remap_cs(i)%h_extensive_prev(G%isd:G%ied,G%jsd:G%jed, diag_cs%diag_remap_cs(i)%nz, 2))
     allocate(diag_cs%diag_remap_cs(i)%h_extensive(G%isd:G%ied,G%jsd:G%jed, diag_cs%diag_remap_cs(i)%nz))
 
     ! This vertical coordinate has been configured so can be used.
@@ -1338,6 +1339,58 @@ subroutine post_data_1d_k(diag_field_id, field, diag_cs, is_static)
   if (id_clock_diag_mediator>0) call cpu_clock_end(id_clock_diag_mediator)
 end subroutine post_data_1d_k
 
+!> Get the diagnostics-compute indices (to be passed to send_data)
+!! based on the shape of the diag field
+subroutine diag_indices_get(caller, fo1, fo2, diag_cs, isv, iev, jsv, jev)
+  character(len=*),  intent(in)  :: caller  !< name of calling subroutine
+  integer,           intent(in)  :: fo1     !< The size of the diag field in x
+  integer,           intent(in)  :: fo2     !< The size of the diag field in y
+  type(diag_ctrl),   intent(in)  :: diag_CS !< Structure used to regulate diagnostic output
+  integer,           intent(out) :: isv     !< i-start index for diagnostics
+  integer,           intent(out) :: iev     !< i-end index for diagnostics
+  integer,           intent(out) :: jsv     !< j-start index for diagnostics
+  integer,           intent(out) :: jev     !< j-end index for diagnostics
+  ! Local variables
+  integer :: dszi,cszi,dszj,cszj
+  character(len=500) :: mesg
+
+  ! Determine the proper array indices, noting that because of the (:,:)
+  ! declaration of field, symmetric arrays are using a SW-grid indexing,
+  ! but non-symmetric arrays are using a NE-grid indexing.  Send_data
+  ! actually only uses the difference between ie and is to determine
+  ! the output data size and assumes that halos are symmetric.
+
+  cszi = diag_cs%ie-diag_cs%is +1 ; dszi = diag_cs%ied-diag_cs%isd +1
+  if ( fo1 == dszi ) then
+    isv = diag_cs%is ; iev = diag_cs%ie     ! Data domain
+  elseif ( fo1 == dszi + 1 ) then
+    isv = diag_cs%is ; iev = diag_cs%ie+1   ! Symmetric data domain
+  elseif ( fo1 == cszi) then
+    isv = 1 ; iev = cszi                    ! Computational domain
+  elseif ( fo1 == cszi + 1 ) then
+    isv = 1 ; iev = cszi+1                  ! Symmetric computational domain
+  else
+    write (mesg,*) " peculiar size ",fo1," in i-direction\n"//&
+          "does not match one of ", cszi, cszi+1, dszi, dszi+1
+    call MOM_error(FATAL,trim(caller)//":diag_indices_get: "//trim(mesg))
+  endif
+
+  cszj = diag_cs%je-diag_cs%js +1 ; dszj = diag_cs%jed-diag_cs%jsd +1
+  if ( fo2 == dszj ) then
+    jsv = diag_cs%js ; jev = diag_cs%je     ! Data domain
+  elseif ( fo2 == dszj + 1 ) then
+    jsv = diag_cs%js ; jev = diag_cs%je+1   ! Symmetric data domain
+  elseif ( fo2 == cszj ) then
+    jsv = 1 ; jev = cszj                    ! Computational domain
+  elseif ( fo2 == cszj+1 ) then
+    jsv = 1 ; jev = cszj+1                  ! Symmetric computational domain
+  else
+    write (mesg,*) " peculiar size ",fo2," in j-direction\n"//&
+          "does not match one of ", cszj, cszj+1, dszj, dszj+1
+    call MOM_error(FATAL,trim(caller)//":diag_indices_get: "//trim(mesg))
+  endif
+end subroutine diag_indices_get
+
 !> Make a real 2-d array diagnostic available for averaging or output
 subroutine post_data_2d(diag_field_id, field, diag_cs, is_static, mask)
   integer,           intent(in) :: diag_field_id !< The id for an output variable returned by a
@@ -1378,7 +1431,6 @@ subroutine post_data_2d_low(diag, field, diag_cs, is_static, mask)
   real, dimension(:,:), pointer :: locmask
   character(len=300) :: mesg
   logical :: used, is_stat
-  integer :: cszi, cszj, dszi, dszj
   integer :: isv, iev, jsv, jev, i, j, chksum, isv_o,jsv_o
   real, dimension(:,:), allocatable, target :: locfield_dsamp
   real, dimension(:,:), allocatable, target :: locmask_dsamp
@@ -1388,42 +1440,8 @@ subroutine post_data_2d_low(diag, field, diag_cs, is_static, mask)
   locmask => NULL()
   is_stat = .false. ; if (present(is_static)) is_stat = is_static
 
-  ! Determine the propery array indices, noting that because of the (:,:)
-  ! declaration of field, symmetric arrays are using a SW-grid indexing,
-  ! but non-symmetric arrays are using a NE-grid indexing.  Send_data
-  ! actually only uses the difference between ie and is to determine
-  ! the output data size and assumes that halos are symmetric.
-  isv = diag_cs%is ; iev = diag_cs%ie ; jsv = diag_cs%js ; jev = diag_cs%je
-
-  cszi = diag_cs%ie-diag_cs%is +1 ; dszi = diag_cs%ied-diag_cs%isd +1
-  cszj = diag_cs%je-diag_cs%js +1 ; dszj = diag_cs%jed-diag_cs%jsd +1
-  if ( size(field,1) == dszi ) then
-    isv = diag_cs%is ; iev = diag_cs%ie     ! Data domain
-  elseif ( size(field,1) == dszi + 1 ) then
-    isv = diag_cs%is ; iev = diag_cs%ie+1   ! Symmetric data domain
-  elseif ( size(field,1) == cszi) then
-    isv = 1 ; iev = cszi                    ! Computational domain
-  elseif ( size(field,1) == cszi + 1 ) then
-    isv = 1 ; iev = cszi+1                  ! Symmetric computational domain
-  else
-    write (mesg,*) " peculiar size ",size(field,1)," in i-direction\n"//&
-       "does not match one of ", cszi, cszi+1, dszi, dszi+1
-    call MOM_error(FATAL,"post_data_2d_low: "//trim(diag%debug_str)//trim(mesg))
-  endif
-
-  if ( size(field,2) == dszj ) then
-    jsv = diag_cs%js ; jev = diag_cs%je     ! Data domain
-  elseif ( size(field,2) == dszj + 1 ) then
-    jsv = diag_cs%js ; jev = diag_cs%je+1   ! Symmetric data domain
-  elseif ( size(field,2) == cszj ) then
-    jsv = 1 ; jev = cszj                    ! Computational domain
-  elseif ( size(field,2) == cszj+1 ) then
-    jsv = 1 ; jev = cszj+1                  ! Symmetric computational domain
-  else
-    write (mesg,*) " peculiar size ",size(field,2)," in j-direction\n"//&
-       "does not match one of ", cszj, cszj+1, dszj, dszj+1
-    call MOM_error(FATAL,"post_data_2d_low: "//trim(diag%debug_str)//trim(mesg))
-  endif
+  call diag_indices_get(trim(diag%debug_str)//":post_data_2d_low", size(field,1), size(field,2), &
+                        diag_cs, isv, iev, jsv, jev)
 
   if ((diag%conversion_factor /= 0.) .and. (diag%conversion_factor /= 1.)) then
     allocate( locfield( lbound(field,1):ubound(field,1), lbound(field,2):ubound(field,2) ) )
@@ -1632,49 +1650,73 @@ subroutine post_data_3d(diag_field_id, field, diag_cs, is_static, mask, alt_h)
 end subroutine post_data_3d
 
 !> Make a real 3-d array tendency diagnostic available for averaging or output.
-subroutine post_data_3d_tend(diag_field_id, dt, field_tend, field_new, &
-                             h_prev, h_new, h_extensive_prev_ind, diag_cs, is_static, mask)
+!! At least one of field_tend and field_prev must be provided.
+subroutine post_data_tend(diag_field_id, dt, field_new, h_prev, h_new, h_extensive_prev_ind, &
+                          diag_cs, field_tend, field_prev, mask)
 
-  integer,           intent(in) :: diag_field_id !< The id for an output variable returned by a
-                                                 !! previous call to register_diag_field.
-  real,              intent(in) :: dt                !< duration of time interval that field_tend is over
-  real,              intent(in) :: field_tend(:,:,:) !< tendency of field on model vertical grid
-  real,              intent(in) :: field_new(:,:,:)  !< updated field after field_tend is applied
-  real,              intent(in) :: h_prev(:,:,:)     !< model layer thicknesses before tendency was applied
-  real,              intent(in) :: h_new(:,:,:)      !< model layer thicknesses after tendency was applied
-  integer,           intent(in) :: h_extensive_prev_ind !< value to use for 1st index of h_extensive_prev
-  type(diag_ctrl), target, intent(in) :: diag_CS     !< Structure used to regulate diagnostic output
-  logical, optional, intent(in) :: is_static         !< If true, this is a static field that is always offered.
-  real,    optional, intent(in) :: mask(:,:,:)       !< If present, use this real array as the data mask.
+  integer,                 intent(in) :: diag_field_id        !< The id for an output variable returned by a
+                                                              !! previous call to register_diag_field.
+  real,                    intent(in) :: dt                   !< duration of time interval that field_tend is over
+  real,                    intent(in) :: field_new(:,:,:)     !< field after tendency was applied
+  real,                    intent(in) :: h_prev(:,:,:)        !< model layer thicknesses before tendency was applied
+  real,                    intent(in) :: h_new(:,:,:)         !< model layer thicknesses after tendency was applied
+  integer,                 intent(in) :: h_extensive_prev_ind !< value to use for last index of h_extensive_prev
+  type(diag_ctrl), target, intent(in) :: diag_cs              !< Structure used to regulate diagnostic output
+  real,  target, optional, intent(in) :: field_tend(:,:,:)    !< tendency of field (on model vertical grid)
+  real,  target, optional, intent(in) :: field_prev(:,:,:)    !< field before tendency was applied
+  real,          optional, intent(in) :: mask(:,:,:)          !< If present, use this real array as the data mask.
 
   ! Local variables
   type(diag_type), pointer :: diag => null()
-  integer :: nz, i, j, k
-  real, dimension(:,:,:), allocatable :: remapped_field_tend
+  integer :: isv, iev, jsv, jev, i, j, k
   logical :: staggered_in_x, staggered_in_y
   real :: Idt
+  real, dimension(:,:,:), pointer :: field_prev_ptr ! if field_prev present, points to field_prev,
+    ! else points to space allocated for the computation of field_prev
+  real, dimension(:,:,:), pointer :: field_tend_ptr ! if field_tend present, points to field_tend,
+    ! else points to space allocated for the computation of field_tend
+  real, dimension(:,:,:,:), allocatable :: remapped_field_work ! space for construction of remapped tendency
 
   ! Tendencies on diagnostic grids are defined as
-  ! d field / dt = Idt * (L_new(field_new) - L_prev(field_prev)),
+  ! d field / dt := Idt * (L_new(field_new) - L_prev(field_prev)),
   ! where L_new and L_prev are operators that remap from the model grid to diagnostic grids,
-  ! based on model thicknesses h_new and h_prev respectively. This tendency is computed as
-  ! d field / dt = Idt * (L_new(field_new) - L_prev(field_prev))
-  !   = Idt * (L_new(field_new) + L_prev(field_new - field_prev) - L_prev(field_new))
-  !   = L_prev(Idt * (field_new - field_prev)) + Idt * (L_new(field_new) - L_prev(field_new))
-  !   = L_prev(field_tend) + Idt * (L_new(field_new) - L_prev(field_new))
-  ! These algebraic manipulations assume that the remapping operators are linear.
+  ! based on model thicknesses h_new and h_prev respectively.
+  ! If field_tend is provided instead of field_prev, then field_prev is computed from
+  ! field_new and field_tend.
 
   if (id_clock_diag_mediator>0) call cpu_clock_begin(id_clock_diag_mediator)
+
+  call diag_indices_get("post_data_tend", size(field_new,1), size(field_new,2), diag_cs, &
+                        isv, iev, jsv, jev)
+
+  ! Ensure that at least one of field_tend and field_prev are provided.
+  call assert(present(field_tend) .or. present(field_prev), &
+              "post_data_tend: At least one of field_tend and field_prev must be provided.")
+
+  ! Ensure field arrays have same shape.
+  if (present(field_tend)) then
+    call assert(all(shape(field_tend) == shape(field_new)), &
+                "post_data_tend: field_tend and field_new shapes differ")
+  else
+    call assert(all(shape(field_prev) == shape(field_new)), &
+                "post_data_tend: field_prev and field_new shapes differ")
+  endif
+
+  field_prev_ptr => NULL()
+  if (present(field_prev)) field_prev_ptr => field_prev
+
+  field_tend_ptr => NULL()
+  if (present(field_tend)) field_tend_ptr => field_tend
 
   Idt = 1.0 / dt
 
   ! Iterate over list of diag 'variants', e.g. CMOR aliases, different vertical
   ! grids, and post each.
   call assert(diag_field_id < diag_cs%next_free_diag_id, &
-              'post_data_3d_tend: Unregistered diagnostic id')
+              'post_data_tend: Unregistered diagnostic id')
   diag => diag_cs%diags(diag_field_id)
   do while (associated(diag))
-    call assert(associated(diag%axes), 'post_data_3d_tend: axes is not associated')
+    call assert(associated(diag%axes), 'post_data_tend: axes is not associated')
 
     staggered_in_x = diag%axes%is_u_point .or. diag%axes%is_q_point
     staggered_in_y = diag%axes%is_v_point .or. diag%axes%is_q_point
@@ -1682,60 +1724,79 @@ subroutine post_data_3d_tend(diag_field_id, dt, field_tend, field_new, &
     if (diag%v_extensive .and. .not.diag%axes%is_native) then
       ! The field is vertically integrated and needs to be re-gridded
       if (present(mask)) then
-        call MOM_error(FATAL,"post_data_3d_tend: no mask for regridded field.")
+        call MOM_error(FATAL,"post_data_tend: no mask for regridded field.")
+      endif
+
+      ! Setup field_prev_ptr if needed
+      if (.not. associated(field_prev_ptr)) then
+        allocate(field_prev_ptr(size(field_new,1), size(field_new,2), size(field_new,3)))
+        do k=1,size(field_new,3) ; do j=jsv,jev ; do i=isv,iev
+          field_prev_ptr(i,j,k) = field_new(i,j,k) - dt * field_tend(i,j,k)
+        enddo ; enddo ; enddo
       endif
 
       if (id_clock_diag_remap>0) call cpu_clock_begin(id_clock_diag_remap)
-      allocate(remapped_field_tend(size(field_tend,1), size(field_tend,2), diag%axes%nz))
-      call vertically_reintegrate_diag_field(                                           &
-        diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), diag_cs%G, h_prev, &
-        diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number)%h_extensive_prev(h_extensive_prev_ind,:,:,:), &
-        staggered_in_x, staggered_in_y, diag%axes%mask3d, field_tend,             &
-        remapped_field_tend)
+      allocate(remapped_field_work(size(field_new,1), size(field_new,2), diag%axes%nz, 2))
       call vertically_reintegrate_diag_field(                                          &
         diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), diag_cs%G, h_new, &
         diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number)%h_extensive,       &
         staggered_in_x, staggered_in_y, diag%axes%mask3d, field_new,                   &
-        remapped_field_tend, increment=.true., increment_scale=Idt)
+        remapped_field_work(:,:,:,1))
       call vertically_reintegrate_diag_field(                                           &
         diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number), diag_cs%G, h_prev, &
-        diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number)%h_extensive_prev(h_extensive_prev_ind,:,:,:), &
-        staggered_in_x, staggered_in_y, diag%axes%mask3d, field_new,                    &
-        remapped_field_tend, increment=.true., increment_scale=-Idt)
+        diag_cs%diag_remap_cs(diag%axes%vertical_coordinate_number)%h_extensive_prev(:,:,:,h_extensive_prev_ind), &
+        staggered_in_x, staggered_in_y, diag%axes%mask3d, field_prev_ptr,               &
+        remapped_field_work(:,:,:,2))
+      do k=1,diag%axes%nz ; do j=jsv,jev ; do i=isv,iev
+        remapped_field_work(i,j,k,1) = Idt * (remapped_field_work(i,j,k,1) - remapped_field_work(i,j,k,2))
+      enddo ; enddo ; enddo
       if (id_clock_diag_remap>0) call cpu_clock_end(id_clock_diag_remap)
       if (associated(diag%axes%mask3d)) then
         ! Since 3d masks do not vary in the vertical, just use as much as is
         ! needed.
-        call post_data_3d_low(diag, remapped_field_tend, diag_cs, is_static, &
-                              mask=diag%axes%mask3d)
+        call post_data_3d_low(diag, remapped_field_work(:,:,:,1), diag_cs, mask=diag%axes%mask3d)
       else
-        call post_data_3d_low(diag, remapped_field_tend, diag_cs, is_static)
+        call post_data_3d_low(diag, remapped_field_work(:,:,:,1), diag_cs)
       endif
       if (id_clock_diag_remap>0) call cpu_clock_begin(id_clock_diag_remap)
-      deallocate(remapped_field_tend)
+      deallocate(remapped_field_work)
       if (id_clock_diag_remap>0) call cpu_clock_end(id_clock_diag_remap)
     elseif (diag%axes%needs_remapping) then
       ! Remap this field to another vertical coordinate.
       if (present(mask)) then
-        call MOM_error(FATAL,"post_data_3d_tend: no mask for regridded field.")
+        call MOM_error(FATAL,"post_data_tend: no mask for regridded field.")
       endif
 
-      call MOM_error(FATAL,"post_data_3d_tend: not implemented for needs_remapping.")
+      call MOM_error(FATAL,"post_data_tend: not implemented for needs_remapping.")
     elseif (diag%axes%needs_interpolating) then
       ! Interpolate this field to another vertical coordinate.
       if (present(mask)) then
-        call MOM_error(FATAL,"post_data_3d_tend: no mask for regridded field.")
+        call MOM_error(FATAL,"post_data_tend: no mask for regridded field.")
       endif
 
-      call MOM_error(FATAL,"post_data_3d_tend: not implemented for needs_interpolating.")
+      call MOM_error(FATAL,"post_data_tend: not implemented for needs_interpolating.")
     else
-      call post_data_3d_low(diag, field_tend, diag_cs, is_static, mask)
+      ! Setup field_tend_ptr if needed
+      if (.not. associated(field_tend_ptr)) then
+        allocate(field_tend_ptr(size(field_new,1), size(field_new,2), size(field_new,3)))
+        do k=1,size(field_new,3) ; do j=jsv,jev ; do i=isv,iev
+          field_tend_ptr(i,j,k) = Idt * (field_new(i,j,k) - field_prev(i,j,k))
+        enddo ; enddo ; enddo
+      endif
+
+      call post_data_3d_low(diag, field_tend_ptr, diag_cs, mask=mask)
     endif
     diag => diag%next
   enddo
+
+  if (associated(field_prev_ptr) .and. .not. associated(field_prev_ptr, field_prev)) &
+    deallocate(field_prev_ptr)
+  if (associated(field_tend_ptr) .and. .not. associated(field_tend_ptr, field_tend)) &
+    deallocate(field_tend_ptr)
+
   if (id_clock_diag_mediator>0) call cpu_clock_end(id_clock_diag_mediator)
 
-end subroutine post_data_3d_tend
+end subroutine post_data_tend
 
 !> Make a real 3-d array diagnostic available for averaging or output
 !! using a diag_type instead of an integer id.
@@ -1753,7 +1814,6 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
   logical :: used  ! The return value of send_data is not used for anything.
   logical :: staggered_in_x, staggered_in_y
   logical :: is_stat
-  integer :: cszi, cszj, dszi, dszj
   integer :: isv, iev, jsv, jev, ks, ke, i, j, k, isv_c, jsv_c, isv_o,jsv_o
   integer :: chksum
   real, dimension(:,:,:), allocatable, target :: locfield_dsamp
@@ -1764,42 +1824,8 @@ subroutine post_data_3d_low(diag, field, diag_cs, is_static, mask)
   locmask => NULL()
   is_stat = .false. ; if (present(is_static)) is_stat = is_static
 
-  ! Determine the proper array indices, noting that because of the (:,:)
-  ! declaration of field, symmetric arrays are using a SW-grid indexing,
-  ! but non-symmetric arrays are using a NE-grid indexing.  Send_data
-  ! actually only uses the difference between ie and is to determine
-  ! the output data size and assumes that halos are symmetric.
-  isv = diag_cs%is ; iev = diag_cs%ie ; jsv = diag_cs%js ; jev = diag_cs%je
-
-  cszi = (diag_cs%ie-diag_cs%is) +1 ; dszi = (diag_cs%ied-diag_cs%isd) +1
-  cszj = (diag_cs%je-diag_cs%js) +1 ; dszj = (diag_cs%jed-diag_cs%jsd) +1
-  if ( size(field,1) == dszi ) then
-    isv = diag_cs%is ; iev = diag_cs%ie     ! Data domain
-  elseif ( size(field,1) == dszi + 1 ) then
-    isv = diag_cs%is ; iev = diag_cs%ie+1   ! Symmetric data domain
-  elseif ( size(field,1) == cszi) then
-    isv = 1 ; iev = cszi                    ! Computational domain
-  elseif ( size(field,1) == cszi + 1 ) then
-    isv = 1 ; iev = cszi+1                  ! Symmetric computational domain
-  else
-    write (mesg,*) " peculiar size ",size(field,1)," in i-direction\n"//&
-       "does not match one of ", cszi, cszi+1, dszi, dszi+1
-    call MOM_error(FATAL,"post_data_3d_low: "//trim(diag%debug_str)//trim(mesg))
-  endif
-
-  if ( size(field,2) == dszj ) then
-    jsv = diag_cs%js ; jev = diag_cs%je     ! Data domain
-  elseif ( size(field,2) == dszj + 1 ) then
-    jsv = diag_cs%js ; jev = diag_cs%je+1   ! Symmetric data domain
-  elseif ( size(field,2) == cszj ) then
-    jsv = 1 ; jev = cszj                    ! Computational domain
-  elseif ( size(field,2) == cszj+1 ) then
-    jsv = 1 ; jev = cszj+1                  ! Symmetric computational domain
-  else
-    write (mesg,*) " peculiar size ",size(field,2)," in j-direction\n"//&
-       "does not match one of ", cszj, cszj+1, dszj, dszj+1
-    call MOM_error(FATAL,"post_data_3d_low: "//trim(diag%debug_str)//trim(mesg))
-  endif
+  call diag_indices_get(trim(diag%debug_str)//":post_data_3d_low", size(field,1), size(field,2), &
+                        diag_cs, isv, iev, jsv, jev)
 
   ks = lbound(field,3) ; ke = ubound(field,3)
   if ((diag%conversion_factor /= 0.) .and. (diag%conversion_factor /= 1.)) then
@@ -3437,13 +3463,13 @@ end subroutine diag_update_remap_grids
 !> Store extensive thicknesses on diagnostic grids
 subroutine diag_store_h_extensive(diag_cs, h_extensive_prev_ind)
   type(diag_ctrl),  intent(inout) :: diag_cs                !< Diagnostics control structure
-  integer,             intent(in) :: h_extensive_prev_ind   !< value to use for 1st index of h_extensive_prev
+  integer,             intent(in) :: h_extensive_prev_ind   !< value to use for last index of h_extensive_prev
 
   ! Local variables
   integer :: i
 
   do i=1, diag_cs%num_diag_coords
-    diag_cs%diag_remap_cs(i)%h_extensive_prev(h_extensive_prev_ind,:,:,:) = &
+    diag_cs%diag_remap_cs(i)%h_extensive_prev(:,:,:,h_extensive_prev_ind) = &
       diag_cs%diag_remap_cs(i)%h_extensive(:,:,:)
   enddo
 

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -113,8 +113,8 @@ type :: diag_remap_ctrl
   real, dimension(:,:,:), allocatable :: h !< Remap grid thicknesses [H ~> m or kg m-2]
   real, dimension(:,:,:,:), allocatable :: h_extensive_prev !< Remap grid thicknesses from previous
                                            !! timelevels for extensive variables [H ~> m or kg m-2]
-    !! first index=1 => thickness from before a process is applied
-    !! first index=2 => thickness from beginning of thermodynamic timestep
+    !! last index=1 => thickness from before a process is applied
+    !! last index=2 => thickness from beginning of thermodynamic timestep
   real, dimension(:,:,:), allocatable :: h_extensive !< Remap grid thicknesses for extensive
                                            !! variables [H ~> m or kg m-2]
   integer :: interface_axes_id = 0 !< Vertical axes id for remapping at interfaces
@@ -492,8 +492,7 @@ end subroutine diag_remap_calc_hmask
 
 !> Vertically re-grid an already vertically-integrated diagnostic field to alternative vertical grid.
 subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered_in_x, staggered_in_y, &
-                                             mask, field, reintegrated_field, &
-                                             increment, increment_scale)
+                                             mask, field, reintegrated_field)
   type(diag_remap_ctrl),  intent(in) :: remap_cs !< Diagnostic coodinate control structure
   type(ocean_grid_type),  intent(in) :: G        !< Ocean grid structure
   real, dimension(:,:,:), intent(in) :: h        !< The thicknesses of the source grid [H ~> m or kg m-2]
@@ -503,13 +502,7 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered
   real, dimension(:,:,:), pointer    :: mask     !< A mask for the field [nondim]
   real, dimension(:,:,:), intent(in) :: field    !<  The diagnostic field to be remapped [A]
   real, dimension(:,:,:), intent(inout) :: reintegrated_field !< Field argument remapped to alternative coordinate [A]
-  logical, optional,      intent(in) :: increment !< if present and .true., add, instead of assigning,
-                                                  !< computed result to reintegrated_field
-  real, optional,         intent(in) :: increment_scale !< scaling to apply to computed result
-                                                        !< when increment=.true.
   ! Local variables
-  real, dimension(remap_cs%nz) :: reintegrated_temp ! temp location for computed result,
-                                                    ! used if increment=.true.
   real, dimension(remap_cs%nz) :: h_dest ! Destination thicknesses [H ~> m or kg m-2]
   real, dimension(size(h,3)) :: h_src    ! A column of source thicknesses [H ~> m or kg m-2]
   integer :: nz_src, nz_dest
@@ -517,8 +510,6 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered
   integer :: i1, j1                 !< 1-based index
   integer :: i_lo, i_hi, j_lo, j_hi !< (uv->h) interpolation indices
   integer :: shift                  !< Symmetric offset for 1-based indexing
-  logical :: increment_local
-  real :: increment_scale_local
 
   call assert(remap_cs%initialized, 'vertically_reintegrate_diag_field: remap_cs not initialized.')
   call assert(size(field, 3) == size(h, 3), &
@@ -526,16 +517,7 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered
 
   nz_src = size(field,3)
   nz_dest = remap_cs%nz
-
-  increment_local = .false.
-  if (present(increment)) increment_local = increment
-
-  if (.not. increment_local) then
-    reintegrated_field(:,:,:) = 0.
-  else
-    increment_scale_local = 1.0
-    if (present(increment_scale)) increment_scale_local = increment_scale
-  endif
+  reintegrated_field(:,:,:) = 0.
 
   ! Symmetric grid offset under 1-based indexing; see header for details.
   shift = 0 ; if (G%symmetric) shift = 1
@@ -551,15 +533,8 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered
         endif
         h_src(:) = 0.5 * (h(i_lo,j,:) + h(i_hi,j,:))
         h_dest(:) = 0.5 * (h_target(i_lo,j,:) + h_target(i_hi,j,:))
-        if (.not. increment_local) then
-          call reintegrate_column(nz_src, h_src, field(I1,j,:), &
-                                  nz_dest, h_dest, 0., reintegrated_field(I1,j,:))
-        else
-          call reintegrate_column(nz_src, h_src, field(I1,j,:), &
-                                  nz_dest, h_dest, 0., reintegrated_temp(:))
-          reintegrated_field(I1,j,:) = reintegrated_field(I1,j,:) &
-            + increment_scale_local * reintegrated_temp(:)
-        endif
+        call reintegrate_column(nz_src, h_src, field(I1,j,:), &
+                                nz_dest, h_dest, 0., reintegrated_field(I1,j,:))
       enddo
     enddo
   elseif (staggered_in_y .and. .not. staggered_in_x) then
@@ -573,15 +548,8 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered
         endif
         h_src(:) = 0.5 * (h(i,j_lo,:) + h(i,j_hi,:))
         h_dest(:) = 0.5 * (h_target(i,j_lo,:) + h_target(i,j_hi,:))
-        if (.not. increment_local) then
-          call reintegrate_column(nz_src, h_src, field(i,J1,:), &
-                                  nz_dest, h_dest, 0., reintegrated_field(i,J1,:))
-        else
-          call reintegrate_column(nz_src, h_src, field(i,J1,:), &
-                                  nz_dest, h_dest, 0., reintegrated_temp(:))
-          reintegrated_field(i,J1,:) = reintegrated_field(i,J1,:) &
-            + increment_scale_local * reintegrated_temp(:)
-        endif
+        call reintegrate_column(nz_src, h_src, field(i,J1,:), &
+                                nz_dest, h_dest, 0., reintegrated_field(i,J1,:))
       enddo
     enddo
   elseif ((.not. staggered_in_x) .and. (.not. staggered_in_y)) then
@@ -593,15 +561,8 @@ subroutine vertically_reintegrate_diag_field(remap_cs, G, h, h_target, staggered
         endif
         h_src(:) = h(i,j,:)
         h_dest(:) = h_target(i,j,:)
-        if (.not. increment_local) then
-          call reintegrate_column(nz_src, h_src, field(i,j,:), &
-                                  nz_dest, h_dest, 0., reintegrated_field(i,j,:))
-        else
-          call reintegrate_column(nz_src, h_src, field(i,j,:), &
-                                  nz_dest, h_dest, 0., reintegrated_temp(:))
-          reintegrated_field(i,j,:) = reintegrated_field(i,j,:) &
-            + increment_scale_local * reintegrated_temp(:)
-        endif
+        call reintegrate_column(nz_src, h_src, field(i,j,:), &
+                                nz_dest, h_dest, 0., reintegrated_field(i,j,:))
       enddo
     enddo
   else

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -224,7 +224,10 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
                  units="m", default=-9999.0, scale=m_to_Z)
   if (mask_depth == -9999.*m_to_Z) mask_depth = min_depth
 
-  if (len_trim(topo_edits_file)==0) return
+  if (len_trim(topo_edits_file)==0) then
+    call callTree_leave(trim(mdl)//'()')
+    return
+  endif
 
   topo_edits_file = trim(inputdir)//trim(topo_edits_file)
   if (is_root_PE()) then

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -20,7 +20,7 @@ use MOM_diag_mediator,       only : diag_ctrl, query_averaging_enabled, enable_a
 use MOM_diag_mediator,       only : diag_grid_storage, diag_grid_storage_init, diag_grid_storage_end
 use MOM_diag_mediator,       only : diag_copy_diag_to_storage, diag_copy_storage_to_diag
 use MOM_diag_mediator,       only : diag_save_grids, diag_restore_grids
-use MOM_diag_mediator,       only : diag_store_h_extensive
+use MOM_diag_mediator,       only : diag_store_h_extensive, post_data_tend
 use MOM_diapyc_energy_req,   only : diapyc_energy_req_init, diapyc_energy_req_end
 use MOM_diapyc_energy_req,   only : diapyc_energy_req_calc, diapyc_energy_req_test, diapyc_energy_req_CS
 use MOM_CVMix_conv,          only : CVMix_conv_init, CVMix_conv_cs
@@ -2693,11 +2693,8 @@ subroutine diagnose_boundary_forcing_tendency(tv, h, temp_old, saln_old, h_old, 
 
   ! Thickness tendency
   if (CS%id_boundary_forcing_h_tendency > 0) then
-    do k=1,nz ; do j=js,je ; do i=is,ie
-      work_3d(i,j,k) = (h(i,j,k) - h_old(i,j,k))*Idt
-    enddo ; enddo ; enddo
-    call post_data(CS%id_boundary_forcing_h_tendency, dt, work_3d, h, h_old, h, &
-                   h_extensive_prev_ind, CS%diag)
+    call post_data_tend(CS%id_boundary_forcing_h_tendency, dt, h, h_old, h, &
+                        h_extensive_prev_ind, CS%diag, field_prev=h_old)
   endif
 
   ! temperature tendency


### PR DESCRIPTION
initial commit, for thickness budget terms

ensures that the following hold, up to roundoff, on non-native grids

1. `dhdt = dynamics_h_tendency + vert_remap_h_tendency + boundary_forcing_h_tendency`
2. change in `h`, from snapshot output, matches time-integrated `dhdt`

also adds `callTree_leave` call for early return from `apply_topography_edits_from_file`

Background: [MOM6_budget.pdf](https://github.com/NCAR/MOM6/files/7637450/MOM6_budget.pdf)

Caveat: This code changes answers for remapped `h` tendency terms. Support for recovering existing remapped `h` tendency terms is not yet implemented.

