### PR TITLE
Accommodate multi-instance runs in CESM

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -481,7 +481,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
         ! Multiinstance logfile name needs a correction
         if(logfile(4:4) == '_') then
           logfile = logfile(1:3)//trim(inst_suffix)//logfile(9:)
-        endif 
+        endif
       endif
 
       open(newunit=stdout,file=trim(diro)//"/"//trim(logfile))

--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -229,7 +229,7 @@ contains
 !!   This subroutine initializes both the ocean state and the ocean surface type.
 !! Because of the way that indicies and domains are handled, Ocean_sfc must have
 !! been used in a previous call to initialize_ocean_type.
-subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, input_restart_file)
+subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, input_restart_file, inst_index)
   type(ocean_public_type), target, &
                        intent(inout) :: Ocean_sfc !< A structure containing various publicly
                                 !! visible ocean surface properties after initialization,
@@ -246,6 +246,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                                               !! tracer fluxes, and can be used to spawn related
                                               !! internal variables in the ice model.
   character(len=*), optional, intent(in) :: input_restart_file !< If present, name of restart file to read
+  integer, optional :: inst_index !< Ensemble index provided by the cap (instead of FMS ensemble manager)
 
   ! Local variables
   real :: Rho0        ! The Boussinesq ocean density, in kg m-3.
@@ -283,7 +284,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &
                       OS%restart_CSp, Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       input_restart_file=input_restart_file, &
-                      diag_ptr=OS%diag, count_calls=.true., waves_CSp=OS%Waves)
+                      diag_ptr=OS%diag, count_calls=.true., waves_CSp=OS%Waves, ensemble_num=inst_index)
   call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%C_p, &
                               C_p_scaled=OS%fluxes%C_p, use_temp=use_temperature)
 

--- a/config_src/infra/FMS1/MOM_ensemble_manager_infra.F90
+++ b/config_src/infra/FMS1/MOM_ensemble_manager_infra.F90
@@ -9,6 +9,8 @@ use ensemble_manager_mod, only : FMS_get_ensemble_id => get_ensemble_id
 use ensemble_manager_mod, only : FMS_get_ensemble_size => get_ensemble_size
 use ensemble_manager_mod, only : FMS_get_ensemble_pelist => get_ensemble_pelist
 use ensemble_manager_mod, only : FMS_get_ensemble_filter_pelist => get_ensemble_filter_pelist
+use fms2_io_mod, only : fms2_io_set_filename_appendix=>set_filename_appendix
+use fms_io_mod, only  : fms_io_set_filename_appendix=>set_filename_appendix
 
 implicit none ; private
 
@@ -20,9 +22,16 @@ contains
 
 !> Initializes the ensemble manager which divides available resources
 !! in order to concurrently execute an ensemble of model realizations.
-subroutine ensemble_manager_init()
+subroutine ensemble_manager_init(ensemble_suffix)
+  character(len=*), optional, intent(in) :: ensemble_suffix !> Ensemble suffix provided by the cap. This may be
+                                                            !! provided to bypass FMS ensemble manager.
 
-  call FMS_ensemble_manager_init()
+  if (present(ensemble_suffix)) then
+    call fms2_io_set_filename_appendix(trim(ensemble_suffix))
+    call fms_io_set_filename_appendix(trim(ensemble_suffix))
+  else
+    call FMS_ensemble_manager_init()
+  endif
 
 end subroutine ensemble_manager_init
 

--- a/config_src/infra/FMS1/MOM_ensemble_manager_infra.F90
+++ b/config_src/infra/FMS1/MOM_ensemble_manager_infra.F90
@@ -9,7 +9,6 @@ use ensemble_manager_mod, only : FMS_get_ensemble_id => get_ensemble_id
 use ensemble_manager_mod, only : FMS_get_ensemble_size => get_ensemble_size
 use ensemble_manager_mod, only : FMS_get_ensemble_pelist => get_ensemble_pelist
 use ensemble_manager_mod, only : FMS_get_ensemble_filter_pelist => get_ensemble_filter_pelist
-use fms2_io_mod, only : fms2_io_set_filename_appendix=>set_filename_appendix
 use fms_io_mod, only  : fms_io_set_filename_appendix=>set_filename_appendix
 
 implicit none ; private
@@ -27,7 +26,6 @@ subroutine ensemble_manager_init(ensemble_suffix)
                                                             !! provided to bypass FMS ensemble manager.
 
   if (present(ensemble_suffix)) then
-    call fms2_io_set_filename_appendix(trim(ensemble_suffix))
     call fms_io_set_filename_appendix(trim(ensemble_suffix))
   else
     call FMS_ensemble_manager_init()

--- a/config_src/infra/FMS2/MOM_ensemble_manager_infra.F90
+++ b/config_src/infra/FMS2/MOM_ensemble_manager_infra.F90
@@ -9,6 +9,8 @@ use ensemble_manager_mod, only : FMS_get_ensemble_id => get_ensemble_id
 use ensemble_manager_mod, only : FMS_get_ensemble_size => get_ensemble_size
 use ensemble_manager_mod, only : FMS_get_ensemble_pelist => get_ensemble_pelist
 use ensemble_manager_mod, only : FMS_get_ensemble_filter_pelist => get_ensemble_filter_pelist
+use fms2_io_mod, only : fms2_io_set_filename_appendix=>set_filename_appendix
+use fms_io_mod, only  : fms_io_set_filename_appendix=>set_filename_appendix
 
 implicit none ; private
 
@@ -20,9 +22,16 @@ contains
 
 !> Initializes the ensemble manager which divides available resources
 !! in order to concurrently execute an ensemble of model realizations.
-subroutine ensemble_manager_init()
+subroutine ensemble_manager_init(ensemble_suffix)
+  character(len=*), optional, intent(in) :: ensemble_suffix !> Ensemble suffix provided by the cap. This may be
+                                                            !! provided to bypass FMS ensemble manager.
 
-  call FMS_ensemble_manager_init()
+  if (present(ensemble_suffix)) then
+    call fms2_io_set_filename_appendix(trim(ensemble_suffix))
+    call fms_io_set_filename_appendix(trim(ensemble_suffix))
+  else
+    call FMS_ensemble_manager_init()
+  endif
 
 end subroutine ensemble_manager_init
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1830,7 +1830,7 @@ end subroutine step_offline
 !! initializing the ocean state variables, and initializing subsidiary modules
 subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                           Time_in, offline_tracer_mode, input_restart_file, diag_ptr, &
-                          count_calls, tracer_flow_CSp,  ice_shelf_CSp, waves_CSp)
+                          count_calls, tracer_flow_CSp,  ice_shelf_CSp, waves_CSp, ensemble_num)
   type(time_type), target,   intent(inout) :: Time        !< model time, set in this routine
   type(time_type),           intent(in)    :: Time_init   !< The start time for the coupled model's calendar
   type(param_file_type),     intent(out)   :: param_file  !< structure indicating parameter file to parse
@@ -1853,7 +1853,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                                                           !! dynamics timesteps.
   type(ice_shelf_CS), optional,     pointer :: ice_shelf_CSp !< A pointer to an ice shelf control structure
   type(Wave_parameters_CS), &
-                   optional, pointer       :: Waves_CSp       !< An optional pointer to a wave property CS
+                   optional, pointer       :: Waves_CSp   !< An optional pointer to a wave property CS
+  integer, optional :: ensemble_num                       !< Ensemble index provided by the cap (instead of FMS
+                                                          !! ensemble manager)
   ! local variables
   type(ocean_grid_type),  pointer :: G => NULL()    ! A pointer to the metric grid use for the run
   type(ocean_grid_type),  pointer :: G_in => NULL() ! Pointer to the input grid
@@ -1962,7 +1964,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   ! Read paths and filenames from namelist and store in "dirs".
   ! Also open the parsed input parameter file(s) and setup param_file.
-  call get_MOM_input(param_file, dirs, default_input_filename=input_restart_file)
+  call get_MOM_input(param_file, dirs, default_input_filename=input_restart_file, ensemble_num=ensemble_num)
 
   verbosity = 2 ; call read_param(param_file, "VERBOSITY", verbosity)
   call MOM_set_verbosity(verbosity)

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -124,7 +124,7 @@ end interface
 contains
 
 !> Make the contents of a parameter input file availalble in a param_file_type
-subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
+subroutine open_param_file(filename, CS, checkable, component, doc_file_dir, ensemble_num)
   character(len=*),           intent(in) :: filename !< An input file name, optionally with the full path
   type(param_file_type),   intent(inout) :: CS      !< The control structure for the file_parser module,
                                          !! it is also a structure to parse for run-time parameters
@@ -134,11 +134,13 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
                                          !! to generate parameter documentation file names; the default is"MOM"
   character(len=*), optional, intent(in) :: doc_file_dir !< An optional directory in which to write out
                                          !! the documentation files.  The default is effectively './'.
+  integer, optional, intent(in)          :: ensemble_num !< ensemble number to be appended to _doc filenames (optional)
 
   ! Local variables
   logical :: file_exists, Netcdf_file, may_check, reopened_file
   integer :: ios, iounit, strlen, i
   character(len=240) :: doc_path
+  character(len=5)  :: ensemble_suffix
   type(parameter_block), pointer :: block => NULL()
 
   may_check = .true. ; if (present(checkable)) may_check = checkable
@@ -211,6 +213,11 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
   call read_param(CS,"REPORT_UNUSED_PARAMS",CS%report_unused)
   call read_param(CS,"FATAL_UNUSED_PARAMS",CS%unused_params_fatal)
   CS%doc_file = "MOM_parameter_doc"
+  if (present(ensemble_num)) then
+    ! append instance suffix to doc_file
+    write(ensemble_suffix,'(A,I0.4)') '_', ensemble_num
+    CS%doc_file = trim(CS%doc_file)//ensemble_suffix
+  endif
   if (present(component)) CS%doc_file = trim(component)//"_parameter_doc"
   call read_param(CS,"DOCUMENT_FILE", CS%doc_file)
   if (.not.may_check) then

--- a/src/framework/MOM_get_input.F90
+++ b/src/framework/MOM_get_input.F90
@@ -102,7 +102,7 @@ subroutine get_MOM_input(param_file, dirs, check_params, default_input_filename,
       if (len_trim(trim(parameter_filename(io))) > 0) then
         if (present(ensemble_num)) then
           call open_param_file(ensembler(parameter_filename(io),ensemble_num), param_file, &
-               check_params, doc_file_dir=output_dir)
+               check_params, doc_file_dir=output_dir, ensemble_num=ensemble_num)
         else
           call open_param_file(ensembler(parameter_filename(io)), param_file, &
                check_params, doc_file_dir=output_dir)


### PR DESCRIPTION
This PR introduces changes that are mainly in NUOPC cap, infra/FMS, and src/framework to accommodate multi-instance runs in CESM:

Changes in nuopc cap:
 - receive instance id and suffix from the CESM coupler.
 - call `ensemble_manager_init`. This makes sure the input/output files contain the instance suffix.
 - add instance suffix to log files, restart files, and rpointer.

Changes in infra/FMS{1,2}:
 - add the optional `ensumble_suffix` arg to  `ensemble_manager_init`.  If provided, this arg bypasses the call to `FMS_ensemble_manager_init`, and instead, calls `fms_io_set_filename_appendix` and `fms2_io_set_filename_appendix`. This makes sure that all i/o files managed my FMS contains the ensemble suffix.

Change in src/framework:
 - append instance suffix to MOM_parameter_doc* files. ( I believe this is the only change that may potentially impact GFDL's ensemble workflow.)

This PR should be evaluating in conjunction with https://github.com/ESCOMP/MOM_interface/pull/137.

I am mentioning @MJHarrison-GFDL, @marshallward, and @hkershaw-brown in case they'd prefer to review this PR before it gets merged to dev/ncar. If so, please let us know and will hold off until you review.

