### PR TITLE
Fix NUOPC gnu restart issue by removing leading spaces in restartfiles list

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -625,7 +625,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   endif
 
   ocean_public%is_ocean_pe = .true.
-  call ocean_model_init(ocean_public, ocean_state, time0, time_start, input_restart_file=trim(restartfiles))
+  call ocean_model_init(ocean_public, ocean_state, time0, time_start, input_restart_file=trim(adjustl(restartfiles)))
 
   ! GMM, this call is not needed in CESM. Check with EMC if it can be deleted.
   call ocean_model_flux_init(ocean_state)


### PR DESCRIPTION
Fix NUOPC gnu restart issue by removing leading spaces in restartfiles list.

Fixes #199 

Testing:
ERS.TL319_t061.CMOM_JRA.cheyenne_gnu
ERS.TL319_t061.CMOM_JRA.cheyenne_intel
