### PR TITLE
Option to provide enthalpy fluxes via NUOPC coupler

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap_methods.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_methods.F90
@@ -217,17 +217,53 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
        isc, iec, jsc, jec, ice_ocean_boundary%frunoff, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-  ! heat content of lrunoff
-  ice_ocean_boundary%lrunoff_hflx(:,:) = 0._ESMF_KIND_R8
-  call state_getimport(importState, 'mean_runoff_heat_flx',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%lrunoff_hflx, areacor=med2mod_areacor, rc=rc)
-  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  !----
+  ! Enthalpy terms (only in CESM)
+  !----
+  if (cesm_coupled) then
+    !----
+    ! enthalpy from liquid precipitation (hrain)
+    !----
+    call state_getimport(importState, 'heat_content_lprec', &
+         isc, iec, jsc, jec, ice_ocean_boundary%hrain, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-  ! heat content of frunoff
-  ice_ocean_boundary%frunoff_hflx(:,:) = 0._ESMF_KIND_R8
-  call state_getimport(importState, 'mean_calving_heat_flx',  &
-       isc, iec, jsc, jec, ice_ocean_boundary%frunoff_hflx, areacor=med2mod_areacor, rc=rc)
-  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    !----
+    ! enthalpy from frozen precipitation (hsnow)
+    !----
+    call state_getimport(importState, 'heat_content_fprec', &
+         isc, iec, jsc, jec, ice_ocean_boundary%hsnow, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !----
+    ! enthalpy from liquid runoff (hrofl)
+    !----
+    call state_getimport(importState, 'heat_content_rofl', &
+         isc, iec, jsc, jec, ice_ocean_boundary%hrofl, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !----
+    ! enthalpy from frozen runoff (hrofi)
+    !----
+    call state_getimport(importState, 'heat_content_rofi', &
+         isc, iec, jsc, jec, ice_ocean_boundary%hrofi, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !----
+    ! enthalpy from evaporation (hevap)
+    !----
+    call state_getimport(importState, 'heat_content_evap', &
+         isc, iec, jsc, jec, ice_ocean_boundary%hevap, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    !----
+    ! enthalpy from condensation (hcond)
+    !----
+    call state_getimport(importState, 'heat_content_cond', &
+         isc, iec, jsc, jec, ice_ocean_boundary%hcond, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  endif
 
   !----
   ! salt flux from ice

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -544,23 +544,25 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
                      fluxes%sw_nir_dir(i,j) + fluxes%sw_nir_dif(i,j)
 
     ! enthalpy terms
-    if (associated(IOB%hrofl)) &
-      fluxes%heat_content_lrunoff(i,j) = US%W_m2_to_QRZ_T * IOB%hrofl(i-i0,j-j0) * G%mask2dT(i,j)
+    if (CS%enthalpy_cpl) then
+      if (associated(IOB%hrofl)) &
+        fluxes%heat_content_lrunoff(i,j) = US%W_m2_to_QRZ_T * IOB%hrofl(i-i0,j-j0) * G%mask2dT(i,j)
 
-    if (associated(IOB%hrofi)) &
-      fluxes%heat_content_frunoff(i,j) = US%W_m2_to_QRZ_T * IOB%hrofi(i-i0,j-j0) * G%mask2dT(i,j)
+      if (associated(IOB%hrofi)) &
+        fluxes%heat_content_frunoff(i,j) = US%W_m2_to_QRZ_T * IOB%hrofi(i-i0,j-j0) * G%mask2dT(i,j)
 
-    if (associated(IOB%hrain)) &
-      fluxes%heat_content_lprec(i,j)   = US%W_m2_to_QRZ_T * IOB%hrain(i-i0,j-j0) * G%mask2dT(i,j)
+      if (associated(IOB%hrain)) &
+        fluxes%heat_content_lprec(i,j)   = US%W_m2_to_QRZ_T * IOB%hrain(i-i0,j-j0) * G%mask2dT(i,j)
 
-    if (associated(IOB%hsnow)) &
-      fluxes%heat_content_fprec(i,j)   = US%W_m2_to_QRZ_T * IOB%hsnow(i-i0,j-j0) * G%mask2dT(i,j)
+      if (associated(IOB%hsnow)) &
+        fluxes%heat_content_fprec(i,j)   = US%W_m2_to_QRZ_T * IOB%hsnow(i-i0,j-j0) * G%mask2dT(i,j)
 
-     if (associated(IOB%hevap)) &
-      fluxes%heat_content_evap(i,j)    = US%W_m2_to_QRZ_T * IOB%hevap(i-i0,j-j0) * G%mask2dT(i,j)
+       if (associated(IOB%hevap)) &
+        fluxes%heat_content_evap(i,j)    = US%W_m2_to_QRZ_T * IOB%hevap(i-i0,j-j0) * G%mask2dT(i,j)
 
-     if (associated(IOB%hcond)) &
-      fluxes%heat_content_cond(i,j)    = US%W_m2_to_QRZ_T * IOB%hcond(i-i0,j-j0) * G%mask2dT(i,j)
+       if (associated(IOB%hcond)) &
+        fluxes%heat_content_cond(i,j)    = US%W_m2_to_QRZ_T * IOB%hcond(i-i0,j-j0) * G%mask2dT(i,j)
+    endif
 
     ! sea ice fraction [nondim]
     if (associated(IOB%ice_fraction) .and. associated(fluxes%ice_fraction)) &

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -82,6 +82,8 @@ type, public :: surface_forcing_CS ; private
                                 !! pressure limited by max_p_surf instead of the
                                 !! full atmospheric pressure.  The default is true.
   logical :: use_CFC            !< enables the MOM_CFC_cap tracer package.
+  logical :: enthalpy_cpl       !< Controls if enthalpy terms are provided by the coupler or computed
+                                !! internally.
   real :: gust_const            !< constant unresolved background gustiness for ustar [R L Z T-1 ~> Pa]
   logical :: read_gust_2d       !< If true, use a 2-dimensional gustiness supplied
                                 !! from an input file.
@@ -181,8 +183,12 @@ type, public :: ice_ocean_boundary_type
   real, pointer, dimension(:,:) :: ustar_berg        =>NULL() !< frictional velocity beneath icebergs [m/s]
   real, pointer, dimension(:,:) :: area_berg         =>NULL() !< area covered by icebergs[m2/m2]
   real, pointer, dimension(:,:) :: mass_berg         =>NULL() !< mass of icebergs(kg/m2)
-  real, pointer, dimension(:,:) :: lrunoff_hflx      =>NULL() !< heat content of liquid runoff [W/m2]
-  real, pointer, dimension(:,:) :: frunoff_hflx      =>NULL() !< heat content of frozen runoff [W/m2]
+  real, pointer, dimension(:,:) :: hrofl             =>NULL() !< heat content from liquid runoff [W/m2]
+  real, pointer, dimension(:,:) :: hrofi             =>NULL() !< heat content from frozen runoff [W/m2]
+  real, pointer, dimension(:,:) :: hrain             =>NULL() !< heat content from liquid precipitation [W/m2]
+  real, pointer, dimension(:,:) :: hsnow             =>NULL() !< heat content from frozen precipitation [W/m2]
+  real, pointer, dimension(:,:) :: hevap             =>NULL() !< heat content from evaporation [W/m2]
+  real, pointer, dimension(:,:) :: hcond             =>NULL() !< heat content from condensation [W/m2]
   real, pointer, dimension(:,:) :: p                 =>NULL() !< pressure of overlying ice and atmosphere
                                                               !< on ocean surface [Pa]
   real, pointer, dimension(:,:) :: ice_fraction      =>NULL() !< fractional ice area [nondim]
@@ -304,7 +310,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   if (fluxes%dt_buoy_accum < 0) then
     call allocate_forcing_type(G, fluxes, water=.true., heat=.true., ustar=.true., &
                                press=.true., fix_accum_bug=CS%fix_ustar_gustless_bug, &
-                               cfc=CS%use_CFC)
+                               cfc=CS%use_CFC, hevap=CS%enthalpy_cpl)
 
     call safe_alloc_ptr(fluxes%sw_vis_dir,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%sw_vis_dif,isd,ied,jsd,jed)
@@ -487,13 +493,6 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     if (associated(IOB%mass_berg)) &
       fluxes%mass_berg(i,j) = US%m_to_Z*US%kg_m3_to_R * IOB%mass_berg(i-i0,j-j0) * G%mask2dT(i,j)
 
-    if (associated(IOB%lrunoff_hflx)) &
-      fluxes%heat_content_lrunoff(i,j) = US%W_m2_to_QRZ_T * IOB%lrunoff_hflx(i-i0,j-j0) * G%mask2dT(i,j)
-
-    if (associated(IOB%frunoff_hflx)) &
-      fluxes%heat_content_frunoff(i,j) = US%W_m2_to_QRZ_T * kg_m2_s_conversion * &
-                                         IOB%frunoff_hflx(i-i0,j-j0) * G%mask2dT(i,j)
-
     if (associated(IOB%lw_flux)) &
       fluxes%lw(i,j) = US%W_m2_to_QRZ_T * IOB%lw_flux(i-i0,j-j0) * G%mask2dT(i,j)
 
@@ -543,6 +542,25 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
     fluxes%sw(i,j) = fluxes%sw_vis_dir(i,j) + fluxes%sw_vis_dif(i,j) + &
                      fluxes%sw_nir_dir(i,j) + fluxes%sw_nir_dif(i,j)
+
+    ! enthalpy terms
+    if (associated(IOB%hrofl)) &
+      fluxes%heat_content_lrunoff(i,j) = US%W_m2_to_QRZ_T * IOB%hrofl(i-i0,j-j0) * G%mask2dT(i,j)
+
+    if (associated(IOB%hrofi)) &
+      fluxes%heat_content_frunoff(i,j) = US%W_m2_to_QRZ_T * IOB%hrofi(i-i0,j-j0) * G%mask2dT(i,j)
+
+    if (associated(IOB%hrain)) &
+      fluxes%heat_content_lprec(i,j)   = US%W_m2_to_QRZ_T * IOB%hrain(i-i0,j-j0) * G%mask2dT(i,j)
+
+    if (associated(IOB%hsnow)) &
+      fluxes%heat_content_fprec(i,j)   = US%W_m2_to_QRZ_T * IOB%hsnow(i-i0,j-j0) * G%mask2dT(i,j)
+
+     if (associated(IOB%hevap)) &
+      fluxes%heat_content_evap(i,j)    = US%W_m2_to_QRZ_T * IOB%hevap(i-i0,j-j0) * G%mask2dT(i,j)
+
+     if (associated(IOB%hcond)) &
+      fluxes%heat_content_cond(i,j)    = US%W_m2_to_QRZ_T * IOB%hcond(i-i0,j-j0) * G%mask2dT(i,j)
 
     ! sea ice fraction [nondim]
     if (associated(IOB%ice_fraction) .and. associated(fluxes%ice_fraction)) &
@@ -1201,6 +1219,9 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   call get_param(param_file, mdl, "USE_CFC_CAP", CS%use_CFC, &
                  default=.false., do_not_log=.true.)
 
+  call get_param(param_file, mdl, "ENTHALPY_FROM_COUPLER", CS%enthalpy_cpl, &
+                 default=.false., do_not_log=.true.)
+
   if (restore_salt) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &
                  "The constant that relates the restoring surface fluxes to the relative "//&
@@ -1505,6 +1526,26 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
   endif
   if (associated(iobt%mass_berg)) then
     chks = field_chksum( iobt%mass_berg  ) ; if (root) write(outunit,100) 'iobt%mass_berg      ', chks
+  endif
+
+  ! enthalpy
+  if (associated(iobt%hrofl)) then
+    chks = field_chksum( iobt%hrofl  ) ; if (root) write(outunit,100) 'iobt%hrofl      ', chks
+  endif
+  if (associated(iobt%hrofi)) then
+    chks = field_chksum( iobt%hrofi  ) ; if (root) write(outunit,100) 'iobt%hrofi      ', chks
+  endif
+  if (associated(iobt%hrain)) then
+    chks = field_chksum( iobt%hrain  ) ; if (root) write(outunit,100) 'iobt%hrain      ', chks
+  endif
+  if (associated(iobt%hsnow)) then
+    chks = field_chksum( iobt%hsnow  ) ; if (root) write(outunit,100) 'iobt%hsnow      ', chks
+  endif
+  if (associated(iobt%hevap)) then
+    chks = field_chksum( iobt%hevap  ) ; if (root) write(outunit,100) 'iobt%hevap      ', chks
+  endif
+  if (associated(iobt%hcond)) then
+    chks = field_chksum( iobt%hcond  ) ; if (root) write(outunit,100) 'iobt%hcond      ', chks
   endif
 
 100 FORMAT("   CHECKSUM::",A20," = ",Z20)

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -1220,7 +1220,8 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                  default=.false., do_not_log=.true.)
 
   call get_param(param_file, mdl, "ENTHALPY_FROM_COUPLER", CS%enthalpy_cpl, &
-                 default=.false., do_not_log=.true.)
+                 "If True, the heat (enthalpy) associated with mass entering/leaving the "//&
+                 "ocean is provided via coupler.", default=.false.)
 
   if (restore_salt) then
     call get_param(param_file, mdl, "FLUXCONST", CS%Flux_const, &

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -3384,14 +3384,17 @@ subroutine rotate_forcing(fluxes_in, fluxes, turns)
 
   if (do_heat .and. do_water) then
     call rotate_array(fluxes_in%heat_content_cond, turns, fluxes%heat_content_cond)
-    call rotate_array(fluxes_in%heat_content_evap, turns, fluxes%heat_content_evap)
     call rotate_array(fluxes_in%heat_content_lprec, turns, fluxes%heat_content_lprec)
     call rotate_array(fluxes_in%heat_content_fprec, turns, fluxes%heat_content_fprec)
     call rotate_array(fluxes_in%heat_content_vprec, turns, fluxes%heat_content_vprec)
     call rotate_array(fluxes_in%heat_content_lrunoff, turns, fluxes%heat_content_lrunoff)
     call rotate_array(fluxes_in%heat_content_frunoff, turns, fluxes%heat_content_frunoff)
-    call rotate_array(fluxes_in%heat_content_massout, turns, fluxes%heat_content_massout)
-    call rotate_array(fluxes_in%heat_content_massin, turns, fluxes%heat_content_massin)
+    if (associated (fluxes_in%heat_content_evap))  then
+      call rotate_array(fluxes_in%heat_content_evap, turns, fluxes%heat_content_evap)
+    else
+      call rotate_array(fluxes_in%heat_content_massout, turns, fluxes%heat_content_massout)
+      call rotate_array(fluxes_in%heat_content_massin, turns, fluxes%heat_content_massin)
+    endif
   endif
 
   if (do_press) then

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -2997,7 +2997,11 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
 
   ! Local variables
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
-  logical :: heat_water
+  logical :: heat_water, enthalpy_mom
+
+  ! if true, allocate fluxes needed to calculate enthalpy terms in MOM6
+  enthalpy_mom = .true.
+  if (present (hevap)) enthalpy_mom = .not. hevap
 
   isd  = G%isd   ; ied  = G%ied    ; jsd  = G%jsd   ; jed  = G%jed
   IsdB = G%IsdB  ; IedB = G%IedB   ; JsdB = G%JsdB  ; JedB = G%JedB
@@ -3027,14 +3031,14 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
 
   if (present(heat) .and. present(water)) then ; if (heat .and. water) then
     call myAlloc(fluxes%heat_content_cond,isd,ied,jsd,jed, .true.)
-    call myAlloc(fluxes%heat_content_evap,isd,ied,jsd,jed, hevap)
+    call myAlloc(fluxes%heat_content_evap,isd,ied,jsd,jed, .not. enthalpy_mom)
     call myAlloc(fluxes%heat_content_lprec,isd,ied,jsd,jed, .true.)
     call myAlloc(fluxes%heat_content_fprec,isd,ied,jsd,jed, .true.)
     call myAlloc(fluxes%heat_content_vprec,isd,ied,jsd,jed, .true.)
     call myAlloc(fluxes%heat_content_lrunoff,isd,ied,jsd,jed, .true.)
     call myAlloc(fluxes%heat_content_frunoff,isd,ied,jsd,jed, .true.)
-    call myAlloc(fluxes%heat_content_massout,isd,ied,jsd,jed, .not. hevap)
-    call myAlloc(fluxes%heat_content_massin,isd,ied,jsd,jed,  .not. hevap)
+    call myAlloc(fluxes%heat_content_massout,isd,ied,jsd,jed, enthalpy_mom)
+    call myAlloc(fluxes%heat_content_massin,isd,ied,jsd,jed,  enthalpy_mom)
   endif ; endif
 
   call myAlloc(fluxes%p_surf,isd,ied,jsd,jed, press)

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -1008,7 +1008,14 @@ subroutine accumulate_net_input(fluxes, sfc_state, tv, dt, G, US, CS)
 !    enddo ; enddo ; endif
 
     ! smg: old code
-    if (associated(tv%TempxPmE)) then
+    if (associated(fluxes%heat_content_evap)) then
+      do j=js,je ; do i=is,ie
+        heat_in(i,j) = heat_in(i,j) + dt * QRZL2_to_J * G%areaT(i,j) * &
+                       (fluxes%heat_content_evap(i,j) + fluxes%heat_content_lprec(i,j) + &
+                        fluxes%heat_content_cond(i,j) + fluxes%heat_content_fprec(i,j) + &
+                        fluxes%heat_content_lrunoff(i,j) + fluxes%heat_content_frunoff(i,j))
+      enddo ; enddo
+    elseif (associated(tv%TempxPmE)) then
       do j=js,je ; do i=is,ie
         heat_in(i,j) = heat_in(i,j) + (fluxes%C_p * QRZL2_to_J*G%areaT(i,j)) * tv%TempxPmE(i,j)
       enddo ; enddo

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -1031,7 +1031,9 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   real :: dThickness, dTemp, dSalt
   real :: fractionOfForcing, hOld, Ithickness
   real :: RivermixConst  ! A constant used in implementing river mixing [R Z2 T-1 ~> Pa s].
-
+  real :: EnthalpyConst  ! A constant used to control the enthalpy calculation
+                         ! By default EnthalpyConst = 1.0. If fluxes%heat_content_evap
+                         ! is associated enthalpy is provided via coupler and EnthalpyConst = 0.0.
   real, dimension(SZI_(G)) :: &
     d_pres,       &  ! pressure change across a layer [R L2 T-2 ~> Pa]
     p_lay,        &  ! average pressure in a layer [R L2 T-2 ~> Pa]
@@ -1095,6 +1097,9 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   ! Only apply forcing if fluxes%sw is associated.
   if (.not.associated(fluxes%sw) .and. .not.calculate_energetics) return
 
+  EnthalpyConst = 1.0
+  if (associated(fluxes%heat_content_evap)) EnthalpyConst = 0.0
+
   if (calculate_buoyancy) then
     SurfPressure(:) = 0.0
     GoRho = US%L_to_Z**2*GV%g_Earth / GV%Rho0
@@ -1116,7 +1121,8 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
   !$OMP                                  nonPenSW,hGrounding,CS,Idt,aggregate_FW_forcing,  &
   !$OMP                                  minimum_forcing_depth,evap_CFL_limit,dt,EOSdom,   &
   !$OMP                                  calculate_buoyancy,netPen_rate,SkinBuoyFlux,GoRho, &
-  !$OMP                                  calculate_energetics,dSV_dT,dSV_dS,cTKE,g_Hconv2) &
+  !$OMP                                  calculate_energetics,dSV_dT,dSV_dS,cTKE,g_Hconv2, &
+  !$OMP                                  EnthalpyConst)                  &
   !$OMP                          private(opacityBand,h2d,T2d,netMassInOut,netMassOut,      &
   !$OMP                                  netHeat,netSalt,Pen_SW_bnd,fractionOfForcing,     &
   !$OMP                                  IforcingDepthScale,                               &
@@ -1258,17 +1264,19 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
           ! This line accounts for the temperature of the mass exchange
           Temp_in = T2d(i,k)
           Salin_in = 0.0
-          dTemp = dTemp + dThickness*Temp_in
+          dTemp = dTemp + dThickness*Temp_in*EnthalpyConst
 
           ! Diagnostics of heat content associated with mass fluxes
-          if (associated(fluxes%heat_content_massin))                             &
-            fluxes%heat_content_massin(i,j) = fluxes%heat_content_massin(i,j) +   &
-                         T2d(i,k) * max(0.,dThickness) * GV%H_to_RZ * fluxes%C_p * Idt
-          if (associated(fluxes%heat_content_massout))                            &
-            fluxes%heat_content_massout(i,j) = fluxes%heat_content_massout(i,j) + &
-                         T2d(i,k) * min(0.,dThickness) * GV%H_to_RZ * fluxes%C_p * Idt
-          if (associated(tv%TempxPmE)) tv%TempxPmE(i,j) = tv%TempxPmE(i,j) + &
-                         T2d(i,k) * dThickness * GV%H_to_RZ
+          if (.not. associated(fluxes%heat_content_evap)) then
+            if (associated(fluxes%heat_content_massin))                             &
+              fluxes%heat_content_massin(i,j) = fluxes%heat_content_massin(i,j) +   &
+                           T2d(i,k) * max(0.,dThickness) * GV%H_to_RZ * fluxes%C_p * Idt
+            if (associated(fluxes%heat_content_massout))                            &
+              fluxes%heat_content_massout(i,j) = fluxes%heat_content_massout(i,j) + &
+                           T2d(i,k) * min(0.,dThickness) * GV%H_to_RZ * fluxes%C_p * Idt
+            if (associated(tv%TempxPmE)) tv%TempxPmE(i,j) = tv%TempxPmE(i,j) +      &
+                           T2d(i,k) * dThickness * GV%H_to_RZ
+          endif
 
           ! Determine the energetics of river mixing before updating the state.
           if (calculate_energetics .and. associated(fluxes%lrunoff) .and. CS%do_rivermix) then
@@ -1341,17 +1349,19 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
           netSalt(i) = netSalt(i) - dSalt
 
           ! This line accounts for the temperature of the mass exchange
-          dTemp = dTemp + dThickness*T2d(i,k)
+          dTemp = dTemp + dThickness*T2d(i,k)*EnthalpyConst
 
           ! Diagnostics of heat content associated with mass fluxes
-          if (associated(fluxes%heat_content_massin)) &
-            fluxes%heat_content_massin(i,j) = fluxes%heat_content_massin(i,j) + &
-                         T2d(i,k) * max(0.,dThickness) * GV%H_to_RZ * fluxes%C_p * Idt
-          if (associated(fluxes%heat_content_massout)) &
-            fluxes%heat_content_massout(i,j) = fluxes%heat_content_massout(i,j) + &
-                         T2d(i,k) * min(0.,dThickness) * GV%H_to_RZ * fluxes%C_p * Idt
-          if (associated(tv%TempxPmE)) tv%TempxPmE(i,j) = tv%TempxPmE(i,j) + &
-                         T2d(i,k) * dThickness * GV%H_to_RZ
+          if (.not. associated(fluxes%heat_content_evap)) then
+            if (associated(fluxes%heat_content_massin))                             &
+              fluxes%heat_content_massin(i,j) = fluxes%heat_content_massin(i,j) +   &
+                           T2d(i,k) * max(0.,dThickness) * GV%H_to_RZ * fluxes%C_p * Idt
+            if (associated(fluxes%heat_content_massout))                            &
+              fluxes%heat_content_massout(i,j) = fluxes%heat_content_massout(i,j) + &
+                           T2d(i,k) * min(0.,dThickness) * GV%H_to_RZ * fluxes%C_p * Idt
+            if (associated(tv%TempxPmE)) tv%TempxPmE(i,j) = tv%TempxPmE(i,j) +      &
+                           T2d(i,k) * dThickness * GV%H_to_RZ
+          endif
 
           ! Update state by the appropriate increment.
           hOld     = h2d(i,k)               ! Keep original thickness in hand


### PR DESCRIPTION
This PR must be evaluated in conjunction with https://github.com/ESCOMP/CMEPS/pull/278

These changes allow MOM6 to receive enthalpy fluxes via coupler, instead of having them being computed inside the model. This option is only implemented in the NUOPC cap. To control how enthalpy fluxes are provided, a new `MOM_input` parameter is introduced `ENTHALPY_FROM_COUPLER`. Currently, by default, this parameter is set to `False` (MOM6 will compute the enthalpy terms), but this can be changed in a future PR or via MOM_interface.  

When `cesm_coupled=True` and `ENTHALPY_FROM_COUPLER=True`, the NUOPC cap allocates `fluxes%heat_content_evap`. The latter is then used to control if MOM6 needs to compute the enthalpy fluxes and how/which diagnostics should be calculated or accounted for. The heat contribution from mass entering/leaving the ocean is considered  using the following six terms provided by the coupler:
  - heat_content_evap
  - heat_content_cond
  - heat_content_fprec
  - heat_content_lprec
  - heat_content_lrunoff
  - heat_content_frunoff

Fields `heat_content_massout` and `heat_content_massin` are no longer used/allocated when `ENTHALPY_FROM_COUPLER=True`. This is because MOM6 can no longer determine if the corresponding heat content is from mass being added/removed into/from the ocean.  

### Consistency/Conservation checks
[This](https://github.com/gustavo-marques/cesm_mom6_progress/blob/master/enthalpy_via_coupler/surface_flux_analysis_enthalpy_via_cpl_BMOM_05April2022.ipynb) notebook documents consistency checks for heat, mass, and salt, where global changes are within truncation error of the corresponding forcing applied :heavy_check_mark:

[This](https://github.com/gustavo-marques/cesm_mom6_progress/blob/master/enthalpy_via_coupler/bmom.e23.f09_t061_zstar_N65.nuopc.enthalpy_via_cpl_PR_check.001.ipynb) notebook provides a comparison between a yearly-average MOM6 history file against the heat and water budget tables generated by the coupler for the second year of a BMOM simulation :heavy_check_mark:

### Diagnostics

* Diagnostics `heat_content_icemelt` and `total_heat_content_icemelt` were removed. This explains why the regression tests are failing; 
* When `ENTHALPY_FROM_COUPLER=True`, two new diagnostics become available: `heat_content_evap` and `total_heat_content_evap`; and the following diagnostics are no longer available: `heat_content_massout`, `heat_content_massin`, `total_heat_content_massout`, and `total_heat_content_massin`.

### Summary of additional commits:

* Remove `lrunoff_hflx` and `frunoff_hflx`  and `mean_runoff_heat_flx` and `mean_calving_heat_flx` from the NUOPC cap. These were never used;
* Deletes all entries associated with `heat_content_icemelt`. The enthalpy associated with the mass from sea ice formation/melting is already accounted for in `seaice_melt_heat`. A note explaining this has been added to the code;
* Modify `forcing_diagnostics` so that diagnostics are properly computed whether enthalpy terms are provided via coupler or computed by MOM6. This is done by introducing a logical variable `mom_enthalpy` (default = true, meaning diagnostics are computed in the default way, using `heat_content_massout`). When the optional argument (`enthalpy`) is present and true, `mom_enthalpy = false`. In this case, diagnostics are computed using `heat_content_evap` instead of `heat_content_massout`. 
* Introduces a new constant (`EnthalpyConst` = 1.0, by default) which is set to 0.0 when `fluxes%heat_content_evap` is associated. This constant is used in the expression that accounts for the temperature of the mass exchange (`dTemp`) to avoid double-counting for the enthalpy terms when they are provided via coupler. 

### Change in answers

* This PR will change answers for the `aux_mom` test suit because `heat_content_icemelt` has been removed. As mentioned before, the enthalpy associated with the mass from sea ice formation/melting is already accounted for in `seaice_melt_heat`. Answers will also change once `ENTHALPY_FROM_COUPLER=True`;
* All answers and output are bitwise identical in the `MOM6-examples` test suite.