### PR TITLE
POSIX: siglongjmp and sigsetjmp_missing fixes

### DIFF
--- a/src/framework/posix.F90
+++ b/src/framework/posix.F90
@@ -188,7 +188,7 @@ interface
 
   !> C interface to POSIX siglongjmp()
   !! Users should use the Fortran-defined siglongjmp() function.
-  subroutine siglongjmp_posix(env, val) bind(c, name="longjmp")
+  subroutine siglongjmp_posix(env, val) bind(c, name="siglongjmp")
     ! #include <setjmp.h>
     ! int siglongjmp(jmp_buf env, int val);
     import :: sigjmp_buf, c_int
@@ -360,6 +360,9 @@ function sigsetjmp_missing(env, savesigs) result(rc) bind(c)
   print '(a)', 'ERROR: sigsetjmp() is not implemented in this build.'
   print '(a)', 'Recompile with autoconf or -DSIGSETJMP_NAME=\"<symbol name>\".'
   error stop
+
+  ! NOTE: Compilers may expect a return value, even if it is unreachable
+  rc = -1
 end function sigsetjmp_missing
 
 end module posix


### PR DESCRIPTION
This patch fixes two issues in the POSIX API.

The `siglongjmp` interface was referencing the wrong symbol (`longjmp`). While this did not seem to cause any issues, possibly due to some shared definitions on glibc/BSD platforms, the error was correctly detected by
the Cray compiler.   This patch corrects the C symbol name.

The `sigsetjmp_missing` function, as a default replacement for a missing `sigsetjmp`, was also defined without a return value, since it always returns an error if called at runtime.  The Cray compiler raised a warning about this, so we now assign a return value of -1, although it is never used.

Thanks to Jim Edwards for reporting these errors.