### PR TITLE
ensure consistent tendency diagnostics on diagnostic grids

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -120,9 +120,9 @@ use MOM_tracer_hor_diff,       only : tracer_hordiff, tracer_hor_diff_init
 use MOM_tracer_hor_diff,       only : tracer_hor_diff_end, tracer_hor_diff_CS
 use MOM_tracer_registry,       only : tracer_registry_type, register_tracer, tracer_registry_init
 use MOM_tracer_registry,       only : register_tracer_diagnostics, post_tracer_diagnostics_at_sync
-use MOM_tracer_registry,       only : post_tracer_transport_diagnostics
 use MOM_tracer_registry,       only : preALE_tracer_diagnostics, postALE_tracer_diagnostics
 use MOM_tracer_registry,       only : lock_tracer_registry, tracer_registry_end
+use MOM_tracer_registry,       only : post_tracer_hordiff_diagnostics
 use MOM_tracer_flow_control,   only : call_tracer_register, tracer_flow_control_CS
 use MOM_tracer_flow_control,   only : tracer_flow_control_init, call_tracer_surface_state
 use MOM_tracer_flow_control,   only : tracer_flow_control_end
@@ -1290,6 +1290,7 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)
   call post_transport_diagnostics(G, GV, US, CS%uhtr, CS%vhtr, h, CS%transport_IDs, &
            CS%diag_pre_dyn, CS%diag, CS%t_dyn_rel_adv, CS%tracer_reg)
+  call post_tracer_hordiff_diagnostics(G, GV, CS%tracer_reg, CS%diag_pre_dyn, CS%diag)
   ! Rebuild the remap grids now that we've posted the fields which rely on thicknesses
   ! from before the dynamics calls
   call diag_update_remap_grids(CS%diag)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1276,16 +1276,26 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
 
   call advect_tracer(h, CS%uhtr, CS%vhtr, CS%OBC, CS%t_dyn_rel_adv, G, GV, US, &
                      CS%tracer_adv_CSp, CS%tracer_Reg, x_first_in=x_first)
+  call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
+
+  call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)
   ! all diagnostic grids are now out of sync with respect to h
   call set_diag_in_sync_with_state(CS%diag, .false.)
   call post_transport_diagnostics(G, GV, US, CS%uhtr, CS%vhtr, h, CS%transport_IDs, &
            CS%diag_pre_dyn, CS%diag, CS%t_dyn_rel_adv, CS%tracer_reg)
   call diag_drop_h(CS%diag, "transports")
+  call cpu_clock_end(id_clock_diagnostics) ; call cpu_clock_end(id_clock_other)
 
+  call cpu_clock_begin(id_clock_thermo) ; call cpu_clock_begin(id_clock_tracer)
   call tracer_hordiff(h, CS%t_dyn_rel_adv, CS%MEKE, CS%VarMix, G, GV, US, &
                       CS%tracer_diff_CSp, CS%tracer_Reg, CS%tv)
-  call post_tracer_hordiff_diagnostics(G, GV, CS%tracer_reg, CS%diag_pre_dyn, CS%diag)
+  call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
 
+  call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)
+  call post_tracer_hordiff_diagnostics(G, GV, CS%tracer_reg, CS%diag_pre_dyn, CS%diag)
+  call cpu_clock_end(id_clock_diagnostics) ; call cpu_clock_end(id_clock_other)
+
+  call cpu_clock_begin(id_clock_thermo) ; call cpu_clock_begin(id_clock_tracer)
   if (showCallTree) call callTree_waypoint("finished tracer advection/diffusion (step_MOM)")
   call update_segment_tracer_reservoirs(G, GV, CS%uhtr, CS%vhtr, h, CS%OBC, &
                      CS%t_dyn_rel_adv, CS%tracer_Reg)

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -908,7 +908,7 @@ subroutine step_MOM(forces_in, fluxes_in, sfc_state, Time_start, time_int_in, CS
       call enable_averages(CS%t_dyn_rel_diag, Time_local, CS%diag)
       call calculate_diagnostic_fields(u, v, h, CS%uh, CS%vh, CS%tv, CS%ADp, &
           CS%CDp, p_surf, CS%t_dyn_rel_diag, CS%diag_pre_sync, G, GV, US, CS%diagnostics_CSp)
-      call post_tracer_diagnostics_at_sync(CS%Tracer_reg, h, CS%diag, G, GV, CS%t_dyn_rel_diag)
+      call post_tracer_diagnostics_at_sync(CS%tracer_Reg, h, CS%diag, G, GV, CS%t_dyn_rel_diag)
       call diag_drop_h(CS%diag, "sync")
       call diag_push_h(CS%diag, "sync")
       call diag_copy_diag_to_storage(CS%diag_pre_sync, h, CS%diag)
@@ -1282,7 +1282,7 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   ! all diagnostic grids are now out of sync with respect to h
   call set_diag_in_sync_with_state(CS%diag, .false.)
   call post_transport_diagnostics(G, GV, US, CS%uhtr, CS%vhtr, h, CS%transport_IDs, &
-           CS%diag_pre_dyn, CS%diag, CS%t_dyn_rel_adv, CS%tracer_reg)
+           CS%diag_pre_dyn, CS%diag, CS%t_dyn_rel_adv, CS%tracer_Reg)
   call diag_drop_h(CS%diag, "transports")
   call cpu_clock_end(id_clock_diagnostics) ; call cpu_clock_end(id_clock_other)
 
@@ -1292,7 +1292,7 @@ subroutine step_MOM_tracer_dyn(CS, G, GV, US, h, Time_local)
   call cpu_clock_end(id_clock_tracer) ; call cpu_clock_end(id_clock_thermo)
 
   call cpu_clock_begin(id_clock_other) ; call cpu_clock_begin(id_clock_diagnostics)
-  call post_tracer_hordiff_diagnostics(G, GV, CS%tracer_reg, CS%diag_pre_dyn, CS%diag)
+  call post_tracer_hordiff_diagnostics(G, GV, CS%tracer_Reg, CS%diag_pre_dyn, CS%diag)
   call cpu_clock_end(id_clock_diagnostics) ; call cpu_clock_end(id_clock_other)
 
   call cpu_clock_begin(id_clock_thermo) ; call cpu_clock_begin(id_clock_tracer)
@@ -1425,7 +1425,7 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
 
     call cpu_clock_begin(id_clock_diabatic)
 
-    call diabatic(u, v, h, tv, CS%Hml, fluxes, CS%visc, CS%ADp, CS%CDp, dtdia, &
+    call diabatic(u, v, h, tv, CS%tracer_Reg, CS%Hml, fluxes, CS%visc, CS%ADp, CS%CDp, dtdia, &
                   Time_end_thermo, G, GV, US, CS%diabatic_CSp, CS%stoch_CS, CS%OBC, Waves)
     fluxes%fluxes_used = .true.
 
@@ -2482,7 +2482,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     !
     ! XXX: This call on OBC_in allocates the tracer fields on the unrotated
     !   grid, but also incorrectly stores a pointer to a tracer_type for the
-    !   rotated registry (e.g. segment%tr_reg%Tr(n)%Tr) from CS%tracer_reg.
+    !   rotated registry (e.g. segment%tr_reg%Tr(n)%Tr) from CS%tracer_Reg.
     !
     !   While incorrect and potentially dangerous, it does not seem that this
     !   pointer is used during initialization, so we leave it for now.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2822,7 +2822,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
   else
     call diabatic_driver_init(Time, G, GV, US, param_file, CS%use_ALE_algorithm, diag, &
                               CS%ADp, CS%CDp, CS%diabatic_CSp, CS%tracer_flow_CSp, &
-                              CS%sponge_CSp, CS%ALE_sponge_CSp, CS%oda_incupd_CSp)
+                              CS%sponge_CSp, CS%ALE_sponge_CSp, CS%oda_incupd_CSp, CS%tv)
   endif
 
   if (associated(CS%sponge_CSp)) &

--- a/src/diagnostics/MOM_diagnostics.F90
+++ b/src/diagnostics/MOM_diagnostics.F90
@@ -27,7 +27,7 @@ use MOM_grid,              only : ocean_grid_type
 use MOM_interface_heights, only : find_eta
 use MOM_spatial_means,     only : global_area_mean, global_layer_mean
 use MOM_spatial_means,     only : global_volume_mean, global_area_integral
-use MOM_tracer_registry,   only : tracer_registry_type, post_tracer_transport_diagnostics
+use MOM_tracer_registry,   only : tracer_registry_type, post_tracer_advection_diagnostics
 use MOM_unit_scaling,      only : unit_scale_type
 use MOM_variables,         only : thermo_var_ptrs, ocean_internal_state, p3d
 use MOM_variables,         only : accel_diag_ptrs, cont_diag_ptrs, surface
@@ -1499,7 +1499,7 @@ subroutine post_transport_diagnostics(G, GV, US, uhtr, vhtr, h, IDs, diag_pre_dy
     call post_data(IDs%id_dynamics_h_tendency, h_tend, diag, alt_h=diag_pre_dyn%h_state)
   endif
 
-  call post_tracer_transport_diagnostics(G, GV, Reg, diag_pre_dyn%h_state, diag)
+  call post_tracer_advection_diagnostics(G, GV, Reg, diag_pre_dyn%h_state, diag)
 
   call diag_restore_grids(diag)
 

--- a/src/framework/MOM_diag_mediator.F90
+++ b/src/framework/MOM_diag_mediator.F90
@@ -353,7 +353,6 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
   integer :: id_xq, id_yq, id_zl, id_zi, id_xh, id_yh, id_null
   integer :: id_zl_native, id_zi_native
   integer :: i, j, k, nz
-  integer :: max_h_prev_size
   real :: zlev(GV%ke), zinter(GV%ke+1)
   logical :: set_vert
   real, allocatable, dimension(:) :: IaxB,iax
@@ -503,11 +502,7 @@ subroutine set_axes_info(G, GV, US, param_file, diag_cs, set_vertical)
     allocate(diag_cs%diag_remap_cs(i)%h(G%isd:G%ied,G%jsd:G%jed, diag_cs%diag_remap_cs(i)%nz))
     allocate(diag_cs%diag_remap_cs(i)%h_extensive(G%isd:G%ied,G%jsd:G%jed, diag_cs%diag_remap_cs(i)%nz))
 
-    ! Axes info is set before tracer diagnostics are registered, making it hard
-    ! to adaptively determine max_h_prev_size. So use 2. Will need to be
-    ! increased to 3 if multiprocess tendencies are implemented and used.
-    max_h_prev_size = 2
-    call field_stack_init(diag_cs%diag_remap_cs(i)%h_prev, max_h_prev_size, &
+    call field_stack_init(diag_cs%diag_remap_cs(i)%h_prev, &
         G%isd, G%ied, G%jsd, G%jed, diag_cs%diag_remap_cs(i)%nz, &
         "diag h_prev " // trim(diag_cs%diag_remap_cs(i)%diag_coord_name))
 
@@ -3363,7 +3358,6 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
 
   ! Local variables
   integer :: ios, i, new_unit
-  integer :: max_h_prev_size
   logical :: opened, new_file
   logical :: answers_2018, default_2018_answers
   character(len=8)   :: this_pe
@@ -3451,12 +3445,7 @@ subroutine diag_mediator_init(G, GV, US, nz, param_file, diag_cs, doc_file_dir)
   diag_cs%h_old(:,:,:) = 0.0
 #endif
 
-  ! diag_mediator is initialized before tracer diagnostics are registered, making it hard
-  ! to adaptively determine max_h_prev_size. So use 2. Will need to be
-  ! increased to 3 if multiprocess tendencies are implemented and used.
-  max_h_prev_size = 2
-  call field_stack_init(diag_cs%h_prev, max_h_prev_size, &
-      G%isd, G%ied, G%jsd, G%jed, nz, "diag h_prev native")
+  call field_stack_init(diag_cs%h_prev, G%isd, G%ied, G%jsd, G%jed, nz, "diag h_prev native")
 
   diag_cs%is = G%isc - (G%isd-1) ; diag_cs%ie = G%iec - (G%isd-1)
   diag_cs%js = G%jsc - (G%jsd-1) ; diag_cs%je = G%jec - (G%jsd-1)

--- a/src/framework/MOM_diag_remap.F90
+++ b/src/framework/MOM_diag_remap.F90
@@ -63,7 +63,7 @@ use MOM_error_handler,    only : MOM_error, FATAL, assert, WARNING
 use MOM_debugging,        only : check_column_integrals
 use MOM_diag_manager_infra,only : MOM_diag_axis_init
 use MOM_diag_vkernels,    only : interpolate_column, reintegrate_column
-use MOM_field_stack,      only : field_stack_type
+use MOM_field_stack,      only : field_stack_type, field_stack_end
 use MOM_file_parser,      only : get_param, log_param, param_file_type
 use MOM_string_functions, only : lowercase, extractWord
 use MOM_grid,             only : ocean_grid_type
@@ -154,6 +154,7 @@ subroutine diag_remap_end(remap_cs)
   type(diag_remap_ctrl), intent(inout) :: remap_cs !< Diag remapping control structure
 
   if (allocated(remap_cs%h)) deallocate(remap_cs%h)
+  call field_stack_end(remap_cs%h_prev, "diag_remap_end")
 
   remap_cs%configured = .false.
   remap_cs%initialized = .false.

--- a/src/framework/MOM_field_stack.F90
+++ b/src/framework/MOM_field_stack.F90
@@ -15,7 +15,7 @@ public field_stack_peek, field_stack_drop
 !> The field_stack type
 type, public :: field_stack_type ; private
   real, dimension(:,:,:,:), pointer :: field => NULL() !< field values stored in stack
-  integer :: top                                       !< index of top of stack, zero for an empty stack
+  integer :: top = 0                                   !< index of top of stack, zero for an empty stack
   character(:), allocatable :: name                    !< stack name to include in informational messages
 end type field_stack_type
 

--- a/src/framework/MOM_field_stack.F90
+++ b/src/framework/MOM_field_stack.F90
@@ -1,0 +1,156 @@
+!> This module contains utilities for maintaning stacks of model fields.
+!! The current implementation handles 3 dimensional fields.
+module MOM_field_stack
+
+! This file is part of MOM6. See LICENSE.md for the license.
+
+use MOM_error_handler, only : MOM_error, FATAL, MOM_get_verbosity, MOM_mesg
+
+implicit none ; private
+
+public field_stack_init, field_stack_end
+public field_stack_push, field_stack_pop
+
+!> The field_stack type
+type, public :: field_stack_type ; private
+  real, dimension(:,:,:,:), allocatable :: field !< field values stored in stack
+  integer :: top                                 !< index of top of stack, zero for an empty stack
+  character(:), allocatable :: name              !< stack name to include in informational messages
+end type field_stack_type
+
+contains
+
+!> Initialize a field_stack object
+subroutine field_stack_init(field_stack_obj, max_size, is, ie, js, je, nk, name)
+  type(field_stack_type), intent(inout) :: field_stack_obj !< field_stack object being initialized
+  integer,                   intent(in) :: max_size        !< maximum size that stack can grow to
+  integer,                   intent(in) :: is              !< The start index to allocate for the 1st dimension
+  integer,                   intent(in) :: ie              !< The end index to allocate for the 1st dimension
+  integer,                   intent(in) :: js              !< The start index to allocate for the 2nd dimension
+  integer,                   intent(in) :: je              !< The end index to allocate for the 2nd dimension
+  integer,                   intent(in) :: nk              !< The size to allocate for the 3rd dimension
+  character(len=*),          intent(in) :: name            !< stack name to include in informational messages
+
+  if (max_size < 0) call MOM_error(FATAL, &
+      "field_stack_init: max_size not permitted to be negative")
+
+  if (allocated(field_stack_obj%field)) call MOM_error(FATAL, &
+      "field_stack_init: field_stack_obj has already been initialized")
+
+  allocate(field_stack_obj%field(is:ie, js:je, nk, max_size))
+  field_stack_obj%top = 0
+  field_stack_obj%name = trim(name)
+
+end subroutine field_stack_init
+
+
+!> Deallocate memory associated with field_stack object
+subroutine field_stack_end(field_stack_obj)
+  type(field_stack_type), intent(inout) :: field_stack_obj !< field_stack object being operated on
+
+  if (allocated(field_stack_obj%field)) then
+    deallocate(field_stack_obj%field)
+    deallocate(field_stack_obj%name)
+  endif
+
+end subroutine field_stack_end
+
+
+!> Push field values to stack
+subroutine field_stack_push(field_stack_obj, field, info_msg)
+  type(field_stack_type), intent(inout) :: field_stack_obj !< field_stack object being operated on
+  real, dimension(:,:,:),    intent(in) :: field           !< field values to be pushed to stack
+  character(len=*),          intent(in) :: info_msg        !< informational message to write
+
+  ! Local variables
+  character(*), parameter :: sub_name = "field_stack_push"
+  character(:), allocatable :: info_msg_full
+  integer :: info_msg_full_len, i, j, k
+  integer :: i_offset, j_offset
+
+  ! Only construct full informational message if verbosity is sufficiently high
+  if (MOM_get_verbosity() >= 4) then
+    info_msg_full_len = &
+        len(sub_name) + 2 + len_trim(field_stack_obj%name) + 1 + len_trim(info_msg) + 6 + 3
+    allocate(character(len=info_msg_full_len) :: info_msg_full)
+    write(info_msg_full, '(A,I3)') &
+        sub_name // ": " // trim(field_stack_obj%name) // " " // trim(info_msg) // ", top=", &
+        field_stack_obj%top
+    call MOM_mesg(info_msg_full, 4)
+    deallocate(info_msg_full)
+  endif
+
+  if (.not. allocated(field_stack_obj%field)) call MOM_error(FATAL, &
+      "field_stack_push: field_stack_obj has not been initialized")
+
+  if (field_stack_obj%top == size(field_stack_obj%field, 4)) call MOM_error(FATAL, &
+      "field_stack_push: attempting to push to full stack")
+
+  ! verify that field has same shape as stack field
+  if ((size(field, 1) /= size(field_stack_obj%field, 1)) .or. &
+      (size(field, 2) /= size(field_stack_obj%field, 2)) .or. &
+      (size(field, 3) /= size(field_stack_obj%field, 3))) then
+    call MOM_error(FATAL, &
+        "field_stack_push: field argument shape doesn't match stack field shape")
+  endif
+
+  field_stack_obj%top = field_stack_obj%top + 1
+
+  i_offset = lbound(field_stack_obj%field, 1) - 1
+  j_offset = lbound(field_stack_obj%field, 2) - 1
+  do k=1,size(field,3) ; do j=1,size(field,2) ; do i=1,size(field,1)
+    field_stack_obj%field(i+i_offset,j+j_offset,k,field_stack_obj%top) = field(i,j,k)
+  enddo ; enddo ; enddo
+
+end subroutine field_stack_push
+
+
+!> Pop field values from stack
+subroutine field_stack_pop(field_stack_obj, field, info_msg)
+  type(field_stack_type), intent(inout) :: field_stack_obj !< field_stack object being operated on
+  real, dimension(:,:,:),   intent(out) :: field           !< where popped field values are stored
+  character(len=*),          intent(in) :: info_msg        !< informational message to write
+
+  ! Local variables
+  character(*), parameter :: sub_name = "field_stack_pop"
+  character(:), allocatable :: info_msg_full
+  integer :: info_msg_full_len, i, j, k
+  integer :: i_offset, j_offset
+
+  ! Only construct full informational message if verbosity is sufficiently high
+  if (MOM_get_verbosity() >= 4) then
+    info_msg_full_len = &
+        len(sub_name) + 2 + len_trim(field_stack_obj%name) + 1 + len_trim(info_msg) + 6 + 3
+    allocate(character(len=info_msg_full_len) :: info_msg_full)
+    write(info_msg_full, '(A,I3)') &
+        sub_name // ": " // trim(field_stack_obj%name) // " " // trim(info_msg) // ", top=", &
+        field_stack_obj%top
+    call MOM_mesg(info_msg_full, 4)
+    deallocate(info_msg_full)
+  endif
+
+  if (.not. allocated(field_stack_obj%field)) call MOM_error(FATAL, &
+      "field_stack_pop: field_stack_obj has not been initialized")
+
+  if (field_stack_obj%top == 0) call MOM_error(FATAL, &
+      "field_stack_pop: attempting to pop from empty stack")
+
+  ! verify that field has same shape as stack field
+  if ((size(field, 1) /= size(field_stack_obj%field, 1)) .or. &
+      (size(field, 2) /= size(field_stack_obj%field, 2)) .or. &
+      (size(field, 3) /= size(field_stack_obj%field, 3))) then
+    call MOM_error(FATAL, &
+        "field_stack_pop: field argument shape doesn't match stack field shape")
+  endif
+
+  i_offset = lbound(field_stack_obj%field, 1) - 1
+  j_offset = lbound(field_stack_obj%field, 2) - 1
+  do k=1,size(field,3) ; do j=1,size(field,2) ; do i=1,size(field,1)
+    field(i,j,k) = field_stack_obj%field(i+i_offset,j+j_offset,k,field_stack_obj%top)
+  enddo ; enddo ; enddo
+
+  field_stack_obj%top = field_stack_obj%top - 1
+
+end subroutine field_stack_pop
+
+end module MOM_field_stack

--- a/src/framework/MOM_field_stack.F90
+++ b/src/framework/MOM_field_stack.F90
@@ -45,18 +45,27 @@ subroutine field_stack_init(field_stack_obj, max_size, is, ie, js, je, nk, name)
   field_stack_obj%top = 0
   field_stack_obj%name = trim(name)
 
+  call write_stack_info_msg(sub_name, field_stack_obj, "init")
+
 end subroutine field_stack_init
 
 
 !> Deallocate memory associated with field_stack object
-subroutine field_stack_end(field_stack_obj)
+subroutine field_stack_end(field_stack_obj, info_msg)
   type(field_stack_type), intent(inout) :: field_stack_obj !< field_stack object being operated on
+  character(len=*),          intent(in) :: info_msg        !< informational message to write
 
-  if (associated(field_stack_obj%field)) then
-    deallocate(field_stack_obj%field)
-    field_stack_obj%field => NULL()
-    deallocate(field_stack_obj%name)
-  endif
+  ! Local variables
+  character(*), parameter :: sub_name = "field_stack_end"
+
+  if (.not. associated(field_stack_obj%field)) return
+
+  call write_stack_info_msg(sub_name, field_stack_obj, info_msg)
+
+  deallocate(field_stack_obj%field)
+  field_stack_obj%field => NULL()
+  field_stack_obj%top = 0
+  deallocate(field_stack_obj%name)
 
 end subroutine field_stack_end
 
@@ -72,10 +81,10 @@ subroutine field_stack_push(field_stack_obj, field, info_msg)
   integer :: i, j, k
   integer :: i_offset, j_offset
 
-  call write_stack_info_msg(sub_name, field_stack_obj, info_msg)
-
   if (.not. associated(field_stack_obj%field)) call MOM_error(FATAL, &
       sub_name // ": field_stack_obj has not been initialized")
+
+  call write_stack_info_msg(sub_name, field_stack_obj, info_msg)
 
   if (field_stack_obj%top == size(field_stack_obj%field, 4)) call MOM_error(FATAL, &
       sub_name // ": attempting to push to full stack")
@@ -110,10 +119,10 @@ subroutine field_stack_pop(field_stack_obj, field, info_msg)
   integer :: i, j, k
   integer :: i_offset, j_offset
 
-  call write_stack_info_msg(sub_name, field_stack_obj, info_msg)
-
   if (.not. associated(field_stack_obj%field)) call MOM_error(FATAL, &
       sub_name // ": field_stack_obj has not been initialized")
+
+  call write_stack_info_msg(sub_name, field_stack_obj, info_msg)
 
   if (field_stack_obj%top == 0) call MOM_error(FATAL, &
       sub_name // ": attempting to pop from empty stack")
@@ -146,10 +155,10 @@ subroutine field_stack_peek(field_stack_obj, field_ptr, info_msg)
   ! Local variables
   character(*), parameter :: sub_name = "field_stack_peek"
 
-  call write_stack_info_msg(sub_name, field_stack_obj, info_msg)
-
   if (.not. associated(field_stack_obj%field)) call MOM_error(FATAL, &
       sub_name // ": field_stack_obj has not been initialized")
+
+  call write_stack_info_msg(sub_name, field_stack_obj, info_msg)
 
   if (field_stack_obj%top == 0) call MOM_error(FATAL, &
       sub_name // ": attempting to peek at empty stack")
@@ -169,10 +178,10 @@ subroutine field_stack_drop(field_stack_obj, info_msg)
   integer :: i, j, k
   integer :: i_offset, j_offset
 
-  call write_stack_info_msg(sub_name, field_stack_obj, info_msg)
-
   if (.not. associated(field_stack_obj%field)) call MOM_error(FATAL, &
       sub_name // ": field_stack_obj has not been initialized")
+
+  call write_stack_info_msg(sub_name, field_stack_obj, info_msg)
 
   if (field_stack_obj%top == 0) call MOM_error(FATAL, &
       sub_name // ": attempting to drop from empty stack")

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -216,7 +216,10 @@ subroutine apply_topography_edits_from_file(D, G, param_file, US)
                  units="m", default=-9999.0, scale=US%m_to_Z)
   if (mask_depth == -9999.*US%m_to_Z) mask_depth = min_depth
 
-  if (len_trim(topo_edits_file)==0) return
+  if (len_trim(topo_edits_file)==0) then
+    call callTree_leave(trim(mdl)//'()')
+    return
+  endif
 
   topo_edits_file = trim(inputdir)//trim(topo_edits_file)
   if (is_root_PE()) then

--- a/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
+++ b/src/parameterizations/lateral/MOM_lateral_mixing_coeffs.F90
@@ -450,7 +450,7 @@ subroutine calc_slope_functions(h, tv, dt, G, GV, US, CS, OBC)
   type(ocean_grid_type),                     intent(inout) :: G  !< Ocean grid structure
   type(verticalGrid_type),                   intent(in)    :: GV !< Vertical grid structure
   type(unit_scale_type),                     intent(in)    :: US !< A dimensional unit scaling type
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(inout) :: h  !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in)    :: h  !< Layer thickness [H ~> m or kg m-2]
   type(thermo_var_ptrs),                     intent(in)    :: tv !< Thermodynamic variables
   real,                                      intent(in)    :: dt !< Time increment [T ~> s]
   type(VarMix_CS),                           intent(inout) :: CS !< Variable mixing control struct
@@ -857,7 +857,7 @@ end subroutine calc_Eady_growth_rate_2D
 subroutine calc_slope_functions_using_just_e(h, G, GV, US, CS, e, calculate_slopes, OBC)
   type(ocean_grid_type),                       intent(inout) :: G  !< Ocean grid structure
   type(verticalGrid_type),                     intent(in)    :: GV !< Vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   intent(inout) :: h  !< Layer thickness [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)),   intent(in)    :: h  !< Layer thickness [H ~> m or kg m-2]
   type(unit_scale_type),                       intent(in)    :: US !< A dimensional unit scaling type
   type(VarMix_CS),                             intent(inout) :: CS !< Variable mixing control struct
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)+1), intent(in)    :: e  !< Interface position [Z ~> m]

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -5,8 +5,8 @@ module MOM_CVMix_KPP
 
 use MOM_coms,           only : max_across_PEs
 use MOM_debugging,      only : hchksum, is_NaN
-use MOM_diag_mediator,  only : time_type, diag_ctrl, safe_alloc_ptr, post_data
-use MOM_diag_mediator,  only : query_averaging_enabled, register_diag_field
+use MOM_diag_mediator,  only : time_type, diag_ctrl, post_data
+use MOM_diag_mediator,  only : register_diag_field
 use MOM_error_handler,  only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_PE
 use MOM_EOS,            only : EOS_type, calculate_density
 use MOM_file_parser,    only : get_param, log_param, log_version, param_file_type

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -49,7 +49,7 @@ use MOM_internal_tides,      only : internal_tides_init, internal_tides_end, int
 use MOM_kappa_shear,         only : kappa_shear_is_used
 use MOM_CVMix_KPP,           only : KPP_CS, KPP_init, KPP_compute_BLD, KPP_calculate
 use MOM_CVMix_KPP,           only : KPP_end, KPP_get_BLD
-use MOM_CVMix_KPP,           only : KPP_NonLocalTransport_temp, KPP_NonLocalTransport_saln
+use MOM_CVMix_KPP,           only : KPP_NonLocalTransport
 use MOM_oda_incupd,          only : apply_oda_incupd, oda_incupd_CS
 use MOM_opacity,             only : opacity_init, opacity_end, opacity_CS
 use MOM_opacity,             only : absorbRemainingSW, optics_type, optics_nbands
@@ -741,10 +741,10 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Tim
     endif
     ! Apply non-local transport of heat and salt
     ! Changes: tv%T, tv%S
-    call KPP_NonLocalTransport_temp(CS%KPP_CSp, G, GV, h, CS%KPP_NLTheat,   CS%KPP_temp_flux, &
-                                    dt, tv%tr_T, tv%T, tv%C_p)
-    call KPP_NonLocalTransport_saln(CS%KPP_CSp, G, GV, h, CS%KPP_NLTscalar, CS%KPP_salt_flux, &
-                                    dt, tv%tr_S, tv%S)
+    call KPP_NonLocalTransport(CS%KPP_CSp, G, GV, h, CS%KPP_NLTheat,   CS%KPP_temp_flux, dt, &
+                               tv%tr_T, tv%T)
+    call KPP_NonLocalTransport(CS%KPP_CSp, G, GV, h, CS%KPP_NLTscalar, CS%KPP_salt_flux, dt, &
+                               tv%tr_S, tv%S)
     call cpu_clock_end(id_clock_kpp)
     if (showCallTree) call callTree_waypoint("done with KPP_applyNonLocalTransport (diabatic)")
     if (CS%debugConservation) call MOM_state_stats('KPP_applyNonLocalTransport', u, v, h, tv%T, tv%S, G, GV, US)
@@ -1320,10 +1320,10 @@ subroutine diabatic_ALE(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_end, 
     endif
     ! Apply non-local transport of heat and salt
     ! Changes: tv%T, tv%S
-    call KPP_NonLocalTransport_temp(CS%KPP_CSp, G, GV, h, CS%KPP_NLTheat,   CS%KPP_temp_flux, &
-                                    dt, tv%tr_T, tv%T, tv%C_p)
-    call KPP_NonLocalTransport_saln(CS%KPP_CSp, G, GV, h, CS%KPP_NLTscalar, CS%KPP_salt_flux, &
-                                    dt, tv%tr_S, tv%S)
+    call KPP_NonLocalTransport(CS%KPP_CSp, G, GV, h, CS%KPP_NLTheat,   CS%KPP_temp_flux, dt, &
+                               tv%tr_T, tv%T)
+    call KPP_NonLocalTransport(CS%KPP_CSp, G, GV, h, CS%KPP_NLTscalar, CS%KPP_salt_flux, dt, &
+                               tv%tr_S, tv%S)
     call cpu_clock_end(id_clock_kpp)
     if (showCallTree) call callTree_waypoint("done with KPP_applyNonLocalTransport (diabatic)")
     if (CS%debugConservation) call MOM_state_stats('KPP_applyNonLocalTransport', u, v, h, tv%T, tv%S, G, GV, US)
@@ -1945,10 +1945,10 @@ subroutine layered_diabatic(u, v, h, tv, Hml, fluxes, visc, ADp, CDp, dt, Time_e
     endif
     ! Apply non-local transport of heat and salt
     ! Changes: tv%T, tv%S
-    call KPP_NonLocalTransport_temp(CS%KPP_CSp, G, GV, h, CS%KPP_NLTheat,   CS%KPP_temp_flux, &
-                                    dt, tv%tr_T, tv%T, tv%C_p)
-    call KPP_NonLocalTransport_saln(CS%KPP_CSp, G, GV, h, CS%KPP_NLTscalar, CS%KPP_salt_flux, &
-                                    dt, tv%tr_S, tv%S)
+    call KPP_NonLocalTransport(CS%KPP_CSp, G, GV, h, CS%KPP_NLTheat,   CS%KPP_temp_flux, dt, &
+                               tv%tr_T, tv%T)
+    call KPP_NonLocalTransport(CS%KPP_CSp, G, GV, h, CS%KPP_NLTscalar, CS%KPP_salt_flux, dt, &
+                               tv%tr_S, tv%S)
     call cpu_clock_end(id_clock_kpp)
     if (showCallTree) call callTree_waypoint("done with KPP_applyNonLocalTransport (diabatic)")
     if (CS%debugConservation) call MOM_state_stats('KPP_applyNonLocalTransport', u, v, h, tv%T, tv%S, G, GV, US)

--- a/src/parameterizations/vertical/MOM_geothermal.F90
+++ b/src/parameterizations/vertical/MOM_geothermal.F90
@@ -562,8 +562,6 @@ subroutine geothermal_init(Time, G, GV, US, param_file, diag, CS, tv, useALEalgo
         'internal_heat_temp_tendency', diag%axesTL, Time,              &
         'Temperature tendency (in 3D) due to internal (geothermal) sources', &
         'degC s-1', conversion=US%s_to_T)
-  if ((CS%id_internal_heat_heat_tendency > 0) .or. (CS%id_internal_heat_temp_tendency > 0)) &
-      tv%tr_T%comp_process_tend = .true.
   if (.not.useALEalgorithm) then
     ! Do not offer this diagnostic if heating will be in place.
     CS%id_internal_heat_h_tendency=register_diag_field('ocean_model',    &

--- a/src/tracer/DOME_tracer.F90
+++ b/src/tracer/DOME_tracer.F90
@@ -16,8 +16,13 @@ use MOM_open_boundary,   only : OBC_segment_type
 use MOM_restart,         only : MOM_restart_CS
 use MOM_sponge,          only : set_up_sponge_field, sponge_CS
 use MOM_time_manager,    only : time_type
-use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
+use MOM_tracer_registry, only : register_tracer
+use MOM_tracer_types,    only : tracer_registry_type, col_act_apply_KPP_NLT
+use MOM_tracer_types,    only : col_act_pre_tridiag_solve_sources
+use MOM_tracer_types,    only : col_act_apply_boundary_fluxes
+use MOM_tracer_types,    only : col_act_tridiag_solve
+use MOM_tracer_types,    only : col_act_post_tridiag_solve_sources
 use MOM_unit_scaling,    only : unit_scale_type
 use MOM_variables,       only : surface
 use MOM_verticalGrid,    only : verticalGrid_type
@@ -279,17 +284,14 @@ end subroutine initialize_DOME_tracer
 !> This subroutine applies diapycnal diffusion and any other column
 !! tracer physics or chemistry to the tracers from this file.
 !! This is a simple example of a set of advected passive tracers.
-!!
-!! The arguments to this subroutine are redundant in that
-!!     h_new(k) = h_old(k) + ea(k) - eb(k-1) + eb(k) - ea(k+1)
-subroutine DOME_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV, US, CS, &
+subroutine DOME_tracer_column_physics(action, h, ea, eb, fluxes, dt, G, GV, US, CS, &
               evap_CFL_limit, minimum_forcing_depth)
+  integer,                 intent(in) :: action !< action to be performed with this invocation
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in) :: h_old !< Layer thickness before entrainment [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in) :: h_new !< Layer thickness after entrainment [H ~> m or kg m-2].
+                           intent(in) :: h    !< Layer thickness at time level appropriate
+                                              !! for action [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(in) :: ea   !< an array to which the amount of fluid entrained
                                               !! from the layer above during this call will be
@@ -309,27 +311,33 @@ subroutine DOME_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV,
   real,          optional, intent(in) :: minimum_forcing_depth !< The smallest depth over which
                                               !! fluxes can be applied [H ~> m or kg m-2]
 
-! Local variables
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
-  integer :: i, j, k, is, ie, js, je, nz, m
-  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+  ! Local variables
+  integer :: m
 
   if (.not.associated(CS)) return
 
-  if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
-    do m=1,NTR
-      do k=1,nz ;do j=js,je ; do i=is,ie
-          h_work(i,j,k) = h_old(i,j,k)
-      enddo ; enddo ; enddo
-      call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h_work, &
-                                          evap_CFL_limit, minimum_forcing_depth)
-      call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
-    enddo
-  else
-    do m=1,NTR
-      call tracer_vertdiff(h_old, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
-    enddo
-  endif
+  select case ( action )
+    case ( col_act_apply_KPP_NLT )
+      ! KPP NLT not applicable to this tracer module
+
+    case ( col_act_pre_tridiag_solve_sources )
+      ! there are no pre-tridiag solve sources in this tracer module
+
+    case ( col_act_apply_boundary_fluxes )
+      do m=1,NTR
+        call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h, &
+                                            evap_CFL_limit, minimum_forcing_depth)
+      enddo
+
+    case ( col_act_tridiag_solve )
+      do m=1,NTR
+        call tracer_vertdiff(h, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
+      enddo
+
+    case ( col_act_post_tridiag_solve_sources )
+      ! there are no post-tridiag solve sources in this tracer module
+
+  end select
 
 end subroutine DOME_tracer_column_physics
 

--- a/src/tracer/MOM_CFC_cap.F90
+++ b/src/tracer/MOM_CFC_cap.F90
@@ -317,10 +317,10 @@ subroutine CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, C
     if (associated(KPP_CSp) .and. present(nonLocalTrans)) then
       flux_scale = GV%Z_to_H / GV%rho0
 
-      call KPP_NonLocalTransport(KPP_CSp, G, GV, h_old, nonLocalTrans, fluxes%cfc11_flux(:,:), dt, CS%diag, &
+      call KPP_NonLocalTransport(KPP_CSp, G, GV, h_old, nonLocalTrans, fluxes%cfc11_flux(:,:), dt, &
                                 CS%CFC_data(1)%tr_ptr, CS%CFC_data(1)%conc(:,:,:), &
                                 flux_scale=flux_scale)
-      call KPP_NonLocalTransport(KPP_CSp, G, GV, h_old, nonLocalTrans, fluxes%cfc12_flux(:,:), dt, CS%diag, &
+      call KPP_NonLocalTransport(KPP_CSp, G, GV, h_old, nonLocalTrans, fluxes%cfc12_flux(:,:), dt, &
                                 CS%CFC_data(2)%tr_ptr, CS%CFC_data(2)%conc(:,:,:), &
                                 flux_scale=flux_scale)
     endif

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -442,147 +442,104 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, 
   if (.not. associated(CS)) call MOM_error(FATAL, "call_tracer_column_fns: "// &
          "Module must be initialized via call_tracer_register before it is used.")
 
-  ! Use the applyTracerBoundaryFluxesInOut to handle surface fluxes
-  if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
-    ! Add calls to tracer column functions here.
-    if (CS%use_USER_tracer_example) &
-      call tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                 G, GV, US, CS%USER_tracer_example_CSp)
-    if (CS%use_DOME_tracer) &
-      call DOME_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                      G, GV, US, CS%DOME_tracer_CSp, &
+  ! Add calls to tracer column functions here.
+
+  if (CS%use_USER_tracer_example) &
+    call tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                               G, GV, US, CS%USER_tracer_example_CSp)
+
+  if (CS%use_DOME_tracer) &
+    call DOME_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                    G, GV, US, CS%DOME_tracer_CSp, &
+                                    evap_CFL_limit=evap_CFL_limit, &
+                                    minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_ISOMIP_tracer) &
+    call ISOMIP_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                      G, GV, US, CS%ISOMIP_tracer_CSp, &
                                       evap_CFL_limit=evap_CFL_limit, &
                                       minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_ISOMIP_tracer) &
-      call ISOMIP_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                        G, GV, US, CS%ISOMIP_tracer_CSp, &
-                                        evap_CFL_limit=evap_CFL_limit, &
-                                        minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_RGC_tracer) &
-      call RGC_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                        G, GV, US, CS%RGC_tracer_CSp, &
-                                        evap_CFL_limit=evap_CFL_limit, &
-                                        minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_ideal_age) &
-      call ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                           G, GV, US, CS%ideal_age_tracer_CSp, &
+
+  if (CS%use_RGC_tracer) &
+    call RGC_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                      G, GV, US, CS%RGC_tracer_CSp, &
+                                      evap_CFL_limit=evap_CFL_limit, &
+                                      minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_ideal_age) &
+    call ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                         G, GV, US, CS%ideal_age_tracer_CSp, &
+                                         evap_CFL_limit=evap_CFL_limit, &
+                                         minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_regional_dyes) &
+    call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                   G, GV, US, CS%dye_tracer_CSp, &
+                                   evap_CFL_limit=evap_CFL_limit, &
+                                   minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_oil) &
+    call oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                   G, GV, US, CS%oil_tracer_CSp, tv, &
+                                   evap_CFL_limit=evap_CFL_limit, &
+                                   minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_advection_test_tracer) &
+    call advection_test_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                              G, GV, US, CS%advection_test_tracer_CSp, &
+                                              evap_CFL_limit=evap_CFL_limit, &
+                                              minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_OCMIP2_CFC) &
+    call OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                   G, GV, US, CS%OCMIP2_CFC_CSp, &
+                                   evap_CFL_limit=evap_CFL_limit, &
+                                   minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_CFC_cap) &
+    call CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                   G, GV, US, CS%CFC_cap_CSp, &
+                                   KPP_CSp=KPP_CSp, &
+                                   nonLocalTrans=nonLocalTrans, &
+                                   evap_CFL_limit=evap_CFL_limit, &
+                                   minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_MOM_generic_tracer) then
+    if (US%QRZ_T_to_W_m2 /= 1.0) call MOM_error(FATAL, "MOM_generic_tracer_column_physics "//&
+          "has not been written to permit dimensionsal rescaling.  Set all 4 of the "//&
+          "[QRZT]_RESCALE_POWER parameters to 0.")
+    call MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, dt, &
+                                           G, GV, US, CS%MOM_generic_tracer_CSp, tv, optics, &
                                            evap_CFL_limit=evap_CFL_limit, &
                                            minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_regional_dyes) &
-      call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%dye_tracer_CSp, &
-                                     evap_CFL_limit=evap_CFL_limit, &
-                                     minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_oil) &
-      call oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%oil_tracer_CSp, tv, &
-                                     evap_CFL_limit=evap_CFL_limit, &
-                                     minimum_forcing_depth=minimum_forcing_depth)
-
-    if (CS%use_advection_test_tracer) &
-      call advection_test_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                                G, GV, US, CS%advection_test_tracer_CSp, &
-                                                evap_CFL_limit=evap_CFL_limit, &
-                                                minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_OCMIP2_CFC) &
-      call OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%OCMIP2_CFC_CSp, &
-                                     evap_CFL_limit=evap_CFL_limit, &
-                                     minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_CFC_cap) &
-      call CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%CFC_cap_CSp, &
-                                     KPP_CSp=KPP_CSp, &
-                                     nonLocalTrans=nonLocalTrans, &
-                                     evap_CFL_limit=evap_CFL_limit, &
-                                     minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_MOM_generic_tracer) then
-      if (US%QRZ_T_to_W_m2 /= 1.0) call MOM_error(FATAL, "MOM_generic_tracer_column_physics "//&
-            "has not been written to permit dimensionsal rescaling.  Set all 4 of the "//&
-            "[QRZT]_RESCALE_POWER parameters to 0.")
-      call MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, dt, &
-                                             G, GV, US, CS%MOM_generic_tracer_CSp, tv, optics, &
-                                             evap_CFL_limit=evap_CFL_limit, &
-                                             minimum_forcing_depth=minimum_forcing_depth)
-    endif
-    if (CS%use_pseudo_salt_tracer) &
-      call pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%pseudo_salt_tracer_CSp, tv, &
-                                     debug, &
-                                     KPP_CSp=KPP_CSp, &
-                                     nonLocalTrans=nonLocalTrans, &
-                                     evap_CFL_limit=evap_CFL_limit, &
-                                     minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_boundary_impulse_tracer) &
-      call boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%boundary_impulse_tracer_CSp, tv, debug, &
-                                     evap_CFL_limit=evap_CFL_limit, &
-                                     minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_dyed_obc_tracer) &
-      call dyed_obc_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                      G, GV, US, CS%dyed_obc_tracer_CSp, &
-                                      evap_CFL_limit=evap_CFL_limit, &
-                                      minimum_forcing_depth=minimum_forcing_depth)
-    if (CS%use_nw2_tracers) &
-      call nw2_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, tv, CS%nw2_tracers_CSp, &
-                                     evap_CFL_limit=evap_CFL_limit, &
-                                     minimum_forcing_depth=minimum_forcing_depth)
-  else ! Apply tracer surface fluxes using ea on the first layer
-    if (CS%use_USER_tracer_example) &
-      call tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                 G, GV, US, CS%USER_tracer_example_CSp)
-    if (CS%use_DOME_tracer) &
-      call DOME_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                      G, GV, US, CS%DOME_tracer_CSp)
-    if (CS%use_ISOMIP_tracer) &
-      call ISOMIP_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                      G, GV, US, CS%ISOMIP_tracer_CSp)
-    if (CS%use_RGC_tracer) &
-      call RGC_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                      G, GV, US, CS%RGC_tracer_CSp)
-    if (CS%use_ideal_age) &
-      call ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                           G, GV, US, CS%ideal_age_tracer_CSp)
-    if (CS%use_regional_dyes) &
-      call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                           G, GV, US, CS%dye_tracer_CSp)
-    if (CS%use_oil) &
-      call oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%oil_tracer_CSp, tv)
-    if (CS%use_advection_test_tracer) &
-      call advection_test_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                      G, GV, US, CS%advection_test_tracer_CSp)
-    if (CS%use_OCMIP2_CFC) &
-      call OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%OCMIP2_CFC_CSp)
-    if (CS%use_CFC_cap) &
-      call CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%CFC_cap_CSp, &
-                                     KPP_CSp=KPP_CSp, &
-                                     nonLocalTrans=nonLocalTrans)
-    if (CS%use_MOM_generic_tracer) then
-      if (US%QRZ_T_to_W_m2 /= 1.0) call MOM_error(FATAL, "MOM_generic_tracer_column_physics "//&
-            "has not been written to permit dimensionsal rescaling.  Set all 4 of the "//&
-            "[QRZT]_RESCALE_POWER parameters to 0.")
-      call MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, dt, &
-                                     G, GV, US, CS%MOM_generic_tracer_CSp, tv, optics)
-    endif
-    if (CS%use_pseudo_salt_tracer) &
-      call pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%pseudo_salt_tracer_CSp, &
-                                     tv, debug, &
-                                     KPP_CSp=KPP_CSp, &
-                                     nonLocalTrans=nonLocalTrans)
-    if (CS%use_boundary_impulse_tracer) &
-      call boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                     G, GV, US, CS%boundary_impulse_tracer_CSp, tv, debug)
-    if (CS%use_dyed_obc_tracer) &
-      call dyed_obc_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                      G, GV, US, CS%dyed_obc_tracer_CSp)
-    if (CS%use_nw2_tracers) call nw2_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                                           G, GV, US, tv, CS%nw2_tracers_CSp)
   endif
+
+  if (CS%use_pseudo_salt_tracer) &
+    call pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                   G, GV, US, CS%pseudo_salt_tracer_CSp, tv, &
+                                   debug, &
+                                   KPP_CSp=KPP_CSp, &
+                                   nonLocalTrans=nonLocalTrans, &
+                                   evap_CFL_limit=evap_CFL_limit, &
+                                   minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_boundary_impulse_tracer) &
+    call boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                   G, GV, US, CS%boundary_impulse_tracer_CSp, tv, debug, &
+                                   evap_CFL_limit=evap_CFL_limit, &
+                                   minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_dyed_obc_tracer) &
+    call dyed_obc_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                    G, GV, US, CS%dyed_obc_tracer_CSp, &
+                                    evap_CFL_limit=evap_CFL_limit, &
+                                    minimum_forcing_depth=minimum_forcing_depth)
+
+  if (CS%use_nw2_tracers) &
+    call nw2_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                   G, GV, US, tv, CS%nw2_tracers_CSp, &
+                                   evap_CFL_limit=evap_CFL_limit, &
+                                   minimum_forcing_depth=minimum_forcing_depth)
 
 end subroutine call_tracer_column_fns
 

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -402,14 +402,14 @@ subroutine call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G
 end subroutine call_tracer_set_forcing
 
 !> This subroutine calls all registered tracer column physics subroutines.
-subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, US, tv, optics, CS, &
-                                  debug, KPP_CSp, nonLocalTrans, evap_CFL_limit, minimum_forcing_depth)
+subroutine call_tracer_column_fns(action, h, ea, eb, fluxes, Hml, dt, G, GV, US, tv, &
+                                  optics, CS, debug, KPP_CSp, nonLocalTrans, evap_CFL_limit, &
+                                  minimum_forcing_depth)
+  integer,                               intent(in) :: action !< action to be performed with this invocation
   type(ocean_grid_type),                 intent(in) :: G      !< The ocean's grid structure.
   type(verticalGrid_type),               intent(in) :: GV     !< The ocean's vertical grid structure.
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h_old !< Layer thickness before entrainment
-                                                              !! [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h_new !< Layer thickness after entrainment
-                                                              !! [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h  !< Layer thickness at time level appropriate
+                                                              !! for action [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: ea !< an array to which the amount of
                                           !! fluid entrained from the layer above during this call
                                           !! will be added [H ~> m or kg m-2].
@@ -445,59 +445,59 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, 
   ! Add calls to tracer column functions here.
 
   if (CS%use_USER_tracer_example) &
-    call tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                G, GV, US, CS%USER_tracer_example_CSp)
 
   if (CS%use_DOME_tracer) &
-    call DOME_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call DOME_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                     G, GV, US, CS%DOME_tracer_CSp, &
                                     evap_CFL_limit=evap_CFL_limit, &
                                     minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_ISOMIP_tracer) &
-    call ISOMIP_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call ISOMIP_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                       G, GV, US, CS%ISOMIP_tracer_CSp, &
                                       evap_CFL_limit=evap_CFL_limit, &
                                       minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_RGC_tracer) &
-    call RGC_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call RGC_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                       G, GV, US, CS%RGC_tracer_CSp, &
                                       evap_CFL_limit=evap_CFL_limit, &
                                       minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_ideal_age) &
-    call ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call ideal_age_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                          G, GV, US, CS%ideal_age_tracer_CSp, &
                                          evap_CFL_limit=evap_CFL_limit, &
                                          minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_regional_dyes) &
-    call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call dye_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                    G, GV, US, CS%dye_tracer_CSp, &
                                    evap_CFL_limit=evap_CFL_limit, &
                                    minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_oil) &
-    call oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call oil_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                    G, GV, US, CS%oil_tracer_CSp, tv, &
                                    evap_CFL_limit=evap_CFL_limit, &
                                    minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_advection_test_tracer) &
-    call advection_test_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call advection_test_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                               G, GV, US, CS%advection_test_tracer_CSp, &
                                               evap_CFL_limit=evap_CFL_limit, &
                                               minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_OCMIP2_CFC) &
-    call OCMIP2_CFC_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call OCMIP2_CFC_column_physics(action, h, ea, eb, fluxes, dt, &
                                    G, GV, US, CS%OCMIP2_CFC_CSp, &
                                    evap_CFL_limit=evap_CFL_limit, &
                                    minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_CFC_cap) &
-    call CFC_cap_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call CFC_cap_column_physics(action, h, ea, eb, fluxes, dt, &
                                    G, GV, US, CS%CFC_cap_CSp, &
                                    KPP_CSp=KPP_CSp, &
                                    nonLocalTrans=nonLocalTrans, &
@@ -508,35 +508,34 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, Hml, dt, G, GV, 
     if (US%QRZ_T_to_W_m2 /= 1.0) call MOM_error(FATAL, "MOM_generic_tracer_column_physics "//&
           "has not been written to permit dimensionsal rescaling.  Set all 4 of the "//&
           "[QRZT]_RESCALE_POWER parameters to 0.")
-    call MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, dt, &
-                                           G, GV, US, CS%MOM_generic_tracer_CSp, tv, optics, &
-                                           evap_CFL_limit=evap_CFL_limit, &
+    call MOM_generic_tracer_column_physics(action, h, ea, eb, fluxes, Hml, dt, &
+                                           G, GV, US, CS%MOM_generic_tracer_CSp, tv, &
+                                           optics, evap_CFL_limit=evap_CFL_limit, &
                                            minimum_forcing_depth=minimum_forcing_depth)
   endif
 
   if (CS%use_pseudo_salt_tracer) &
-    call pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                   G, GV, US, CS%pseudo_salt_tracer_CSp, tv, &
-                                   debug, &
+    call pseudo_salt_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
+                                   G, GV, US, CS%pseudo_salt_tracer_CSp, tv, debug, &
                                    KPP_CSp=KPP_CSp, &
                                    nonLocalTrans=nonLocalTrans, &
                                    evap_CFL_limit=evap_CFL_limit, &
                                    minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_boundary_impulse_tracer) &
-    call boundary_impulse_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call boundary_impulse_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                    G, GV, US, CS%boundary_impulse_tracer_CSp, tv, debug, &
                                    evap_CFL_limit=evap_CFL_limit, &
                                    minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_dyed_obc_tracer) &
-    call dyed_obc_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call dyed_obc_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                     G, GV, US, CS%dyed_obc_tracer_CSp, &
                                     evap_CFL_limit=evap_CFL_limit, &
                                     minimum_forcing_depth=minimum_forcing_depth)
 
   if (CS%use_nw2_tracers) &
-    call nw2_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+    call nw2_tracer_column_physics(action, h, ea, eb, fluxes, dt, &
                                    G, GV, US, tv, CS%nw2_tracers_CSp, &
                                    evap_CFL_limit=evap_CFL_limit, &
                                    minimum_forcing_depth=minimum_forcing_depth)

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -570,6 +570,8 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, G, GV, US, CS, Reg, tv, do_online
     call cpu_clock_begin(id_clock_epimix)
     call tracer_epipycnal_ML_diff(h, dt, Reg%Tr, ntr, khdt_x, khdt_y, G, GV, US, &
                                   CS, tv, num_itts)
+    ! state dependent diagnostic grids are now out of sync with respect to h
+    call set_diag_in_sync_with_state(CS%diag, .false.)
     call cpu_clock_end(id_clock_epimix)
   endif
 

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -280,7 +280,6 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
   character(len=120) :: var_lname      ! A temporary longname for a diagnostic.
   character(len=120) :: cmor_var_lname ! The temporary CMOR long name for a diagnostic
   character(len=72)  :: cmor_varname ! The temporary CMOR name for a diagnostic
-  real :: conversion ! Temporary term while we address a bug
   type(tracer_type), pointer :: Tr=>NULL()
   integer :: i, j, k, is, ie, js, je, nz, m, m2, nTr_in
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
@@ -604,20 +603,10 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
           diag%axesTL, Time, &
           trim(longname)//' tendency due to non-local transport of '//trim(lowercase(flux_longname))//&
           ', as calculated by [CVMix] KPP', trim(units)//' s-1', conversion=US%s_to_T)
-      if (Tr%conv_scale == 0.001*GV%H_to_kg_m2) then
-        conversion = GV%H_to_kg_m2
-      else
-        conversion = Tr%conv_scale
-      end if
-      ! We actually want conversion=Tr%conv_scale for all tracers, but introducing the local variable
-      ! 'conversion' and setting it to GV%H_to_kg_m2 instead of 0.001*GV%H_to_kg_m2 for salt tracers
-      ! keeps changes introduced by this refactoring limited to round-off level; as it turns out,
-      ! there is a bug in the code and the NLT budget term for salinity is off by a factor of 10^3
-      ! so introducing the 0.001 here will fix that bug.
       Tr%id_NLT_budget = register_diag_field('ocean_model', Tr%NLT_budget_name, &
           diag%axesTL, Time, &
           trim(flux_longname)//' content change due to non-local transport, as calculated by [CVMix] KPP', &
-          conv_units, conversion=conversion*US%s_to_T, v_extensive=.true.)
+          conv_units, conversion=Tr%conv_scale*US%s_to_T, v_extensive=.true.)
     endif
 
   endif ; enddo

--- a/src/tracer/MOM_tracer_types.F90
+++ b/src/tracer/MOM_tracer_types.F90
@@ -101,6 +101,7 @@ type, public :: tracer_type
   integer :: diag_form = 1  !< An integer indicating which template is to be used to label diagnostics.
   !>@{ Diagnostic IDs
   integer :: id_tr = -1, id_tr_post_horzn = -1
+  integer :: id_trxh = -1, id_trxh_2d = -1
   integer :: id_adx = -1, id_ady = -1, id_dfx = -1, id_dfy = -1
   integer :: id_lbd_bulk_dfx = -1, id_lbd_bulk_dfy = -1, id_lbd_dfx = -1, id_lbd_dfy = -1
   integer :: id_lbd_dfx_2d = -1  , id_lbd_dfy_2d = -1

--- a/src/tracer/MOM_tracer_types.F90
+++ b/src/tracer/MOM_tracer_types.F90
@@ -41,8 +41,6 @@ type, public :: tracer_type
 !  type(vardesc), pointer          :: vd             => NULL() !< metadata describing the tracer
   logical                         :: registry_diags = .false. !< If true, use the registry to set up the
                                                               !! diagnostics associated with this tracer.
-  logical                         :: comp_process_tend = .false. !< If true, then some process tendency
-                                                              !! diagnostics are enabled for this tracer
   character(len=64)               :: cmor_name                !< CMOR name of this tracer
   character(len=64)               :: cmor_units               !< CMOR physical dimensions of the tracer
   character(len=240)              :: cmor_longname            !< CMOR long name of the tracer

--- a/src/tracer/MOM_tracer_types.F90
+++ b/src/tracer/MOM_tracer_types.F90
@@ -64,7 +64,7 @@ type, public :: tracer_type
   character(len=48)               :: net_surfflux_name = ""   !< Name to use for net_surfflux KPP diagnostic
   character(len=48)               :: NLT_budget_name = ""     !< Name to use for NLT_budget KPP diagnostic
   character(len=128)              :: net_surfflux_longname = ""   !< Long name to use for net_surfflux KPP diagnostic
-  integer :: ind_tr_squared = -1 !< The tracer registry index for the square of this tracer
+  integer :: ind_tr_squared = -2 !< The tracer registry index for the square of this tracer
 
   !### THESE CAPABILITIES HAVE NOT YET BEEN IMPLEMENTED.
   ! logical :: advect_tr = .true.       !< If true, this tracer should be advected
@@ -86,7 +86,10 @@ type, public :: tracer_type
   integer :: id_remap_conc = -1, id_remap_cont = -1, id_remap_cont_2d = -1
   integer :: id_tendency = -1, id_trxh_tendency = -1, id_trxh_tendency_2d = -1
   integer :: id_tr_vardec = -1
+  integer :: id_frazil_conc = -1, id_frazil_cont = -1, id_frazil_cont_2d = -1
   integer :: id_net_surfflux = -1, id_NLT_tendency = -1, id_NLT_budget = -1
+  integer :: id_bndry_forc_conc = -1, id_bndry_forc_cont = -1, id_bndry_forc_cont_2d = -1
+  integer :: id_diabatic_diff_conc = -1, id_diabatic_diff_cont = -1, id_diabatic_diff_cont_2d = -1
   !>@}
 end type tracer_type
 
@@ -103,8 +106,22 @@ type, public :: tracer_registry_type
   logical, allocatable     :: comp_remap_tend(:)    !< are remap tendencies being computed, per tracer
   logical, allocatable     :: comp_adv_tend(:)      !< are advective tendencies being computed, per tracer
   logical, allocatable     :: comp_lbd_tend(:)      !< are lbdtendencies being computed, per tracer
-  logical, allocatable     :: comp_neu_diff_tend(:) !< are neutral diffusivetendencies being computed, per tracer
+  logical, allocatable     :: comp_neu_diff_tend(:) !< are neutral diffusive tendencies being computed, per tracer
+  logical, allocatable     :: comp_frazil_tend(:)   !< are frazil formation tendencies being compued, per tracer
+  logical, allocatable     :: comp_KPP_NLT_tend(:)  !< are KPP NLT tendencies being compued, per tracer
+  logical, allocatable     :: comp_bndry_forc_tend(:) !< are boundary forcing tendencies being compued, per tracer
+  logical, allocatable     :: comp_diabatic_diff_tend(:) !< are boundary forcing tendencies being compued, per tracer
 end type tracer_registry_type
 
+! Values to specify actions for tracer_column_physics calls.
+! The actual values are arbitrary.
+
+integer, parameter, public :: col_act_apply_KPP_NLT = 1              !< apply KPP non-local transport term
+integer, parameter, public :: col_act_pre_tridiag_solve_sources = 2  !< apply source terms prior to
+                                                                     !! tridiagonal solve
+integer, parameter, public :: col_act_apply_boundary_fluxes = 3      !< apply boundary fluxes
+integer, parameter, public :: col_act_tridiag_solve = 4              !< perform tridiagonal solve
+integer, parameter, public :: col_act_post_tridiag_solve_sources = 5 !< apply source terms after to
+                                                                     !! tridiagonal solve
 
 end module MOM_tracer_types

--- a/src/tracer/advection_test_tracer.F90
+++ b/src/tracer/advection_test_tracer.F90
@@ -15,8 +15,13 @@ use MOM_open_boundary, only : ocean_OBC_type
 use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_sponge, only : set_up_sponge_field, sponge_CS
 use MOM_time_manager, only : time_type
-use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
+use MOM_tracer_registry, only : register_tracer
+use MOM_tracer_types, only : tracer_registry_type, col_act_apply_KPP_NLT
+use MOM_tracer_types, only : col_act_pre_tridiag_solve_sources
+use MOM_tracer_types, only : col_act_apply_boundary_fluxes
+use MOM_tracer_types, only : col_act_tridiag_solve
+use MOM_tracer_types, only : col_act_post_tridiag_solve_sources
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface
 use MOM_verticalGrid, only : verticalGrid_type
@@ -253,14 +258,14 @@ end subroutine initialize_advection_test_tracer
 
 !>   Applies diapycnal diffusion and any other column tracer physics or chemistry to the tracers
 !! from this package.  This is a simple example of a set of advected passive tracers.
-subroutine advection_test_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, dt, G, GV, US, CS, &
-              evap_CFL_limit, minimum_forcing_depth)
+subroutine advection_test_tracer_column_physics(action, h, ea, eb, fluxes, dt, G, &
+                                                GV, US, CS, evap_CFL_limit, minimum_forcing_depth)
+  integer,                 intent(in) :: action !< action to be performed with this invocation
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in) :: h_old !< Layer thickness before entrainment [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                           intent(in) :: h_new !< Layer thickness after entrainment [H ~> m or kg m-2].
+                           intent(in) :: h    !< Layer thickness at time level appropriate
+                                              !! for action [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(in) :: ea   !< an array to which the amount of fluid entrained
                                               !! from the layer above during this call will be
@@ -283,29 +288,33 @@ subroutine advection_test_tracer_column_physics(h_old, h_new,  ea,  eb, fluxes, 
 ! tracer physics or chemistry to the tracers from this file.
 ! This is a simple example of a set of advected passive tracers.
 
-! The arguments to this subroutine are redundant in that
-!     h_new(k) = h_old(k) + ea(k) - eb(k-1) + eb(k) - ea(k+1)
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
-  integer :: i, j, k, is, ie, js, je, nz, m
-  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+  integer :: m
 
   if (.not.associated(CS)) return
 
-  if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
-    do m=1,CS%ntr
-      do k=1,nz ;do j=js,je ; do i=is,ie
-        h_work(i,j,k) = h_old(i,j,k)
-      enddo ; enddo ; enddo
-      call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h_work, &
-                                          evap_CFL_limit, minimum_forcing_depth)
-      call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
-    enddo
-  else
-    do m=1,NTR
-      call tracer_vertdiff(h_old, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
-    enddo
-  endif
+  select case ( action )
+    case ( col_act_apply_KPP_NLT )
+      ! KPP NLT not applicable to this tracer module
+
+    case ( col_act_pre_tridiag_solve_sources )
+      ! there are no pre-tridiag solve sources in this tracer module
+
+    case ( col_act_apply_boundary_fluxes )
+      do m=1,CS%ntr
+        call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h, &
+                                            evap_CFL_limit, minimum_forcing_depth)
+      enddo
+
+    case ( col_act_tridiag_solve )
+      do m=1,NTR
+        call tracer_vertdiff(h, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
+      enddo
+
+    case ( col_act_post_tridiag_solve_sources )
+      ! there are no post-tridiag solve sources in this tracer module
+
+  end select
 
 end subroutine advection_test_tracer_column_physics
 

--- a/src/tracer/nw2_tracers.F90
+++ b/src/tracer/nw2_tracers.F90
@@ -12,8 +12,13 @@ use MOM_hor_index, only : hor_index_type
 use MOM_io, only : file_exists, MOM_read_data, slasher, vardesc, var_desc
 use MOM_restart, only : query_initialized, MOM_restart_CS
 use MOM_time_manager, only : time_type, time_type_to_real
-use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
+use MOM_tracer_registry, only : register_tracer
+use MOM_tracer_types, only : tracer_registry_type, col_act_apply_KPP_NLT
+use MOM_tracer_types, only : col_act_pre_tridiag_solve_sources
+use MOM_tracer_types, only : col_act_apply_boundary_fluxes
+use MOM_tracer_types, only : col_act_tridiag_solve
+use MOM_tracer_types, only : col_act_post_tridiag_solve_sources
 use MOM_unit_scaling, only : unit_scale_type
 use MOM_variables, only : surface, thermo_var_ptrs
 use MOM_verticalGrid, only : verticalGrid_type
@@ -174,14 +179,14 @@ subroutine initialize_nw2_tracers(restart, day, G, GV, US, h, tv, diag, CS)
 end subroutine initialize_nw2_tracers
 
 !> Applies diapycnal diffusion, aging and regeneration at the surface to the NW2 tracers
-subroutine nw2_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, tv, CS, &
+subroutine nw2_tracer_column_physics(action, h, ea, eb, fluxes, dt, G, GV, US, tv, CS, &
               evap_CFL_limit, minimum_forcing_depth)
+  integer,                 intent(in) :: action !< action to be performed with this invocation
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                           intent(in) :: h_old !< Layer thickness before entrainment [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                           intent(in) :: h_new !< Layer thickness after entrainment [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                           intent(in) :: h    !< Layer thickness at time level appropriate
+                                              !! for action [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(in) :: ea   !< an array to which the amount of fluid entrained
                                               !! from the layer above during this call will be
@@ -205,10 +210,7 @@ subroutine nw2_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
 ! tracer physics or chemistry to the tracers from this file.
 ! This is a simple example of a set of advected passive tracers.
 
-! The arguments to this subroutine are redundant in that
-!     h_new(k) = h_old(k) + ea(k) - eb(k-1) + eb(k) - ea(k+1)
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified [H ~> m or kg m-2]
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)+1) :: eta ! Interface heights [Z ~> m]
   integer :: i, j, k, m
   real :: dt_x_rate ! dt * restoring rate [nondim]
@@ -217,51 +219,60 @@ subroutine nw2_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US
 
 ! if (.not.associated(CS)) return
 
-  if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
-    do m=1,CS%ntr
-      do k=1,GV%ke ; do j=G%jsc,G%jec ; do i=G%isc,G%iec
-        h_work(i,j,k) = h_old(i,j,k)
-      enddo ; enddo ; enddo
-      call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h_work, &
-                                          evap_CFL_limit, minimum_forcing_depth)
-      call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
-    enddo
-  else
-    do m=1,CS%ntr
-      call tracer_vertdiff(h_old, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
-    enddo
-  endif
+  select case ( action )
+    case ( col_act_apply_KPP_NLT )
+      ! KPP NLT not applicable to this tracer module
 
-  ! Calculate z* interface positions
-  if (GV%Boussinesq) then
-    ! First calculate interface positions in z-space (m)
-    do j=G%jsc,G%jec ; do i=G%isc,G%iec
-      eta(i,j,GV%ke+1) = - G%mask2dT(i,j) * G%bathyT(i,j)
-    enddo ; enddo
-    do k=GV%ke,1,-1 ; do j=G%jsc,G%jec ; do i=G%isc,G%iec
-      eta(i,j,K) = eta(i,j,K+1) + G%mask2dT(i,j) * h_new(i,j,k) * GV%H_to_Z
-    enddo ; enddo ; enddo
-    ! Re-calculate for interface positions in z*-space (m)
-    do j=G%jsc,G%jec ; do i=G%isc,G%iec
-      if (G%bathyT(i,j)>0.) then
-        rscl = G%bathyT(i,j) / ( eta(i,j,1) + G%bathyT(i,j) )
-        do K=GV%ke, 1, -1
-          eta(i,j,K) = eta(i,j,K+1) + G%mask2dT(i,j) * h_new(i,j,k) * GV%H_to_Z * rscl
-        enddo
+    case ( col_act_pre_tridiag_solve_sources )
+      ! there are no pre-tridiag solve sources in this tracer module
+
+    case ( col_act_apply_boundary_fluxes )
+      do m=1,CS%ntr
+        call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h, &
+                                            evap_CFL_limit, minimum_forcing_depth)
+      enddo
+
+    case ( col_act_tridiag_solve )
+
+      do m=1,CS%ntr
+        call tracer_vertdiff(h, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
+      enddo
+
+    case ( col_act_post_tridiag_solve_sources )
+
+      ! Calculate z* interface positions
+      if (GV%Boussinesq) then
+        ! First calculate interface positions in z-space (m)
+        do j=G%jsc,G%jec ; do i=G%isc,G%iec
+          eta(i,j,GV%ke+1) = - G%mask2dT(i,j) * G%bathyT(i,j)
+        enddo ; enddo
+        do k=GV%ke,1,-1 ; do j=G%jsc,G%jec ; do i=G%isc,G%iec
+          eta(i,j,K) = eta(i,j,K+1) + G%mask2dT(i,j) * h(i,j,k) * GV%H_to_Z
+        enddo ; enddo ; enddo
+        ! Re-calculate for interface positions in z*-space (m)
+        do j=G%jsc,G%jec ; do i=G%isc,G%iec
+          if (G%bathyT(i,j)>0.) then
+            rscl = G%bathyT(i,j) / ( eta(i,j,1) + G%bathyT(i,j) )
+            do K=GV%ke, 1, -1
+              eta(i,j,K) = eta(i,j,K+1) + G%mask2dT(i,j) * h(i,j,k) * GV%H_to_Z * rscl
+            enddo
+          endif
+        enddo ; enddo
+      else
+        call MOM_error(FATAL, "NW2 tracers assume Boussinesq mode")
       endif
-    enddo ; enddo
-  else
-    call MOM_error(FATAL, "NW2 tracers assume Boussinesq mode")
-  endif
 
-  do m=1,CS%ntr
-    dt_x_rate = dt * CS%restore_rate(m)
-    !$OMP parallel do default(shared) private(target_value)
-    do k=1,GV%ke ; do j=G%jsc,G%jec ; do i=G%isc,G%iec
-      target_value = nw2_tracer_dist(m, G, GV, eta, i, j, k)
-      CS%tr(i,j,k,m) = CS%tr(i,j,k,m) + G%mask2dT(i,j) * dt_x_rate * ( target_value - CS%tr(i,j,k,m) )
-    enddo ; enddo ; enddo
-  enddo
+      do m=1,CS%ntr
+        dt_x_rate = dt * CS%restore_rate(m)
+        !$OMP parallel do default(shared) private(target_value)
+        do k=1,GV%ke ; do j=G%jsc,G%jec ; do i=G%isc,G%iec
+          target_value = nw2_tracer_dist(m, G, GV, eta, i, j, k)
+          CS%tr(i,j,k,m) = CS%tr(i,j,k,m) &
+              + G%mask2dT(i,j) * dt_x_rate * ( target_value - CS%tr(i,j,k,m) )
+        enddo ; enddo ; enddo
+      enddo
+
+  end select
 
 end subroutine nw2_tracer_column_physics
 

--- a/src/tracer/pseudo_salt_tracer.F90
+++ b/src/tracer/pseudo_salt_tracer.F90
@@ -218,7 +218,7 @@ subroutine pseudo_salt_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G
   if (present(KPP_CSp)) then
     if (associated(KPP_CSp) .and. present(nonLocalTrans)) &
       call KPP_NonLocalTransport(KPP_CSp, G, GV, h_old, nonLocalTrans, fluxes%KPP_salt_flux(:,:), &
-                                 dt, CS%diag, CS%tr_ptr, CS%ps(:,:,:))
+                                 dt, CS%tr_ptr, CS%ps(:,:,:))
   endif
 
   ! This uses applyTracerBoundaryFluxesInOut, usually in ALE mode


### PR DESCRIPTION
Because of the large extent of this PR, its summary is supplied externally. A high-level overview and description is
[Diagnostic Remapping PR 215 Summary.pdf](https://github.com/NCAR/MOM6/files/8547033/Diagnostic.Remapping.PR.215.Summary.pdf)

A breakdown of the PR's changes, which doesn't map cleanly to commits, is:

- introduce MOM_field_stack.F90 to maintain stacks of model fields
- add stack objects for tracer and diagnostic thickness previous values
- add diag_push_h and diag_drop_h subroutines to ease stack usage for native and diagnostics thicknesses
- add prep_tracer_tend and diagnose_tracer_tend subroutines to support tracer process tendencies
- add post_data_tend for posting tendency diagnostics
- use stacks and new subroutines to compute thickness and tracer tendencies for following processes:
  - net (across thermodynamic timestep)
  - ALE remapping
  - lateral_boundary_diffusion
  - neutral diffusion
  - advection/transport
  - frazil formation
  - boundary forcing
  - diabatic mixing
  - geothermal heating (not tested)
  - frazil formation
- Refactor tracer module column physics subroutine to perform a single action in each invocation. This enables each action to be performed immediately after that action is performed for t and s in the diabatic driver. Actions are one of 
  - col_act_apply_KPP_NLT
  - col_act_pre_tridiag_solve_sources
  - col_act_apply_boundary_fluxes
  - col_act_tridiag_solve
  - col_act_post_tridiag_solve_sources
- Generalize tendency diagnostics for following processes to passive tracers:
  - frazil formation
  - KPP non-local transport
  - boundary forcing
  - diabatic mixing
- add tracer layer content diagnostics, to enable comparison of layer content tendency to differences between snapshots
- correct KPP_NLT_saln_budget diagnostic
- remove unneeded KPP_NonLocalTransport_{temp,saln} subroutines, use generic KPP_NonLocalTransport subroutine
- If KPP non-local transport tendencies are requested, the term is applied independent of applyNonLocalTrans. If applyNonLocalTrans==.false., the application is undone after diagnostics are posted.
- Move unit conversions in diagnostic computations to conversion argument in corresponding register_diag_field calls.
- split post_tracer_transport_diagnostics into post_tracer_{advection,hordiff}_diagnostics to enable updating diagnostic grids between the posting of these diagnostics
- add in_sync_with_state flag to diagnostic types to enable avoidance of unneeded diagnostic thickness updates
  - mark thicknesses as out of sync after modifying thickness and/or state
  - update diagnostic thicknesses when accessed if they are out of sync
  - (not all diag_update_remap_grids have been replaced with calls to mark thicknesses as out of sync)
- Change intent of h argument of applyTracerBoundaryFluxesInOut to intent(in). The only application needing the updated thickness is offline mode. An optional intent(out) thickness argument has been introduced for this use case.

misc:
- refactor array index generation in MOM_diag_mediator.F90
- remove duplicate tracer_column_physics calls in call_tracer_column_fns
- add callTree_leave call prior to early return in apply_topography_edits_from_file ensures callTree output is properly aligned
- replace intent(inout) with intent(in) for h in some MOM_lateral_mixing_coeffs.F90 subroutines where h is not modified
- use case consistently for tracer_Reg in MOM.F90

TODO:
- replace remaining `diag_update_remap_grids` calls with `set_diag_in_sync_with_state` calls
- replace `diag_pre_sync` and `diag_pre_dyn` usage with thickness stacks
- add tracer source tendency diagnostics
- verify ideal age and CFC_cap tracer budgets can be closed

Other categories of fields whose remappings need modification for internal consistency:
- momentum/velocity budget terms (could potentially be included in this PR)
- lateral fluxes of thickness, tracer, and momentum/velocity (probably postpone to another PR)
