### PR TITLE
Add Leith+E

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -41,7 +41,7 @@ use MOM_time_manager,        only : operator(+), operator(-), operator(*), opera
 use MOM_time_manager,        only : operator(/=), operator(<=), operator(>=)
 use MOM_time_manager,        only : operator(<), real_to_time_type, time_type_to_real
 use MOM_interpolate,         only : time_interp_external_init
-use MOM_tracer_flow_control, only : call_tracer_flux_init
+use MOM_tracer_flow_control, only : tracer_flow_control_CS, call_tracer_flux_init, call_tracer_set_forcing
 use MOM_unit_scaling,        only : unit_scale_type
 use MOM_variables,           only : surface
 use MOM_verticalGrid,        only : verticalGrid_type
@@ -210,6 +210,8 @@ type, public :: ocean_state_type ; private
   type(marine_ice_CS), pointer :: &
     marine_ice_CSp => NULL()  !< A pointer to the control structure for the
                               !! marine ice effects module.
+  type(tracer_flow_control_CS), pointer :: &
+    tracer_flow_CSp => NULL()  !< A pointer to the tracer flow control structure
   type(wave_parameters_CS), pointer, public :: &
     Waves => NULL()           !< A pointer to the surface wave control structure
   type(surface_forcing_CS), pointer :: &
@@ -229,7 +231,7 @@ contains
 !!   This subroutine initializes both the ocean state and the ocean surface type.
 !! Because of the way that indicies and domains are handled, Ocean_sfc must have
 !! been used in a previous call to initialize_ocean_type.
-subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, input_restart_file)
+subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, input_restart_file, inst_index)
   type(ocean_public_type), target, &
                        intent(inout) :: Ocean_sfc !< A structure containing various publicly
                                 !! visible ocean surface properties after initialization,
@@ -246,6 +248,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                                               !! tracer fluxes, and can be used to spawn related
                                               !! internal variables in the ice model.
   character(len=*), optional, intent(in) :: input_restart_file !< If present, name of restart file to read
+  integer, optional :: inst_index !< Ensemble index provided by the cap (instead of FMS ensemble manager)
 
   ! Local variables
   real :: Rho0        ! The Boussinesq ocean density, in kg m-3.
@@ -255,7 +258,6 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
                       !! min(HFrz, OBLD), where OBLD is the boundary layer depth.
                       !! If HFrz <= 0 (default), melt potential will not be computed.
   logical :: use_melt_pot !< If true, allocate melt_potential array
-  logical :: use_CFC  !< If true, allocated arrays for surface CFCs.
 
 
 ! This include declares and sets the variable "version".
@@ -283,7 +285,8 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &
                       OS%restart_CSp, Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       input_restart_file=input_restart_file, &
-                      diag_ptr=OS%diag, count_calls=.true., waves_CSp=OS%Waves)
+                      diag_ptr=OS%diag, count_calls=.true., tracer_flow_CSp=OS%tracer_flow_CSp, &
+                      waves_CSp=OS%Waves, ensemble_num=inst_index)
   call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%C_p, &
                               C_p_scaled=OS%fluxes%C_p, use_temp=use_temperature)
 
@@ -376,8 +379,6 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
     use_melt_pot=.false.
   endif
 
-  call get_param(param_file, mdl, "USE_CFC_CAP", use_CFC, &
-                 default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "USE_WAVES", OS%Use_Waves, &
        "If true, enables surface wave modules.", default=.false.)
 
@@ -385,7 +386,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   ! vertical integrals, since the related 3-d sums are not negligible in cost.
   call allocate_surface_state(OS%sfc_state, OS%grid, use_temperature, &
                               do_integrals=.true., gas_fields_ocn=gas_fields_ocn, &
-                              use_meltpot=use_melt_pot, use_cfcs=use_CFC)
+                              use_meltpot=use_melt_pot)
 
   call surface_forcing_init(Time_in, OS%grid, OS%US, param_file, OS%diag, &
                             OS%forcing_CSp, OS%restore_salinity, OS%restore_temp, OS%use_waves)
@@ -610,6 +611,11 @@ subroutine update_ocean_model(Ice_ocean_boundary, OS, Ocean_sfc, &
   if (OS%nstep==0) then
     call finish_MOM_initialization(OS%Time, OS%dirs, OS%MOM_CSp, OS%restart_CSp)
   endif
+
+  if (do_thermo) &
+    call call_tracer_set_forcing(OS%sfc_state, OS%fluxes, OS%Time, &
+                                 real_to_time_type(dt_coupling), OS%grid, OS%US, OS%GV%Rho0, &
+                                 OS%tracer_flow_CSp)
 
   call disable_averaging(OS%diag)
   Master_time = OS%Time ; Time1 = OS%Time

--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -346,7 +346,8 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
   endif
 
   if (associated(CS%tracer_flow_CSp)) then
-    call call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G, CS%tracer_flow_CSp)
+    call call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G, US, CS%Rho0, &
+                                 CS%tracer_flow_CSp)
   endif
 
   ! Allow for user-written code to alter the fluxes after all the above

--- a/config_src/infra/FMS1/MOM_ensemble_manager_infra.F90
+++ b/config_src/infra/FMS1/MOM_ensemble_manager_infra.F90
@@ -9,6 +9,7 @@ use ensemble_manager_mod, only : FMS_get_ensemble_id => get_ensemble_id
 use ensemble_manager_mod, only : FMS_get_ensemble_size => get_ensemble_size
 use ensemble_manager_mod, only : FMS_get_ensemble_pelist => get_ensemble_pelist
 use ensemble_manager_mod, only : FMS_get_ensemble_filter_pelist => get_ensemble_filter_pelist
+use fms_io_mod, only  : fms_io_set_filename_appendix=>set_filename_appendix
 
 implicit none ; private
 
@@ -20,9 +21,15 @@ contains
 
 !> Initializes the ensemble manager which divides available resources
 !! in order to concurrently execute an ensemble of model realizations.
-subroutine ensemble_manager_init()
+subroutine ensemble_manager_init(ensemble_suffix)
+  character(len=*), optional, intent(in) :: ensemble_suffix !> Ensemble suffix provided by the cap. This may be
+                                                            !! provided to bypass FMS ensemble manager.
 
-  call FMS_ensemble_manager_init()
+  if (present(ensemble_suffix)) then
+    call fms_io_set_filename_appendix(trim(ensemble_suffix))
+  else
+    call FMS_ensemble_manager_init()
+  endif
 
 end subroutine ensemble_manager_init
 

--- a/config_src/infra/FMS2/MOM_ensemble_manager_infra.F90
+++ b/config_src/infra/FMS2/MOM_ensemble_manager_infra.F90
@@ -9,6 +9,8 @@ use ensemble_manager_mod, only : FMS_get_ensemble_id => get_ensemble_id
 use ensemble_manager_mod, only : FMS_get_ensemble_size => get_ensemble_size
 use ensemble_manager_mod, only : FMS_get_ensemble_pelist => get_ensemble_pelist
 use ensemble_manager_mod, only : FMS_get_ensemble_filter_pelist => get_ensemble_filter_pelist
+use fms2_io_mod, only : fms2_io_set_filename_appendix=>set_filename_appendix
+use fms_io_mod, only  : fms_io_set_filename_appendix=>set_filename_appendix
 
 implicit none ; private
 
@@ -20,9 +22,16 @@ contains
 
 !> Initializes the ensemble manager which divides available resources
 !! in order to concurrently execute an ensemble of model realizations.
-subroutine ensemble_manager_init()
+subroutine ensemble_manager_init(ensemble_suffix)
+  character(len=*), optional, intent(in) :: ensemble_suffix !> Ensemble suffix provided by the cap. This may be
+                                                            !! provided to bypass FMS ensemble manager.
 
-  call FMS_ensemble_manager_init()
+  if (present(ensemble_suffix)) then
+    call fms2_io_set_filename_appendix(trim(ensemble_suffix))
+    call fms_io_set_filename_appendix(trim(ensemble_suffix))
+  else
+    call FMS_ensemble_manager_init()
+  endif
 
 end subroutine ensemble_manager_init
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1862,7 +1862,7 @@ end subroutine step_offline
 !! initializing the ocean state variables, and initializing subsidiary modules
 subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                           Time_in, offline_tracer_mode, input_restart_file, diag_ptr, &
-                          count_calls, tracer_flow_CSp,  ice_shelf_CSp, waves_CSp)
+                          count_calls, tracer_flow_CSp,  ice_shelf_CSp, waves_CSp, ensemble_num)
   type(time_type), target,   intent(inout) :: Time        !< model time, set in this routine
   type(time_type),           intent(in)    :: Time_init   !< The start time for the coupled model's calendar
   type(param_file_type),     intent(out)   :: param_file  !< structure indicating parameter file to parse
@@ -1885,7 +1885,9 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                                                           !! dynamics timesteps.
   type(ice_shelf_CS), optional,     pointer :: ice_shelf_CSp !< A pointer to an ice shelf control structure
   type(Wave_parameters_CS), &
-                   optional, pointer       :: Waves_CSp       !< An optional pointer to a wave property CS
+                   optional, pointer       :: Waves_CSp   !< An optional pointer to a wave property CS
+  integer, optional :: ensemble_num                       !< Ensemble index provided by the cap (instead of FMS
+                                                          !! ensemble manager)
   ! local variables
   type(ocean_grid_type),  pointer :: G => NULL()    ! A pointer to the metric grid use for the run
   type(ocean_grid_type),  pointer :: G_in => NULL() ! Pointer to the input grid
@@ -1994,7 +1996,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   ! Read paths and filenames from namelist and store in "dirs".
   ! Also open the parsed input parameter file(s) and setup param_file.
-  call get_MOM_input(param_file, dirs, default_input_filename=input_restart_file)
+  call get_MOM_input(param_file, dirs, default_input_filename=input_restart_file, ensemble_num=ensemble_num)
 
   verbosity = 2 ; call read_param(param_file, "VERBOSITY", verbosity)
   call MOM_set_verbosity(verbosity)

--- a/src/core/MOM_unit_tests.F90
+++ b/src/core/MOM_unit_tests.F90
@@ -9,7 +9,7 @@ use MOM_string_functions,           only : string_functions_unit_tests
 use MOM_remapping,                  only : remapping_unit_tests
 use MOM_neutral_diffusion,          only : neutral_diffusion_unit_tests
 use MOM_random,                     only : random_unit_tests
-use MOM_lateral_boundary_diffusion, only : near_boundary_unit_tests
+use MOM_hor_bnd_diffusion,          only : near_boundary_unit_tests
 use MOM_CFC_cap,                    only : CFC_cap_unit_tests
 implicit none ; private
 

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -44,8 +44,6 @@ type, public :: surface
     SST, &         !< The sea surface temperature [C ~> degC].
     SSS, &         !< The sea surface salinity [S ~> psu or gSalt/kg].
     sfc_density, & !< The mixed layer density [R ~> kg m-3].
-    sfc_cfc11,   & !< Sea surface concentration of CFC11 [mol kg-1].
-    sfc_cfc12,   & !< Sea surface concentration of CFC12 [mol kg-1].
     Hml, &         !< The mixed layer depth [Z ~> m].
     u, &           !< The mixed layer zonal velocity [L T-1 ~> m s-1].
     v, &           !< The mixed layer meridional velocity [L T-1 ~> m s-1].
@@ -332,7 +330,7 @@ contains
 !! the ocean model. Unused fields are unallocated.
 subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
                                   gas_fields_ocn, use_meltpot, use_iceshelves, &
-                                  omit_frazil, use_cfcs)
+                                  omit_frazil)
   type(ocean_grid_type), intent(in)    :: G                !< ocean grid structure
   type(surface),         intent(inout) :: sfc_state        !< ocean surface state type to be allocated.
   logical,     optional, intent(in)    :: use_temperature  !< If true, allocate the space for thermodynamic variables.
@@ -345,14 +343,13 @@ subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
                                               !! tracer fluxes, and can be used to spawn related
                                               !! internal variables in the ice model.
   logical,     optional, intent(in)    :: use_meltpot      !< If true, allocate the space for melt potential
-  logical,     optional, intent(in)    :: use_cfcs         !< If true, allocate the space for cfcs
   logical,     optional, intent(in)    :: use_iceshelves   !< If true, allocate the space for the stresses
                                                            !! under ice shelves.
   logical,     optional, intent(in)    :: omit_frazil      !< If present and false, do not allocate the space to
                                                            !! pass frazil fluxes to the coupler
 
   ! local variables
-  logical :: use_temp, alloc_integ, use_melt_potential, alloc_iceshelves, alloc_frazil, alloc_cfcs
+  logical :: use_temp, alloc_integ, use_melt_potential, alloc_iceshelves, alloc_frazil
   integer :: is, ie, js, je, isd, ied, jsd, jed
   integer :: isdB, iedB, jsdB, jedB
 
@@ -363,7 +360,6 @@ subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
   use_temp = .true. ; if (present(use_temperature)) use_temp = use_temperature
   alloc_integ = .true. ; if (present(do_integrals)) alloc_integ = do_integrals
   use_melt_potential = .false. ; if (present(use_meltpot)) use_melt_potential = use_meltpot
-  alloc_cfcs = .false. ; if (present(use_cfcs)) alloc_cfcs = use_cfcs
   alloc_iceshelves = .false. ; if (present(use_iceshelves)) alloc_iceshelves = use_iceshelves
   alloc_frazil = .true. ; if (present(omit_frazil)) alloc_frazil = .not.omit_frazil
 
@@ -385,11 +381,6 @@ subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
 
   if (use_melt_potential) then
     allocate(sfc_state%melt_potential(isd:ied,jsd:jed), source=0.0)
-  endif
-
-  if (alloc_cfcs) then
-    allocate(sfc_state%sfc_cfc11(isd:ied,jsd:jed), source=0.0)
-    allocate(sfc_state%sfc_cfc12(isd:ied,jsd:jed), source=0.0)
   endif
 
   if (alloc_integ) then
@@ -431,8 +422,6 @@ subroutine deallocate_surface_state(sfc_state)
   if (allocated(sfc_state%ocean_mass)) deallocate(sfc_state%ocean_mass)
   if (allocated(sfc_state%ocean_heat)) deallocate(sfc_state%ocean_heat)
   if (allocated(sfc_state%ocean_salt)) deallocate(sfc_state%ocean_salt)
-  if (allocated(sfc_state%sfc_cfc11)) deallocate(sfc_state%sfc_cfc11)
-  if (allocated(sfc_state%sfc_cfc12)) deallocate(sfc_state%sfc_cfc12)
   call coupler_type_destructor(sfc_state%tr_fields)
 
   sfc_state%arrays_allocated = .false.

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -94,6 +94,8 @@ subroutine find_obsolete_params(param_file)
   call obsolete_real(param_file, "FIRST_GUESS_SURFACE_LAYER_DEPTH")
   call obsolete_logical(param_file, "CORRECT_SURFACE_LAYER_AVERAGE")
   call obsolete_int(param_file, "SEAMOUNT_LENGTH_SCALE", hint="Use SEAMOUNT_X_LENGTH_SCALE instead.")
+  call obsolete_int(param_file, "USE_LATERAL_BOUNDARY_DIFFUSION", &
+                    hint="Use USE_HORIZONTAL_BOUNDARY_DIFFUSION instead.")
 
   call obsolete_logical(param_file, "MSTAR_FIXED", hint="Instead use MSTAR_MODE.")
   call obsolete_logical(param_file, "USE_VISBECK_SLOPE_BUG", .false.)

--- a/src/framework/MOM_file_parser.F90
+++ b/src/framework/MOM_file_parser.F90
@@ -124,7 +124,7 @@ end interface
 contains
 
 !> Make the contents of a parameter input file availalble in a param_file_type
-subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
+subroutine open_param_file(filename, CS, checkable, component, doc_file_dir, ensemble_num)
   character(len=*),           intent(in) :: filename !< An input file name, optionally with the full path
   type(param_file_type),   intent(inout) :: CS      !< The control structure for the file_parser module,
                                          !! it is also a structure to parse for run-time parameters
@@ -134,11 +134,13 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
                                          !! to generate parameter documentation file names; the default is"MOM"
   character(len=*), optional, intent(in) :: doc_file_dir !< An optional directory in which to write out
                                          !! the documentation files.  The default is effectively './'.
+  integer, optional, intent(in)          :: ensemble_num !< ensemble number to be appended to _doc filenames (optional)
 
   ! Local variables
   logical :: file_exists, Netcdf_file, may_check, reopened_file
   integer :: ios, iounit, strlen, i
   character(len=240) :: doc_path
+  character(len=5)  :: ensemble_suffix
   type(parameter_block), pointer :: block => NULL()
 
   may_check = .true. ; if (present(checkable)) may_check = checkable
@@ -211,6 +213,11 @@ subroutine open_param_file(filename, CS, checkable, component, doc_file_dir)
   call read_param(CS,"REPORT_UNUSED_PARAMS",CS%report_unused)
   call read_param(CS,"FATAL_UNUSED_PARAMS",CS%unused_params_fatal)
   CS%doc_file = "MOM_parameter_doc"
+  if (present(ensemble_num)) then
+    ! append instance suffix to doc_file
+    write(ensemble_suffix,'(A,I0.4)') '_', ensemble_num
+    CS%doc_file = trim(CS%doc_file)//ensemble_suffix
+  endif
   if (present(component)) CS%doc_file = trim(component)//"_parameter_doc"
   call read_param(CS,"DOCUMENT_FILE", CS%doc_file)
   if (.not.may_check) then

--- a/src/framework/MOM_get_input.F90
+++ b/src/framework/MOM_get_input.F90
@@ -102,7 +102,7 @@ subroutine get_MOM_input(param_file, dirs, check_params, default_input_filename,
       if (len_trim(trim(parameter_filename(io))) > 0) then
         if (present(ensemble_num)) then
           call open_param_file(ensembler(parameter_filename(io),ensemble_num), param_file, &
-               check_params, doc_file_dir=output_dir)
+               check_params, doc_file_dir=output_dir, ensemble_num=ensemble_num)
         else
           call open_param_file(ensembler(parameter_filename(io)), param_file, &
                check_params, doc_file_dir=output_dir)

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -68,6 +68,11 @@ type, public :: hor_visc_CS ; private
   logical :: use_beta_in_Leith !< If true, includes the beta term in the Leith viscosity
   logical :: Leith_Ah        !< If true, use a biharmonic form of 2D Leith
                              !! nonlinear eddy viscosity. AH is the background.
+  logical :: use_Leithy      !< If true, use a biharmonic form of 2D Leith
+                             !! nonlinear eddy viscosity with harmonic backscatter.
+                             !! Ah is the background. Leithy = Leith+E
+  real    :: c_K             !< Fraction of energy dissipated by the biharmonic term
+                             !! that gets backscattered in the Leith+E scheme. [nondim]
   logical :: use_QG_Leith_visc    !< If true, use QG Leith nonlinear eddy viscosity.
                              !! KH is the background value.
   logical :: bound_Coriolis  !< If true & SMAGORINSKY_AH is used, the biharmonic
@@ -145,10 +150,12 @@ type, public :: hor_visc_CS ; private
     n1n1_m_n2n2_q     !< Factor n1**2-n2**2 in the anisotropic direction tensor at q-points [nondim]
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: &
-    dx2h,   & !< Pre-calculated dx^2 at h points [L2 ~> m2]
-    dy2h,   & !< Pre-calculated dy^2 at h points [L2 ~> m2]
-    dx_dyT, & !< Pre-calculated dx/dy at h points [nondim]
-    dy_dxT    !< Pre-calculated dy/dx at h points [nondim]
+    dx2h,           & !< Pre-calculated dx^2 at h points [L2 ~> m2]
+    dy2h,           & !< Pre-calculated dy^2 at h points [L2 ~> m2]
+    dx_dyT,         & !< Pre-calculated dx/dy at h points [nondim]
+    dy_dxT,         & !< Pre-calculated dy/dx at h points [nondim]
+    m_const_leithy, & !< Pre-calculated .5*sqrt(c_K)*max{dx,dy} [L ~> m]
+    m_leithy_max      !< Pre-calculated 4./max(dx,dy)^2 at h points [L-2 ~> m-2]
   real ALLOCABLE_, dimension(NIMEMB_PTR_,NJMEMB_PTR_) :: &
     dx2q,    & !< Pre-calculated dx^2 at q points [L2 ~> m2]
     dy2q,    & !< Pre-calculated dy^2 at q points [L2 ~> m2]
@@ -257,18 +264,23 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     Del2u, &      ! The u-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
     h_u, &        ! Thickness interpolated to u points [H ~> m or kg m-2].
     vort_xy_dy, & ! y-derivative of vertical vorticity (d/dy(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
+    vort_xy_dy_smooth, & ! y-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
     div_xx_dx, &  ! x-derivative of horizontal divergence (d/dx(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
-    ubtav         ! zonal barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+    ubtav, &      ! zonal barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+    u_smooth      ! Zonal velocity, smoothed with a spatial low-pass filter [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G)) :: &
     Del2v, &      ! The v-component of the Laplacian of velocity [L-1 T-1 ~> m-1 s-1]
     h_v, &        ! Thickness interpolated to v points [H ~> m or kg m-2].
     vort_xy_dx, & ! x-derivative of vertical vorticity (d/dx(dv/dx - du/dy)) [L-1 T-1 ~> m-1 s-1]
+    vort_xy_dx_smooth, & ! x-derivative of smoothed vertical vorticity [L-1 T-1 ~> m-1 s-1]
     div_xx_dy, &  ! y-derivative of horizontal divergence (d/dy(du/dx + dv/dy)) [L-1 T-1 ~> m-1 s-1]
-    vbtav         ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+    vbtav, &      ! meridional barotropic velocity averaged over a baroclinic time-step [L T-1 ~> m s-1]
+    v_smooth      ! Meridional velocity, smoothed with a spatial low-pass filter [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJ_(G)) :: &
     dudx_bt, dvdy_bt, & ! components in the barotropic horizontal tension [T-1 ~> s-1]
     div_xx, &     ! Estimate of horizontal divergence at h-points [T-1 ~> s-1]
     sh_xx, &      ! horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
+    sh_xx_smooth, & ! horizontal tension from smoothed velocity including metric terms [T-1 ~> s-1]
     sh_xx_bt, &   ! barotropic horizontal tension (du/dx - dv/dy) including metric terms [T-1 ~> s-1]
     str_xx,&      ! str_xx is the diagonal term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
                   ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
@@ -279,23 +291,28 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     grad_vort_mag_h_2d, & ! Magnitude of 2d vorticity gradient at h-points [L-1 T-1 ~> m-1 s-1]
     grad_div_mag_h, &     ! Magnitude of divergence gradient at h-points [L-1 T-1 ~> m-1 s-1]
     dudx, dvdy, &    ! components in the horizontal tension [T-1 ~> s-1]
+    dudx_smooth, dvdy_smooth, & ! components in the horizontal tension from smoothed velocity [T-1 ~> s-1]
     GME_effic_h, &  ! The filtered efficiency of the GME terms at h points [nondim]
-    htot          ! The total thickness of all layers [Z ~> m]
+    htot, &       ! The total thickness of all layers [Z ~> m]
+    m_leithy      ! Kh=m_leithy*Ah in Leith+E parameterization [L-2 ~> m-2]
   real :: Del2vort_h ! Laplacian of vorticity at h-points [L-2 T-1 ~> m-2 s-1]
   real :: grad_vel_mag_bt_h ! Magnitude of the barotropic velocity gradient tensor squared at h-points [T-2 ~> s-2]
   real :: boundary_mask_h ! A mask that zeroes out cells with at least one land edge [nondim]
 
   real, dimension(SZIB_(G),SZJB_(G)) :: &
     dvdx, dudy, & ! components in the shearing strain [T-1 ~> s-1]
+    dvdx_smooth, dudy_smooth, & ! components in the shearing strain from smoothed velocity [T-1 ~> s-1]
     dDel2vdx, dDel2udy, & ! Components in the biharmonic equivalent of the shearing strain [L-2 T-1 ~> m-2 s-1]
     dvdx_bt, dudy_bt,   & ! components in the barotropic shearing strain [T-1 ~> s-1]
     sh_xy,  &     ! horizontal shearing strain (du/dy + dv/dx) including metric terms [T-1 ~> s-1]
+    sh_xy_smooth,  & ! horizontal shearing strain from smoothed velocity including metric terms [T-1 ~> s-1]
     sh_xy_bt, &   ! barotropic horizontal shearing strain (du/dy + dv/dx) inc. metric terms [T-1 ~> s-1]
     str_xy, &     ! str_xy is the cross term in the stress tensor [H L2 T-2 ~> m3 s-2 or kg s-2], but
                   ! at some points in the code it is not yet layer integrated, so is in [L2 T-2 ~> m2 s-2].
     str_xy_GME, & ! smoothed cross term in the stress tensor from GME [L2 T-2 ~> m2 s-2]
     bhstr_xy, &   ! A copy of str_xy that only contains the biharmonic contribution [H L2 T-2 ~> m3 s-2 or kg s-2]
     vort_xy, &    ! Vertical vorticity (dv/dx - du/dy) including metric terms [T-1 ~> s-1]
+    vort_xy_smooth, & ! Vertical vorticity including metric terms, smoothed [T-1 ~> s-1]
     grad_vort_mag_q, & ! Magnitude of vorticity gradient at q-points [L-1 T-1 ~> m-1 s-1]
     grad_vort_mag_q_2d, & ! Magnitude of 2d vorticity gradient at q-points [L-1 T-1 ~> m-1 s-1]
     Del2vort_q, & ! Laplacian of vorticity at q-points [L-2 T-1 ~> m-2 s-1]
@@ -331,6 +348,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     GME_coeff_h      ! GME coefficient at h-points [L2 T-1 ~> m2 s-1]
   real :: AhSm       ! Smagorinsky biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: AhLth      ! 2D Leith biharmonic viscosity [L4 T-1 ~> m4 s-1]
+  real :: AhLthy     ! 2D Leith+E biharmonic viscosity [L4 T-1 ~> m4 s-1]
   real :: Shear_mag_bc  ! Shear_mag value in backscatter [T-1 ~> s-1]
   real :: sh_xx_sq   ! Square of tension (sh_xx) [T-2 ~> s-2]
   real :: sh_xy_sq   ! Square of shearing strain (sh_xy) [T-2 ~> s-2]
@@ -382,6 +400,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     Kh, &           ! Laplacian  viscosity (h or q) [L2 T-1 ~> m2 s-1]
     Shear_mag, &    ! magnitude of the shear (h or q) [T-1 ~> s-1]
     vert_vort_mag, &  ! magnitude of the vertical vorticity gradient (h or q) [L-1 T-1 ~> m-1 s-1]
+    vert_vort_mag_smooth, &  ! magnitude of gradient of smoothed vertical vorticity (h or q) [L-1 T-1 ~> m-1 s-1]
     hrat_min, &     ! h_min divided by the thickness at the stress point (h or q) [nondim]
     visc_bound_rem  ! fraction of overall viscous bounds that remain to be applied (h or q) [nondim]
 
@@ -393,6 +412,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   inv_PI3 = 1.0/((4.0*atan(1.0))**3)
   inv_PI2 = 1.0/((4.0*atan(1.0))**2)
   inv_PI6 = inv_PI3 * inv_PI3
+
+  m_leithy(:,:) = 0. ! Initialize
 
   if (present(OBC)) then ; if (associated(OBC)) then ; if (OBC%OBC_pe) then
     apply_OBC = OBC%Flather_u_BCs_exist_globally .or. OBC%Flather_v_BCs_exist_globally
@@ -546,7 +567,11 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
   !$OMP   grid_Ah, grid_Kh, d_Del2u, d_Del2v, d_str, &
   !$OMP   Kh, Ah, AhSm, AhLth, local_strain, Sh_F_pow, &
   !$OMP   dDel2vdx, dDel2udy, Del2vort_q, Del2vort_h, KE, &
-  !$OMP   h2uq, h2vq, hu, hv, hq, FatH, RoScl, GME_coeff &
+  !$OMP   h2uq, h2vq, hu, hv, hq, FatH, RoScl, GME_coeff, &
+  !$OMP   dudx_smooth, dudy_smooth, dvdx_smooth, dvdy_smooth, &
+  !$OMP   vort_xy_smooth, vort_xy_dx_smooth, vort_xy_dy_smooth, &
+  !$OMP   sh_xx_smooth, sh_xy_smooth, u_smooth, v_smooth, &
+  !$OMP   vert_vort_mag_smooth, m_leithy, AhLthy &
   !$OMP )
   do k=1,nz
 
@@ -574,6 +599,30 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       dvdx(I,J) = CS%DY_dxBu(I,J)*(v(i+1,J,k)*G%IdyCv(i+1,J) - v(i,J,k)*G%IdyCv(i,J))
       dudy(I,J) = CS%DX_dyBu(I,J)*(u(I,j+1,k)*G%IdxCu(I,j+1) - u(I,j,k)*G%IdxCu(I,j))
     enddo ; enddo
+
+    if (CS%use_Leithy) then
+      ! Smooth the velocity. Right now it happens twice. In the future
+      ! one might make the number of smoothing cycles a user-specified parameter
+      u_smooth(:,:) = u(:,:,k)
+      v_smooth(:,:) = v(:,:,k)
+      call smooth_x9(CS, G, field_u=u_smooth,field_v=v_smooth) ! one call applies the filter twice
+      ! Calculate horizontal tension from smoothed velocity
+      do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
+        dudx_smooth(i,j) = CS%DY_dxT(i,j)*(G%IdyCu(I,j) * u_smooth(I,j) - &
+                                           G%IdyCu(I-1,j) * u_smooth(I-1,j))
+        dvdy_smooth(i,j) = CS%DX_dyT(i,j)*(G%IdxCv(i,J) * v_smooth(i,J) - &
+                                           G%IdxCv(i,J-1) * v_smooth(i,J-1))
+        sh_xx_smooth(i,j) = dudx_smooth(i,j) - dvdy_smooth(i,j)
+      enddo ; enddo
+
+      ! Components for the shearing strain from smoothed velocity
+      do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
+        dvdx_smooth(I,J) = CS%DY_dxBu(I,J) * &
+                         (v_smooth(i+1,J)*G%IdyCv(i+1,J) - v_smooth(i,J)*G%IdyCv(i,J))
+        dudy_smooth(I,J) = CS%DX_dyBu(I,J) * &
+                         (u_smooth(I,j+1)*G%IdxCu(I,j+1) - u_smooth(I,j)*G%IdxCu(I,j))
+      enddo ; enddo
+    end if ! use Leith+E
 
     if (CS%id_normstress > 0) then
       do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
@@ -728,6 +777,20 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       enddo ; enddo
     endif
 
+    if (CS%use_Leithy) then
+      ! Shearing strain (including no-slip boundary conditions at the 2-D land-sea mask).
+      ! dudy_smooth and dvdx_smooth do not (yet) include modifications at OBCs from above.
+      if (CS%no_slip) then
+        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+          sh_xy_smooth(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J) + dudy_smooth(I,J) )
+        enddo ; enddo
+      else
+        do J=js-2,Jeq+1 ; do I=is-2,Ieq+1
+          sh_xy_smooth(I,J) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J) + dudy_smooth(I,J) )
+        enddo ; enddo
+      endif
+    endif ! use Leith+E
+
     !  Evaluate Del2u = x.Div(Grad u) and Del2v = y.Div( Grad u)
     if (CS%biharmonic) then
       do j=js-1,Jeq+1 ; do I=Isq-1,Ieq+1
@@ -765,12 +828,24 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       enddo ; enddo
     endif
 
+    if (CS%use_Leithy) then
+      if (CS%no_slip) then
+        do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
+          vort_xy_smooth(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx_smooth(I,J) - dudy_smooth(I,J) )
+        enddo ; enddo
+      else
+        do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
+          vort_xy_smooth(I,J) = G%mask2dBu(I,J) * ( dvdx_smooth(I,J) - dudy_smooth(I,J) )
+        enddo ; enddo
+      endif
+    endif
+
     ! Divergence
     do j=Jsq-1,Jeq+2 ; do i=Isq-1,Ieq+2
       div_xx(i,j) = dudx(i,j) + dvdy(i,j)
     enddo ; enddo
 
-    if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
+    if ((CS%Leith_Kh) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
 
       ! Vorticity gradient
       do J=Jsq-1,Jeq+1 ; do i=Isq-1,Ieq+2
@@ -782,6 +857,21 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
         vort_xy_dy(I,j) = DX_dyBu * (vort_xy(I,J) * G%IdxCv(i,J) - vort_xy(I,J-1) * G%IdxCv(i,J-1))
       enddo ; enddo
+
+      if (CS%use_Leithy) then
+        ! Gradient of smoothed vorticity
+        do J=Jsq-1,Jeq+1 ; do i=Isq-1,Ieq+2
+          DY_dxBu = G%dyBu(I,J) * G%IdxBu(I,J)
+          vort_xy_dx_smooth(i,J) = DY_dxBu * &
+                      (vort_xy_smooth(I,J) * G%IdyCu(I,j) - vort_xy_smooth(I-1,J) * G%IdyCu(I-1,j))
+        enddo ; enddo
+
+        do j=Jsq-1,Jeq+2 ; do I=Isq-1,Ieq+1
+          DX_dyBu = G%dxBu(I,J) * G%IdyBu(I,J)
+          vort_xy_dy_smooth(I,j) = DX_dyBu * &
+                      (vort_xy_smooth(I,J) * G%IdxCv(i,J) - vort_xy_smooth(I,J-1) * G%IdxCv(i,J-1))
+        enddo ; enddo
+      endif ! If Leithy
 
       ! Laplacian of vorticity
       do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
@@ -865,6 +955,15 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
                                     (0.5*(vort_xy_dy(I,j) + vort_xy_dy(I,j+1)))**2 )
       enddo ; enddo
 
+      if (CS%use_Leithy) then
+        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+          vert_vort_mag_smooth(i,j) = SQRT((0.5*(vort_xy_dx_smooth(i,J) + &
+                                                 vort_xy_dx_smooth(i,J-1)))**2 + &
+                                           (0.5*(vort_xy_dy_smooth(I,j) + &
+                                                 vort_xy_dy_smooth(I-1,j)))**2 )
+        enddo ; enddo
+      endif ! Leithy
+
     endif ! CS%Leith_Kh
 
     if ((CS%Smagorinsky_Kh) .or. (CS%Smagorinsky_Ah)) then
@@ -890,6 +989,10 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     endif
 
     if (CS%Laplacian) then
+      ! Determine the Laplacian viscosity at h points, using the
+      ! largest value from several parameterizations. Also get
+      ! the Laplacian component of str_xx.
+
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
         if (CS%use_QG_Leith_visc) then
           do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -903,9 +1006,6 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
           enddo ; enddo
         endif
       endif
-
-      ! Determine the Laplacian viscosity at h points, using the
-      ! largest value from several parameterizations.
 
       ! Static (pre-computed) background viscosity
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -980,6 +1080,14 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         enddo ; enddo
       endif
 
+      ! In Leith+E parameterization Kh is computed after Ah in the biharmonic loop.
+      ! The harmonic component of str_xx is added in the biharmonic loop.
+      if (CS%use_Leithy) then
+        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+          Kh(i,j) = 0.
+        enddo ; enddo
+      end if
+
       if (CS%id_Kh_h>0 .or. CS%debug) then
         do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
           Kh_h(i,j,k) = Kh(i,j)
@@ -1013,7 +1121,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         str_xx(i,j) = 0.0
       enddo ; enddo
-    endif
+    endif ! Get Kh at h points and get Laplacian component of str_xx
 
     if (CS%anisotropic) then
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -1026,12 +1134,13 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at h points, using the
-      ! largest value from several parameterizations.
+      ! largest value from several parameterizations. Also get the
+      ! biharmonic component of str_xx.
       do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
         Ah(i,j) = CS%Ah_bg_xx(i,j)
       enddo ; enddo
 
-      if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah)) then
+      if ((CS%Smagorinsky_Ah) .or. (CS%Leith_Ah) .or. (CS%use_Leithy)) then
         if (CS%Smagorinsky_Ah) then
           if (CS%bound_Coriolis) then
             do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
@@ -1057,12 +1166,49 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
           enddo ; enddo
         endif
 
+        if (CS%use_Leithy) then
+          ! Get m_leithy
+          do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+            Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
+                                 (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
+            AhLth  = CS%Biharm6_const_xx(i,j) * inv_PI6 * abs(Del2vort_h)
+            if (AhLth .le. Ah(i,j)) then
+              m_leithy(i,j) = 0.0
+            else
+              if ((CS%m_const_leithy(i,j)*vert_vort_mag(i,j)) .lt. abs(vort_xy_smooth(i,j))) then
+                m_leithy(i,j) = CS%c_K * (vert_vort_mag(i,j) / vort_xy_smooth(i,j))**2
+              else
+                m_leithy(i,j) = CS%m_leithy_max(i,j)
+              endif
+            endif
+          enddo ; enddo
+          ! Smooth m_leithy
+          call smooth_x9(CS, G, field_h=m_leithy, zero_land=.true.)
+          ! Get Ah
+          do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+            Del2vort_h = 0.25 * ((Del2vort_q(I,J) + Del2vort_q(I-1,J-1)) + &
+                                 (Del2vort_q(I-1,J) + Del2vort_q(I,J-1)))
+            AhLthy = CS%Biharm6_const_xx(i,j) * inv_PI6 * &
+                    sqrt(max(0.,Del2vort_h**2 - m_leithy(i,j)*vert_vort_mag_smooth(i,j)**2))
+            Ah(i,j) = max(Ah(i,j), AhLthy)
+          enddo ; enddo
+          ! Smooth Ah before applying upper bound
+          ! square, then smooth, then square root
+          do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+            Ah_h(i,j,k) = Ah(i,j)**2
+          enddo ; enddo
+          call smooth_x9(CS, G, field_h=Ah_h(:,:,k))
+          do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+            Ah(i,j) = sqrt(Ah_h(i,j,k))
+          enddo ; enddo
+        endif
+
         if (CS%bound_Ah .and. .not. CS%better_bound_Ah) then
           do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
             Ah(i,j) = min(Ah(i,j), CS%Ah_Max_xx(i,j))
           enddo ; enddo
         endif
-      endif ! Smagorinsky_Ah or Leith_Ah
+      endif ! Smagorinsky_Ah or Leith_Ah or Leith+E
 
       if (use_MEKE_Au) then
         ! *Add* the MEKE contribution
@@ -1096,6 +1242,15 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         enddo ; enddo
       endif
 
+      if (CS%use_Leithy) then
+        ! Compute Leith+E Kh after bounds have been applied to Ah
+        ! and after it has been smoothed. Kh = -m_leithy * Ah
+        do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
+            Kh(i,j) = -m_leithy(i,j) * Ah(i,j)
+            Kh_h(i,j,k) = Kh(i,j)
+        enddo ; enddo
+      endif
+
       if (CS%id_grid_Re_Ah>0) then
         do j=Jsq,Jeq+1 ; do i=Isq,Ieq+1
           KE = 0.125 * ((u(I,j,k) + u(I-1,j,k))**2 + (v(i,J,k) + v(i,J-1,k))**2)
@@ -1111,10 +1266,12 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
         str_xx(i,j) = str_xx(i,j) + d_str
 
+        if (CS%use_Leithy) str_xx(i,j) = str_xx(i,j) - Kh(i,j) * sh_xx_smooth(i,j)
+
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         bhstr_xx(i,j) = d_str * (h(i,j,k) * CS%reduction_xx(i,j))
       enddo ; enddo
-    endif
+    endif ! Get biharmonic coefficient at h points and biharmonic part of str_xx
 
     if (CS%biharmonic) then
       ! Gradient of Laplacian, for use in bi-harmonic term
@@ -1203,6 +1360,10 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
     endif
 
     if (CS%Laplacian) then
+      ! Determine the Laplacian viscosity at q points, using the
+      ! largest value from several parameterizations. Also get the
+      ! Laplacian component of str_xy.
+
       if ((CS%Leith_Kh) .or. (CS%Leith_Ah)) then
         if (CS%use_QG_Leith_visc) then
           do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1216,9 +1377,6 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
           enddo ; enddo
         endif
       endif
-
-      ! Determine the Laplacian viscosity at q points, using the
-      ! largest value from several parameterizations.
 
       ! Static (pre-computed) background viscosity
       do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1286,6 +1444,11 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
           endif
         endif
 
+        ! Leith+E doesn't recompute Kh at q points, it just interpolates it from h to q points
+        if (CS%use_Leithy) then
+          Kh(I,J) = Kh_h(i+1,j+1,k)
+        end if
+
         if (CS%id_Kh_q>0 .or. CS%debug) &
           Kh_q(I,J,k) = Kh(I,J)
 
@@ -1296,14 +1459,20 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
           sh_xy_q(I,J,k) = sh_xy(I,J)
       enddo ; enddo
 
-      do J=js-1,Jeq ; do I=is-1,Ieq
-        str_xy(I,J) = -Kh(I,J) * sh_xy(I,J)
-      enddo ; enddo
+      if ( .not. CS%use_Leithy) then
+        do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J) = -Kh(I,J) * sh_xy(I,J)
+        enddo ; enddo
+      else
+        do J=js-1,Jeq ; do I=is-1,Ieq
+          str_xy(I,J) = -Kh(I,J) * sh_xy_smooth(I,J)
+        enddo ; enddo
+      endif
     else
       do J=js-1,Jeq ; do I=is-1,Ieq
         str_xy(I,J) = 0.
       enddo ; enddo
-    endif
+    endif ! get harmonic coefficient Kh at q points and harmonic part of str_xy
 
     if (CS%anisotropic) then
       do J=js-1,Jeq ; do I=is-1,Ieq
@@ -1316,7 +1485,8 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
 
     if (CS%biharmonic) then
       ! Determine the biharmonic viscosity at q points, using the
-      ! largest value from several parameterizations.
+      ! largest value from several parameterizations. Also get the
+      ! biharmonic component of str_xy.
       do J=js-1,Jeq ; do I=is-1,Ieq
         Ah(I,J) = CS%Ah_bg_xy(I,J)
       enddo ; enddo
@@ -1380,6 +1550,13 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         endif
       endif
 
+      ! Leith+E doesn't recompute Ah at q points, it just interpolates it from h to q points
+      if (CS%use_Leithy) then
+        do J=js-1,Jeq ; do I=is-1,Ieq
+           Ah(I,J) = Ah_h(i+1,j+1,k)
+        enddo ; enddo
+      end if
+
       if (CS%id_Ah_q>0 .or. CS%debug) then
         do J=js-1,Jeq ; do I=is-1,Ieq
           Ah_q(I,J,k) = Ah(I,J)
@@ -1395,7 +1572,7 @@ subroutine horizontal_viscosity(u, v, h, diffu, diffv, MEKE, VarMix, G, GV, US, 
         ! Keep a copy of the biharmonic contribution for backscatter parameterization
         bhstr_xy(I,J) = d_str * (hq(I,J) * G%mask2dBu(I,J) * CS%reduction_xy(I,J))
       enddo ; enddo
-    endif
+    endif ! Get Ah at q points and biharmonic part of str_xy
 
     if (CS%use_GME) then
       ! The wider halo here is to permit one pass of smoothing without a halo update.
@@ -1907,6 +2084,10 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
                  "If true, use a biharmonic Leith nonlinear eddy "//&
                  "viscosity.", default=.false., do_not_log=.not.CS%biharmonic)
   if (.not.CS%biharmonic) CS%Leith_Ah = .false.
+  call get_param(param_file, mdl, "USE_LEITHY", CS%use_Leithy, &
+                 "If true, use a biharmonic Leith nonlinear eddy "//&
+                 "viscosity together with a harmonic backscatter.", &
+                 default=.false., do_not_log=.not.(CS%biharmonic .and. CS%Laplacian))
   call get_param(param_file, mdl, "BOUND_AH", CS%bound_Ah, &
                  "If true, the biharmonic coefficient is locally limited "//&
                  "to be stable.", default=.true., do_not_log=.not.CS%biharmonic)
@@ -1965,12 +2146,11 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
                  "Coriolis acceleration.  The default is set by MAXVEL.", &
                  units="m s-1", default=maxvel*US%L_T_to_m_s, scale=US%m_s_to_L_T, &
                  do_not_log=.not.(CS%Smagorinsky_Ah .and. CS%bound_Coriolis))
-
   call get_param(param_file, mdl, "LEITH_BI_CONST", Leith_bi_const, &
                  "The nondimensional biharmonic Leith constant, "//&
                  "typical values are thus far undetermined.", units="nondim", default=0.0, &
-                 fail_if_missing=CS%Leith_Ah, do_not_log=.not.CS%Leith_Ah)
-
+                 fail_if_missing=(CS%Leith_Ah .or. CS%use_Leithy), &
+                 do_not_log=.not.(CS%Leith_Ah .or. CS%use_Leithy))
   call get_param(param_file, mdl, "USE_LAND_MASK_FOR_HVISC", CS%use_land_mask, &
                  "If true, use the land mask for the computation of thicknesses "//&
                  "at velocity locations. This eliminates the dependence on arbitrary "//&
@@ -2002,6 +2182,16 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
                  "with the Gent and McWilliams parameterization.", default=.false.)
   call get_param(param_file, mdl, "SPLIT", split, &
                  "Use the split time stepping if true.", default=.true., do_not_log=.true.)
+  if (CS%use_Leithy) then
+    if (.not.(CS%biharmonic .and. CS%Laplacian)) then
+                   call MOM_error(FATAL, "MOM_hor_visc.F90, hor_visc_init:"//&
+                   "LAPLACIAN and BIHARMONIC must both be True when USE_LEITHY=True.")
+    endif
+    call get_param(param_file, mdl, "LEITHY_CK", CS%c_K, &
+                   "Fraction of biharmonic dissipation that gets backscattered, "//&
+                   "in Leith+E.", units="nondim", default=1.0)
+  endif
+
   if (CS%use_GME .and. .not.split) call MOM_error(FATAL,"ERROR: Currently, USE_GME = True "// &
                                            "cannot be used with SPLIT=False.")
 
@@ -2120,9 +2310,13 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
         ALLOC_(CS%Biharm_const2_xy(IsdB:IedB,JsdB:JedB)) ; CS%Biharm_const2_xy(:,:) = 0.0
       endif
     endif
-    if (CS%Leith_Ah) then
-        ALLOC_(CS%biharm6_const_xx(isd:ied,jsd:jed)) ; CS%biharm6_const_xx(:,:) = 0.0
-        ALLOC_(CS%biharm6_const_xy(IsdB:IedB,JsdB:JedB)) ; CS%biharm6_const_xy(:,:) = 0.0
+    if ((CS%Leith_Ah) .or. (CS%use_Leithy)) then
+      ALLOC_(CS%biharm6_const_xx(isd:ied,jsd:jed)) ; CS%biharm6_const_xx(:,:) = 0.0
+      ALLOC_(CS%biharm6_const_xy(IsdB:IedB,JsdB:JedB)) ; CS%biharm6_const_xy(:,:) = 0.0
+    endif
+    if (CS%use_Leithy) then
+      ALLOC_(CS%m_const_leithy(isd:ied,jsd:jed)) ; CS%m_const_leithy(:,:) = 0.0
+      ALLOC_(CS%m_leithy_max(isd:ied,jsd:jed)) ; CS%m_leithy_max(:,:) = 0.0
     endif
     if (CS%Re_Ah > 0.0) then
       ALLOC_(CS%Re_Ah_const_xx(isd:ied,jsd:jed)); CS%Re_Ah_const_xx(:,:) = 0.0
@@ -2265,6 +2459,11 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
       if (CS%Leith_Ah) then
          CS%biharm6_const_xx(i,j) = Leith_bi_const * (grid_sp_h3 * grid_sp_h3)
       endif
+      if (CS%use_Leithy) then
+         CS%biharm6_const_xx(i,j) = Leith_bi_const * max(G%dxT(i,j),G%dyT(i,j))**6
+         CS%m_const_leithy(i,j) = 0.5 * sqrt(CS%c_K) * max(G%dxT(i,j),G%dyT(i,j))
+         CS%m_leithy_max(i,j) = 4. / max(G%dxT(i,j),G%dyT(i,j))**2
+      endif
       CS%Ah_bg_xx(i,j) = MAX(Ah, Ah_vel_scale * grid_sp_h2 * sqrt(grid_sp_h2))
       if (CS%Re_Ah > 0.0) CS%Re_Ah_const_xx(i,j) = grid_sp_h3 / CS%Re_Ah
       if (Ah_time_scale > 0.) CS%Ah_bg_xx(i,j) = &
@@ -2287,7 +2486,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
                                      (abs(G%CoriolisBu(I,J)) * BoundCorConst)
         endif
       endif
-      if (CS%Leith_Ah) then
+      if ((CS%Leith_Ah) .or. (CS%use_Leithy))then
          CS%biharm6_const_xy(I,J) = Leith_bi_const * (grid_sp_q3 * grid_sp_q3)
       endif
       CS%Ah_bg_xy(I,J) = MAX(Ah, Ah_vel_scale * grid_sp_q2 * sqrt(grid_sp_q2))
@@ -2629,6 +2828,113 @@ subroutine smooth_GME(CS, G, GME_flux_h, GME_flux_q)
   enddo ! s-loop
 end subroutine smooth_GME
 
+!> Apply a 9-point smoothing filter twice to reduce horizontal two-grid-point noise
+!! Note that this subroutine does not conserve mass or angular momentum, so don't use it
+!! in situations where you need conservation. Also can't apply it to Ah and Kh in the
+!! horizontal_viscosity subroutine because they are not supposed to be halo-updated.
+!! But you _can_ apply them to Kh_h and Ah_h.
+subroutine smooth_x9(CS, G, field_h, field_u, field_v, field_q, zero_land)
+  type(hor_visc_CS),                            intent(in)    :: CS        !< Control structure
+  type(ocean_grid_type),                        intent(in)    :: G         !< Ocean grid
+  real, dimension(SZI_(G),SZJ_(G)), optional,   intent(inout) :: field_h   !< field to be smoothed
+                                                              !! at h points
+  real, dimension(SZIB_(G),SZJ_(G)), optional,  intent(inout) :: field_u   !< field to be smoothed
+                                                              !! at u points
+  real, dimension(SZI_(G),SZJB_(G)), optional,  intent(inout) :: field_v   !< field to be smoothed
+                                                              !! at v points
+  real, dimension(SZIB_(G),SZJB_(G)), optional, intent(inout) :: field_q   !< field to be smoothed
+                                                              !! at q points
+  logical, optional, intent(in)                               :: zero_land !< An optional argument
+                                                              !! indicating whether to set values
+                                                              !! on land to zero (.true.) or
+                                                              !! whether to ignore land values
+                                                              !! (.false. or not present)
+  ! local variables. It would be good to make the _original variables allocatable.
+  real, dimension(SZI_(G),SZJ_(G))   :: field_h_original
+  real, dimension(SZIB_(G),SZJ_(G))  :: field_u_original
+  real, dimension(SZI_(G),SZJB_(G))  :: field_v_original
+  real, dimension(SZIB_(G),SZJB_(G)) :: field_q_original
+  real, dimension(3,3) :: weights, local_weights ! averaging weights for smoothing, nondimensional
+  logical :: zero_land_val ! actual value of zero_land optional argument
+  integer :: i, j, s
+  integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq
+
+
+  is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec
+  Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
+
+  weights = reshape([1., 2., 1., 2., 4., 2., 1., 2., 1.],shape(weights))/16.
+
+  if (present(zero_land)) then
+    zero_land_val = zero_land
+  else
+    zero_land_val = .false.
+  endif
+
+  if (present(field_h)) then
+    call pass_var(field_h, G%Domain, halo=2) ! Halo size 2 ensures that you can smooth twice
+    do s=1,0,-1
+      field_h_original(:,:) = field_h(:,:)
+      ! apply smoothing on field_h
+      do j=js-s,je+s ; do i=is-s,ie+s
+        ! skip land points
+        if (G%mask2dT(i,j)==0.) cycle
+        ! compute local weights
+        local_weights = weights*G%mask2dT(i-1:i+1,j-1:j+1)
+        if (zero_land_val) local_weights = local_weights/(sum(local_weights) + 1.E-16)
+        field_h(i,j) =  sum(local_weights*field_h_original(i-1:i+1,j-1:j+1))
+      enddo ; enddo
+    enddo
+    call pass_var(field_h, G%Domain)
+  endif
+
+  if (present(field_u)) then
+    call pass_vector(field_u, field_v, G%Domain, halo=2)
+    do s=1,0,-1
+      field_u_original(:,:) = field_u(:,:)
+      ! apply smoothing on field_u
+      do j=js-s,je+s ; do I=Isq-s,Ieq+s
+        ! skip land points
+        if (G%mask2dCu(I,j)==0.) cycle
+        ! compute local weights
+        local_weights = weights*G%mask2dCu(I-1:I+1,j-1:j+1)
+        if (zero_land_val) local_weights = local_weights/(sum(local_weights) + 1.E-16)
+        field_u(I,j) =  sum(local_weights*field_u_original(I-1:I+1,j-1:j+1))
+      enddo ; enddo
+
+      field_v_original(:,:) = field_v(:,:)
+      ! apply smoothing on field_v
+      do J=Jsq-s,Jeq+s ; do i=is-s,ie+s
+        ! skip land points
+        if (G%mask2dCv(i,J)==0.) cycle
+        ! compute local weights
+        local_weights = weights*G%mask2dCv(i-1:i+1,J-1:J+1)
+        if (zero_land_val) local_weights = local_weights/(sum(local_weights) + 1.E-16)
+        field_v(i,J) =  sum(local_weights*field_v_original(i-1:i+1,J-1:J+1))
+      enddo ; enddo
+    enddo
+    call pass_vector(field_u, field_v, G%Domain)
+  endif
+
+  if (present(field_q)) then
+    call pass_var(field_q, G%Domain, halo=2, position=CORNER)
+    do s=1,0,-1
+      field_q_original(:,:) = field_q(:,:)
+      ! apply smoothing on field_q
+      do J=Jsq-s,Jeq+s ; do I=Isq-s,Ieq+s
+        ! skip land points
+        if (G%mask2dBu(I,J)==0.) cycle
+        ! compute local weights
+        local_weights = weights*G%mask2dBu(I-1:I+1,J-1:J+1)
+        if (zero_land_val) local_weights = local_weights/(sum(local_weights) + 1.E-16)
+        field_q(I,J) =  sum(local_weights*field_q_original(I-1:I+1,J-1:J+1))
+      enddo ; enddo
+    enddo
+    call pass_var(field_q, G%Domain, position=CORNER)
+  endif
+
+end subroutine smooth_x9
+
 !> Deallocates any variables allocated in hor_visc_init.
 subroutine hor_visc_end(CS)
   type(hor_visc_CS), intent(inout) :: CS !< Horizontal viscosity control structure
@@ -2661,8 +2967,12 @@ subroutine hor_visc_end(CS)
     if (CS%Smagorinsky_Ah) then
       DEALLOC_(CS%Biharm_const_xx) ; DEALLOC_(CS%Biharm_const_xy)
     endif
-    if (CS%Leith_Ah) then
+    if ((CS%Leith_Ah) .or. (CS%use_Leithy)) then
       DEALLOC_(CS%Biharm6_const_xx) ; DEALLOC_(CS%Biharm6_const_xy)
+    endif
+    if (CS%use_Leithy) then
+      DEALLOC_(CS%m_const_leithy)
+      DEALLOC_(CS%m_leithy_max)
     endif
     if (CS%Re_Ah > 0.0) then
       DEALLOC_(CS%Re_Ah_const_xx) ; DEALLOC_(CS%Re_Ah_const_xy)

--- a/src/tracer/MOM_hor_bnd_diffusion.F90
+++ b/src/tracer/MOM_hor_bnd_diffusion.F90
@@ -1,7 +1,7 @@
-!> Calculates and applies diffusive fluxes as a parameterization of lateral mixing (non-neutral) by
+!> Calculates and applies diffusive fluxes as a parameterization of horizontal mixing (non-neutral) by
 !! mesoscale eddies near the top and bottom (to be implemented) boundary layers of the ocean.
 
-module MOM_lateral_boundary_diffusion
+module MOM_hor_bnd_diffusion
 
 ! This file is part of MOM6. See LICENSE.md for the license.
 
@@ -28,18 +28,19 @@ use MOM_io,                    only : stdout, stderr
 
 implicit none ; private
 
-public near_boundary_unit_tests, lateral_boundary_diffusion, lateral_boundary_diffusion_init
-public boundary_k_range
+public near_boundary_unit_tests, hor_bnd_diffusion, hor_bnd_diffusion_init
+public boundary_k_range, hor_bnd_diffusion_end
 
 ! Private parameters to avoid doing string comparisons for bottom or top boundary layer
 integer, public, parameter :: SURFACE = -1 !< Set a value that corresponds to the surface bopundary
 integer, public, parameter :: BOTTOM  = 1  !< Set a value that corresponds to the bottom boundary
 #include <MOM_memory.h>
 
-!> Sets parameters for lateral boundary mixing module.
-type, public :: lbd_CS ; private
+!> Sets parameters for horizontal boundary mixing module.
+type, public :: hbd_CS ; private
   logical :: debug           !< If true, write verbose checksums for debugging.
   integer :: deg             !< Degree of polynomial reconstruction.
+  integer :: hbd_nk          !< Maximum number of levels in the HBD grid [nondim]
   integer :: surface_boundary_scheme !< Which boundary layer scheme to use
                              !! 1. ePBL; 2. KPP
   logical :: limiter         !< Controls whether a flux limiter is applied in the
@@ -51,50 +52,58 @@ type, public :: lbd_CS ; private
   real    :: H_subroundoff   !< A thickness that is so small that it can be added to a thickness of
                              !! Angstrom or larger without changing it at the bit level [H ~> m or kg m-2].
                              !! If Angstrom is 0 or exceedingly small, this is negligible compared to 1e-17 m.
+  ! HBD dynamic grids
+  real,    allocatable, dimension(:,:,:) :: hbd_grd_u   !< HBD thicknesses at t-points adjecent to
+                                                          !! u-points                     [H ~> m or kg m-2]
+  real,    allocatable, dimension(:,:,:) :: hbd_grd_v   !< HBD thicknesses at t-points adjacent to
+                                                          !! v-points (left and right)    [H ~> m or kg m-2]
+  integer, allocatable, dimension(:,:)   :: hbd_u_kmax  !< Maximum vertical index in hbd_grd_u      [nondim]
+  integer, allocatable, dimension(:,:)   :: hbd_v_kmax  !< Maximum vertical index in hbd_grd_v      [nondim]
   type(remapping_CS)              :: remap_CS          !< Control structure to hold remapping configuration.
   type(KPP_CS),           pointer :: KPP_CSp => NULL() !< KPP control structure needed to get BLD.
   type(energetic_PBL_CS), pointer :: energetic_PBL_CSp => NULL()  !< ePBL control structure needed to get BLD.
   type(diag_ctrl), pointer :: diag => NULL() !< A structure that is used to
                                              !! regulate the timing of diagnostic output.
-end type lbd_CS
+end type hbd_CS
 
 ! This include declares and sets the variable "version".
 #include "version_variable.h"
-character(len=40) :: mdl = "MOM_lateral_boundary_diffusion" !< Name of this module
-integer :: id_clock_lbd                                     !< CPU clock for lbd
+character(len=40) :: mdl = "MOM_hor_bnd_diffusion" !< Name of this module
+integer :: id_clock_hbd                            !< CPU clock for hbd
 
 contains
 
 !> Initialization routine that reads runtime parameters and sets up pointers to other control structures that might be
-!! needed for lateral boundary diffusion.
-logical function lateral_boundary_diffusion_init(Time, G, GV, param_file, diag, diabatic_CSp, CS)
+!! needed for horizontal boundary diffusion.
+logical function hor_bnd_diffusion_init(Time, G, GV, US, param_file, diag, diabatic_CSp, CS)
   type(time_type), target,          intent(in)    :: Time          !< Time structure
   type(ocean_grid_type),            intent(in)    :: G             !< Grid structure
   type(verticalGrid_type),          intent(in)    :: GV            !< ocean vertical grid structure
+  type(unit_scale_type),            intent(in)    :: US            !< A dimensional unit scaling type
   type(param_file_type),            intent(in)    :: param_file    !< Parameter file structure
   type(diag_ctrl), target,          intent(inout) :: diag          !< Diagnostics control structure
   type(diabatic_CS),                pointer       :: diabatic_CSp  !< KPP control structure needed to get BLD
-  type(lbd_CS),                     pointer       :: CS            !< Lateral boundary mixing control structure
+  type(hbd_CS),                     pointer       :: CS            !< Horizontal boundary mixing control structure
 
   ! local variables
   character(len=80)  :: string ! Temporary strings
-  logical :: boundary_extrap   ! controls if boundary extrapolation is used in the LBD code
+  logical :: boundary_extrap   ! controls if boundary extrapolation is used in the HBD code
 
   if (ASSOCIATED(CS)) then
-    call MOM_error(FATAL, "lateral_boundary_diffusion_init called with associated control structure.")
+    call MOM_error(FATAL, "hor_bnd_diffusion_init called with associated control structure.")
     return
   endif
 
   ! Log this module and master switch for turning it on/off
-  call get_param(param_file, mdl, "USE_LATERAL_BOUNDARY_DIFFUSION", lateral_boundary_diffusion_init, &
+  call get_param(param_file, mdl, "USE_HORIZONTAL_BOUNDARY_DIFFUSION", hor_bnd_diffusion_init, &
                  default=.false., do_not_log=.true.)
   call log_version(param_file, mdl, version, &
-           "This module implements lateral diffusion of tracers near boundaries", &
-           all_default=.not.lateral_boundary_diffusion_init)
-  call get_param(param_file, mdl, "USE_LATERAL_BOUNDARY_DIFFUSION", lateral_boundary_diffusion_init, &
-                 "If true, enables the lateral boundary tracer's diffusion module.", &
+           "This module implements horizontal diffusion of tracers near boundaries", &
+           all_default=.not.hor_bnd_diffusion_init)
+  call get_param(param_file, mdl, "USE_HORIZONTAL_BOUNDARY_DIFFUSION", hor_bnd_diffusion_init, &
+                 "If true, enables the horizonal boundary tracer's diffusion module.", &
                  default=.false.)
-  if (.not. lateral_boundary_diffusion_init) return
+  if (.not. hor_bnd_diffusion_init) return
 
   allocate(CS)
   CS%diag => diag
@@ -102,46 +111,55 @@ logical function lateral_boundary_diffusion_init(Time, G, GV, param_file, diag, 
   call extract_diabatic_member(diabatic_CSp, KPP_CSp=CS%KPP_CSp)
   call extract_diabatic_member(diabatic_CSp, energetic_PBL_CSp=CS%energetic_PBL_CSp)
 
+  ! max. number of vertical layers
+  CS%hbd_nk = 2 + (GV%ke*2)
+  ! allocate the hbd grids and k_max
+  allocate(CS%hbd_grd_u(SZIB_(G),SZJ_(G),CS%hbd_nk), source=0.0)
+  allocate(CS%hbd_grd_v(SZI_(G),SZJB_(G),CS%hbd_nk), source=0.0)
+  allocate(CS%hbd_u_kmax(SZIB_(G),SZJ_(G)), source=0)
+  allocate(CS%hbd_v_kmax(SZI_(G),SZJB_(G)), source=0)
+
   CS%surface_boundary_scheme = -1
   if ( .not. ASSOCIATED(CS%energetic_PBL_CSp) .and. .not. ASSOCIATED(CS%KPP_CSp) ) then
-    call MOM_error(FATAL,"Lateral boundary diffusion is true, but no valid boundary layer scheme was found")
+    call MOM_error(FATAL,"Horizontal boundary diffusion is true, but no valid boundary layer scheme was found")
   endif
 
   ! Read all relevant parameters and write them to the model log.
-  call get_param(param_file, mdl, "LBD_LINEAR_TRANSITION", CS%linear, &
+  call get_param(param_file, mdl, "HBD_LINEAR_TRANSITION", CS%linear, &
                  "If True, apply a linear transition at the base/top of the boundary. \n"//&
                  "The flux will be fully applied at k=k_min and zero at k=k_max.", default=.false.)
   call get_param(param_file, mdl, "APPLY_LIMITER", CS%limiter, &
                    "If True, apply a flux limiter in the native grid.", default=.true.)
   call get_param(param_file, mdl, "APPLY_LIMITER_REMAP", CS%limiter_remap, &
                    "If True, apply a flux limiter in the remapped grid.", default=.false.)
-  call get_param(param_file, mdl, "LBD_BOUNDARY_EXTRAP", boundary_extrap, &
-                 "Use boundary extrapolation in LBD code", &
+  call get_param(param_file, mdl, "HBD_BOUNDARY_EXTRAP", boundary_extrap, &
+                 "Use boundary extrapolation in HBD code", &
                  default=.false.)
-  call get_param(param_file, mdl, "LBD_REMAPPING_SCHEME", string, &
+  call get_param(param_file, mdl, "HBD_REMAPPING_SCHEME", string, &
                  "This sets the reconstruction scheme used "//&
                  "for vertical remapping for all variables. "//&
                  "It can be one of the following schemes: "//&
                  trim(remappingSchemesDoc), default=remappingDefaultScheme)
-  !### Revisit this hard-coded answer_date.
+
+  ! GMM, TODO: add HBD params to control optional arguments in initialize_remapping.
   call initialize_remapping( CS%remap_CS, string, boundary_extrapolation = boundary_extrap ,&
-       check_reconstruction=.false., check_remapping=.false., answer_date=20190101)
+       check_reconstruction=.false., check_remapping=.false.)
   call extract_member_remapping_CS(CS%remap_CS, degree=CS%deg)
-  call get_param(param_file, mdl, "LBD_DEBUG", CS%debug, &
-                 "If true, write out verbose debugging data in the LBD module.", &
+  call get_param(param_file, mdl, "HBD_DEBUG", CS%debug, &
+                 "If true, write out verbose debugging data in the HBD module.", &
                  default=.false.)
 
-  id_clock_lbd = cpu_clock_id('(Ocean LBD)', grain=CLOCK_MODULE)
+  id_clock_hbd = cpu_clock_id('(Ocean HBD)', grain=CLOCK_MODULE)
 
-end function lateral_boundary_diffusion_init
+end function hor_bnd_diffusion_init
 
-!> Driver routine for calculating lateral diffusive fluxes near the top and bottom boundaries.
+!> Driver routine for calculating horizontal diffusive fluxes near the top and bottom boundaries.
 !! Diffusion is applied using only information from neighboring cells, as follows:
-!! 1) remap tracer to a z* grid (LBD grid)
-!! 2) calculate diffusive tracer fluxes (F) in the LBD grid using a layer by layer approach
+!! 1) remap tracer to a z* grid (HBD grid)
+!! 2) calculate diffusive tracer fluxes (F) in the HBD grid using a layer by layer approach
 !! 3) remap fluxes to the native grid
 !! 4) update tracer by adding the divergence of F
-subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
+subroutine hor_bnd_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
   type(ocean_grid_type),                intent(inout) :: G      !< Grid type
   type(verticalGrid_type),              intent(in)    :: GV     !< ocean vertical grid structure
   type(unit_scale_type),                intent(in)    :: US     !< A dimensional unit scaling type
@@ -152,7 +170,7 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
   real,                                 intent(in)    :: dt     !< Tracer time step * I_numitts
                                                                 !! (I_numitts in tracer_hordiff) [T ~> s]
   type(tracer_registry_type),           pointer       :: Reg    !< Tracer registry
-  type(lbd_CS),                         pointer       :: CS     !< Control structure for this module
+  type(hbd_CS),                         pointer       :: CS     !< Control structure for this module
 
   ! Local variables
   real, dimension(SZI_(G),SZJ_(G))           :: hbl         !< Boundary layer depth [H ~> m or kg m-2]
@@ -168,28 +186,32 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
   type(tracer_type), pointer                 :: tracer => NULL() !< Pointer to the current tracer
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV))  :: tracer_old  !< local copy of the initial tracer concentration,
                                                             !! only used to compute tendencies.
-  real :: tracer_int_prev !< Globally integrated tracer before LBD is applied, in mks units [conc kg]
-  real :: tracer_int_end  !< Integrated tracer after LBD is applied, in mks units [conc kg]
+  real :: tracer_int_prev !< Globally integrated tracer before HBD is applied, in mks units [conc kg]
+  real :: tracer_int_end  !< Integrated tracer after HBD is applied, in mks units [conc kg]
   real    :: Idt          !< inverse of the time step [T-1 ~> s-1]
   character(len=256) :: mesg !< Message for error messages.
   integer :: i, j, k, m   !< indices to loop over
 
-  call cpu_clock_begin(id_clock_lbd)
+  call cpu_clock_begin(id_clock_hbd)
   Idt = 1./dt
   if (ASSOCIATED(CS%KPP_CSp)) call KPP_get_BLD(CS%KPP_CSp, hbl, G, US, m_to_BLD_units=GV%m_to_H)
   if (ASSOCIATED(CS%energetic_PBL_CSp)) call energetic_PBL_get_MLD(CS%energetic_PBL_CSp, hbl, G, US, &
                                                                    m_to_MLD_units=GV%m_to_H)
   call pass_var(hbl,G%Domain)
+
+  ! build HBD grid
+  call hbd_grid(SURFACE, G, GV, hbl, h, CS)
+
   do m = 1,Reg%ntr
     ! current tracer
     tracer => Reg%tr(m)
 
     if (CS%debug) then
-      call hchksum(tracer%t, "before LBD "//tracer%name,G%HI)
+      call hchksum(tracer%t, "before HBD "//tracer%name,G%HI)
     endif
 
     ! for diagnostics
-    if (tracer%id_lbdxy_conc > 0 .or. tracer%id_lbdxy_cont > 0 .or. tracer%id_lbdxy_cont_2d > 0 .or. CS%debug) then
+    if (tracer%id_hbdxy_conc > 0 .or. tracer%id_hbdxy_cont > 0 .or. tracer%id_hbdxy_cont_2d > 0 .or. CS%debug) then
       tendency(:,:,:) = 0.0
       tracer_old(:,:,:) = tracer%t(:,:,:)
     endif
@@ -198,13 +220,14 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
     uFlx(:,:,:) = 0.
     vFlx(:,:,:) = 0.
 
-    ! LBD layer by layer
+    ! HBD layer by layer
     do j=G%jsc,G%jec
       do i=G%isc-1,G%iec
         if (G%mask2dCu(I,j)>0.) then
-          call fluxes_layer_method(SURFACE, G%ke, hbl(I,j), hbl(I+1,j),  &
+           call fluxes_layer_method(SURFACE, G%ke, hbl(I,j), hbl(I+1,j),  &
             h(I,j,:), h(I+1,j,:), tracer%t(I,j,:), tracer%t(I+1,j,:), &
-            Coef_x(I,j), uFlx(I,j,:), G%areaT(I,j), G%areaT(I+1,j), CS)
+            Coef_x(I,j), uFlx(I,j,:), G%areaT(I,j), G%areaT(I+1,j), CS%hbd_u_kmax(I,j), &
+            CS%hbd_grd_u(I,j,:), CS)
         endif
       enddo
     enddo
@@ -213,7 +236,8 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
         if (G%mask2dCv(i,J)>0.) then
           call fluxes_layer_method(SURFACE, GV%ke, hbl(i,J), hbl(i,J+1),  &
             h(i,J,:), h(i,J+1,:), tracer%t(i,J,:), tracer%t(i,J+1,:), &
-            Coef_y(i,J), vFlx(i,J,:), G%areaT(i,J), G%areaT(i,J+1), CS)
+            Coef_y(i,J), vFlx(i,J,:), G%areaT(i,J), G%areaT(i,J+1), CS%hbd_v_kmax(i,J), &
+            CS%hbd_grd_v(i,J,:), CS)
         endif
       enddo
     enddo
@@ -224,7 +248,7 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
         tracer%t(i,j,k) = tracer%t(i,j,k) + (( (uFlx(I-1,j,k)-uFlx(I,j,k)) ) + ( (vFlx(i,J-1,k)-vFlx(i,J,k) ) ))* &
                           G%IareaT(i,j) / ( h(i,j,k) + GV%H_subroundoff )
 
-        if (tracer%id_lbdxy_conc > 0  .or. tracer%id_lbdxy_cont > 0 .or. tracer%id_lbdxy_cont_2d > 0 ) then
+        if (tracer%id_hbdxy_conc > 0  .or. tracer%id_hbdxy_cont > 0 .or. tracer%id_hbdxy_cont_2d > 0 ) then
           tendency(i,j,k) = ((uFlx(I-1,j,k)-uFlx(I,j,k)) + (vFlx(i,J-1,k)-vFlx(i,J,k)))  * &
                             G%IareaT(i,j) * Idt
         endif
@@ -239,64 +263,131 @@ subroutine lateral_boundary_diffusion(G, GV, US, h, Coef_x, Coef_y, dt, Reg, CS)
     endif
 
     if (CS%debug) then
-      call hchksum(tracer%t, "after LBD "//tracer%name,G%HI)
-      ! tracer (native grid) integrated tracer amounts before and after LBD
+      call hchksum(tracer%t, "after HBD "//tracer%name,G%HI)
+      ! tracer (native grid) integrated tracer amounts before and after HBD
       tracer_int_prev = global_mass_integral(h, G, GV, tracer_old)
       tracer_int_end = global_mass_integral(h, G, GV, tracer%t)
-      write(mesg,*) 'Total '//tracer%name//' before/after LBD:', tracer_int_prev, tracer_int_end
+      write(mesg,*) 'Total '//tracer%name//' before/after HBD:', tracer_int_prev, tracer_int_end
       call MOM_mesg(mesg)
     endif
 
     ! Post the tracer diagnostics
-    if (tracer%id_lbd_dfx>0)      call post_data(tracer%id_lbd_dfx, uFlx(:,:,:)*Idt, CS%diag)
-    if (tracer%id_lbd_dfy>0)      call post_data(tracer%id_lbd_dfy, vFlx(:,:,:)*Idt, CS%diag)
-    if (tracer%id_lbd_dfx_2d>0) then
+    if (tracer%id_hbd_dfx>0)      call post_data(tracer%id_hbd_dfx, uFlx(:,:,:)*Idt, CS%diag)
+    if (tracer%id_hbd_dfy>0)      call post_data(tracer%id_hbd_dfy, vFlx(:,:,:)*Idt, CS%diag)
+    if (tracer%id_hbd_dfx_2d>0) then
       uwork_2d(:,:) = 0.
       do k=1,GV%ke ; do j=G%jsc,G%jec ; do I=G%isc-1,G%iec
         uwork_2d(I,j) = uwork_2d(I,j) + (uFlx(I,j,k) * Idt)
       enddo ; enddo ; enddo
-      call post_data(tracer%id_lbd_dfx_2d, uwork_2d, CS%diag)
+      call post_data(tracer%id_hbd_dfx_2d, uwork_2d, CS%diag)
     endif
 
-    if (tracer%id_lbd_dfy_2d>0) then
+    if (tracer%id_hbd_dfy_2d>0) then
       vwork_2d(:,:) = 0.
       do k=1,GV%ke ; do J=G%jsc-1,G%jec ; do i=G%isc,G%iec
         vwork_2d(i,J) = vwork_2d(i,J) + (vFlx(i,J,k) * Idt)
       enddo ; enddo ; enddo
-      call post_data(tracer%id_lbd_dfy_2d, vwork_2d, CS%diag)
+      call post_data(tracer%id_hbd_dfy_2d, vwork_2d, CS%diag)
     endif
 
     ! post tendency of tracer content
-    if (tracer%id_lbdxy_cont > 0) then
-      call post_data(tracer%id_lbdxy_cont, tendency, CS%diag)
+    if (tracer%id_hbdxy_cont > 0) then
+      call post_data(tracer%id_hbdxy_cont, tendency, CS%diag)
     endif
 
     ! post depth summed tendency for tracer content
-    if (tracer%id_lbdxy_cont_2d > 0) then
+    if (tracer%id_hbdxy_cont_2d > 0) then
       tendency_2d(:,:) = 0.
       do j=G%jsc,G%jec ; do i=G%isc,G%iec
         do k=1,GV%ke
           tendency_2d(i,j) = tendency_2d(i,j) + tendency(i,j,k)
         enddo
       enddo ; enddo
-      call post_data(tracer%id_lbdxy_cont_2d, tendency_2d, CS%diag)
+      call post_data(tracer%id_hbdxy_cont_2d, tendency_2d, CS%diag)
     endif
 
     ! post tendency of tracer concentration; this step must be
     ! done after posting tracer content tendency, since we alter
     ! the tendency array and its units.
-    if (tracer%id_lbdxy_conc > 0) then
+    if (tracer%id_hbdxy_conc > 0) then
       do k=1,GV%ke ; do j=G%jsc,G%jec ; do i=G%isc,G%iec
         tendency(i,j,k) =  tendency(i,j,k) / ( h(i,j,k) + CS%H_subroundoff )
       enddo ; enddo ; enddo
-      call post_data(tracer%id_lbdxy_conc, tendency, CS%diag)
+      call post_data(tracer%id_hbdxy_conc, tendency, CS%diag)
     endif
 
   enddo
 
-  call cpu_clock_end(id_clock_lbd)
+  call cpu_clock_end(id_clock_hbd)
 
-end subroutine lateral_boundary_diffusion
+end subroutine hor_bnd_diffusion
+
+!> Build the HBD grid where tracers will be rammaped to.
+subroutine hbd_grid(boundary, G, GV, hbl, h, CS)
+  integer,                 intent(in   ) :: boundary !< Which boundary layer SURFACE or BOTTOM       [nondim]
+  type(ocean_grid_type),   intent(inout) :: G    !< Grid type
+  type(verticalGrid_type), intent(in)    :: GV   !< ocean vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G))       :: hbl  !< Boundary layer depth                   [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                          intent(in)     :: h    !< Layer thickness in the native grid     [H ~> m or kg m-2]
+  type(hbd_CS),          pointer         :: CS   !< Horizontal diffusion control structure
+
+  ! Local variables
+  real, allocatable :: dz_top(:) !< temporary HBD grid given by merge_interfaces           [H ~> m or kg m-2]
+  integer :: nk, i, j, k         !< number of layers in the HBD grid, and integers used in do-loops
+
+  ! reset arrays
+  CS%hbd_grd_u(:,:,:) = 0.0
+  CS%hbd_grd_v(:,:,:) = 0.0
+  CS%hbd_u_kmax(:,:)  = 0
+  CS%hbd_v_kmax(:,:)  = 0
+
+  do j=G%jsc,G%jec
+    do I=G%isc-1,G%iec
+      if (G%mask2dCu(I,j)>0.) then
+        call merge_interfaces(GV%ke, h(I,j,:), h(I+1,j,:), hbl(I,j), hbl(I+1,j), &
+                              CS%H_subroundoff, dz_top)
+        nk = SIZE(dz_top)
+        if (nk > CS%hbd_nk) then
+          write(*,*)'nk, CS%hbd_nk', nk, CS%hbd_nk
+          call MOM_error(FATAL,"Houston, we've had a problem in hbd_grid, u-points (nk cannot be > CS%hbd_nk)")
+        endif
+
+        CS%hbd_u_kmax(I,j) = nk
+
+        ! set the HBD grid to dz_top
+        do k=1,nk
+          CS%hbd_grd_u(I,j,k) = dz_top(k)
+        enddo
+        deallocate(dz_top)
+      endif
+    enddo
+  enddo
+
+  do J=G%jsc-1,G%jec
+    do i=G%isc,G%iec
+      if (G%mask2dCv(i,J)>0.) then
+        call merge_interfaces(GV%ke, h(i,J,:), h(i,J+1,:), hbl(i,J), hbl(i,J+1), &
+                              CS%H_subroundoff, dz_top)
+
+        nk = SIZE(dz_top)
+        if (nk > CS%hbd_nk) then
+          write(*,*)'nk, CS%hbd_nk', nk, CS%hbd_nk
+          call MOM_error(FATAL,"Houston, we've had a problem in hbd_grid, v-points (nk cannot be > CS%hbd_nk)")
+        endif
+
+        CS%hbd_v_kmax(i,J) = nk
+
+        ! set the HBD grid to dz_top
+        do k=1,nk
+          CS%hbd_grd_v(i,J,k) = dz_top(k)
+        enddo
+        deallocate(dz_top)
+      endif
+    enddo
+  enddo
+
+end subroutine hbd_grid
 
 !> Calculate the harmonic mean of two quantities
 !! See \ref section_harmonic_mean.
@@ -511,6 +602,7 @@ subroutine boundary_k_range(boundary, nk, h, hbl, k_top, zeta_top, k_bot, zeta_b
   ! Local variables
   real :: htot ! Summed thickness [H ~> m or kg m-2]
   integer :: k
+
   ! Surface boundary layer
   if ( boundary == SURFACE ) then
     k_top = 1
@@ -532,6 +624,7 @@ subroutine boundary_k_range(boundary, nk, h, hbl, k_top, zeta_top, k_bot, zeta_b
         return
       endif
     enddo
+
   ! Bottom boundary layer
   elseif ( boundary == BOTTOM ) then
     k_top = nk
@@ -559,10 +652,10 @@ subroutine boundary_k_range(boundary, nk, h, hbl, k_top, zeta_top, k_bot, zeta_b
 
 end subroutine boundary_k_range
 
-!> Calculate the lateral boundary diffusive fluxes using the layer by layer method.
+!> Calculate the horizontal boundary diffusive fluxes using the layer by layer method.
 !! See \ref section_method
 subroutine fluxes_layer_method(boundary, ke, hbl_L, hbl_R, h_L, h_R, phi_L, phi_R, &
-                               khtr_u, F_layer, area_L, area_R, CS)
+                               khtr_u, F_layer, area_L, area_R, nk, dz_top, CS)
 
   integer,              intent(in   ) :: boundary !< Which boundary layer SURFACE or BOTTOM           [nondim]
   integer,              intent(in   ) :: ke       !< Number of layers in the native grid              [nondim]
@@ -580,10 +673,11 @@ subroutine fluxes_layer_method(boundary, ke, hbl_L, hbl_R, h_L, h_R, phi_L, phi_
                                                   !! in the native grid                 [H L2 conc ~> m3 conc]
   real,                 intent(in   ) :: area_L   !< Area of the horizontal grid (left)             [L2 ~> m2]
   real,                 intent(in   ) :: area_R   !< Area of the horizontal grid (right)            [L2 ~> m2]
-  type(lbd_CS),         pointer       :: CS       !< Lateral diffusion control structure
+  integer,              intent(in   ) :: nk       !< Number of layers in the HBD grid                 [nondim]
+  real, dimension(nk),  intent(in   ) :: dz_top   !< The HBD z grid                         [H ~> m or kg m-2]
+  type(hbd_CS),         pointer       :: CS       !< Horizontal diffusion control structure
 
   ! Local variables
-  real, allocatable :: dz_top(:)     !< The LBD z grid to be created                        [H ~> m or kg m-2]
   real, allocatable :: phi_L_z(:)    !< Tracer values in the ztop grid (left)                           [conc]
   real, allocatable :: phi_R_z(:)    !< Tracer values in the ztop grid (right)                          [conc]
   real, allocatable :: F_layer_z(:)  !< Diffusive flux at U/V-point in the ztop grid    [H L2 conc ~> m3 conc]
@@ -594,9 +688,6 @@ subroutine fluxes_layer_method(boundary, ke, hbl_L, hbl_R, h_L, h_R, phi_L, phi_
   integer :: k_bot_min               !< Minimum k-index for the bottom
   integer :: k_bot_max               !< Maximum k-index for the bottom
   integer :: k_bot_diff              !< Difference between bottom left and right k-indices
-  !integer :: k_top_max              !< Minimum k-index for the top
-  !integer :: k_top_min              !< Maximum k-index for the top
-  !integer :: k_top_diff             !< Difference between top left and right k-indices
   integer :: k_top_L, k_bot_L        !< k-indices left native grid
   integer :: k_top_R, k_bot_R        !< k-indices right native grid
   real    :: zeta_top_L, zeta_top_R  !< distance from the top of a layer to the boundary
@@ -607,16 +698,11 @@ subroutine fluxes_layer_method(boundary, ke, hbl_L, hbl_R, h_L, h_R, phi_L, phi_
   real    :: a                       !< coefficient to be used in the linear transition to the interior [nondim]
   real    :: tmp1, tmp2              !< dummy variables                                     [H ~> m or kg m-2]
   real    :: htot_max                !< depth below which no fluxes should be applied       [H ~> m or kg m-2]
-  integer :: nk                      !< number of layers in the LBD grid
 
   F_layer(:) = 0.0
   if (hbl_L == 0. .or. hbl_R == 0.) then
     return
   endif
-
-  ! Define vertical grid, dz_top
-  call merge_interfaces(ke, h_L(:), h_R(:), hbl_L, hbl_R, CS%H_subroundoff, dz_top)
-  nk = SIZE(dz_top)
 
   ! allocate arrays
   allocate(phi_L_z(nk), source=0.0)
@@ -669,27 +755,7 @@ subroutine fluxes_layer_method(boundary, ke, hbl_L, hbl_R, h_L, h_R, phi_L, phi_
     endif
   endif
 
-! TODO, boundary == BOTTOM
-!  if (boundary == BOTTOM) then
-!    ! TODO: GMM add option to apply linear decay
-!    k_top_max = MAX(k_top_L, k_top_R)
-!    ! make sure left and right k indices span same range
-!    if (k_top_max /= k_top_L) then
-!      k_top_L = k_top_max
-!      zeta_top_L = 1.0
-!    endif
-!    if (k_top_max /= k_top_R) then
-!      k_top_R= k_top_max
-!      zeta_top_R = 1.0
-!    endif
-!
-!    ! tracer flux where the minimum BLD intersets layer
-!    F_layer(k_top_max) = (-heff * khtr_u) * (phi_R_avg - phi_L_avg)
-!
-!    do k = k_top_max+1,nk
-!      F_layer_z(k) = -(heff * khtr_u) * (phi_R_z(k) - phi_L_z(k))
-!    enddo
-!  endif
+  !GMM, TODO: boundary == BOTTOM
 
   ! thicknesses at velocity points
   do k = 1,ke
@@ -723,7 +789,6 @@ subroutine fluxes_layer_method(boundary, ke, hbl_L, hbl_R, h_L, h_R, phi_L, phi_
   enddo
 
   ! deallocated arrays
-  deallocate(dz_top)
   deallocate(phi_L_z)
   deallocate(phi_R_z)
   deallocate(F_layer_z)
@@ -748,7 +813,7 @@ logical function near_boundary_unit_tests( verbose )
   real                  :: zeta_top             ! Nondimension position                             [nondim]
   integer               :: k_bot                ! Index of cell containing bottom of boundary
   real                  :: zeta_bot             ! Nondimension position                             [nondim]
-  type(lbd_CS), pointer :: CS
+  type(hbd_CS), pointer :: CS
 
   allocate(CS)
   ! fill required fields in CS
@@ -760,9 +825,11 @@ logical function near_boundary_unit_tests( verbose )
   CS%debug=.false.
   CS%limiter=.false.
   CS%limiter_remap=.false.
-
+  CS%hbd_nk = 2 + (2*2)
+  allocate(CS%hbd_grd_u(1,1,CS%hbd_nk), source=0.0)
+  allocate(CS%hbd_u_kmax(1,1), source=0)
   near_boundary_unit_tests = .false.
-  write(stdout,*) '==== MOM_lateral_boundary_diffusion ======================='
+  write(stdout,*) '==== MOM_hor_bnd_diffusion ======================='
 
   ! Unit tests for boundary_k_range
   test_name = 'Surface boundary spans the entire top cell'
@@ -917,8 +984,9 @@ logical function near_boundary_unit_tests( verbose )
   h_L = (/2.,2./) ; h_R = (/2.,2./)
   phi_L = (/0.,0./) ; phi_R = (/1.,1./)
   khtr_u = 1.
+  call hbd_grid_test(SURFACE, hbl_L, hbl_R, h_L, h_R, CS)
   call fluxes_layer_method(SURFACE, nk, hbl_L, hbl_R, h_L, h_R, phi_L, phi_R, &
-                             khtr_u, F_layer, 1., 1., CS)
+                           khtr_u, F_layer, 1., 1., CS%hbd_u_kmax(1,1), CS%hbd_grd_u(1,1,:), CS)
   near_boundary_unit_tests = near_boundary_unit_tests .or. &
                              test_layer_fluxes( verbose, nk, test_name, F_layer, (/-2.0,0.0/) )
 
@@ -927,8 +995,9 @@ logical function near_boundary_unit_tests( verbose )
   h_L = (/2.,2./) ; h_R = (/2.,2./)
   phi_L = (/2.,1./) ; phi_R = (/1.,1./)
   khtr_u = 0.5
+  call hbd_grid_test(SURFACE, hbl_L, hbl_R, h_L, h_R, CS)
   call fluxes_layer_method(SURFACE, nk, hbl_L, hbl_R, h_L, h_R, phi_L, phi_R, &
-                             khtr_u, F_layer, 1., 1., CS)
+                           khtr_u, F_layer, 1., 1., CS%hbd_u_kmax(1,1), CS%hbd_grd_u(1,1,:), CS)
   near_boundary_unit_tests = near_boundary_unit_tests .or. &
                              test_layer_fluxes( verbose, nk, test_name, F_layer, (/1.0,0.0/) )
 
@@ -937,8 +1006,9 @@ logical function near_boundary_unit_tests( verbose )
   h_L = (/1.,2./) ; h_R = (/1.,2./)
   phi_L = (/0.,0./) ; phi_R = (/0.5,2./)
   khtr_u = 2.
+  call hbd_grid_test(SURFACE, hbl_L, hbl_R, h_L, h_R, CS)
   call fluxes_layer_method(SURFACE, nk, hbl_L, hbl_R, h_L, h_R, phi_L, phi_R, &
-                             khtr_u, F_layer, 1., 1., CS)
+                           khtr_u, F_layer, 1., 1., CS%hbd_u_kmax(1,1), CS%hbd_grd_u(1,1,:), CS)
   near_boundary_unit_tests = near_boundary_unit_tests .or. &
                              test_layer_fluxes( verbose, nk, test_name, F_layer, (/-1.0,-4.0/) )
 
@@ -947,8 +1017,9 @@ logical function near_boundary_unit_tests( verbose )
   h_L = (/6.,6./) ; h_R = (/10.,10./)
   phi_L = (/1.,1./) ; phi_R = (/1.,1./)
   khtr_u = 1.
+  call hbd_grid_test(SURFACE, hbl_L, hbl_R, h_L, h_R, CS)
   call fluxes_layer_method(SURFACE, nk, hbl_L, hbl_R, h_L, h_R, phi_L, phi_R, &
-                             khtr_u, F_layer, 1., 1., CS)
+                           khtr_u, F_layer, 1., 1., CS%hbd_u_kmax(1,1), CS%hbd_grd_u(1,1,:), CS)
   near_boundary_unit_tests = near_boundary_unit_tests .or. &
                              test_layer_fluxes( verbose, nk, test_name, F_layer, (/0.,0./) )
 
@@ -958,9 +1029,9 @@ logical function near_boundary_unit_tests( verbose )
   h_L = (/10.,5./) ; h_R = (/10.,0./)
   phi_L = (/1.,1./) ; phi_R = (/0.,0./)
   khtr_u = 1.
+  call hbd_grid_test(SURFACE, hbl_L, hbl_R, h_L, h_R, CS)
   call fluxes_layer_method(SURFACE, nk, hbl_L, hbl_R, h_L, h_R, phi_L, phi_R, &
-                             khtr_u, F_layer, 1., 1., CS)
-
+                           khtr_u, F_layer, 1., 1., CS%hbd_u_kmax(1,1), CS%hbd_grd_u(1,1,:), CS)
   near_boundary_unit_tests = near_boundary_unit_tests .or. &
                              test_layer_fluxes( verbose, nk, test_name, F_layer, (/10.,0.0/) )
 
@@ -983,7 +1054,7 @@ logical function test_layer_fluxes(verbose, nk, test_name, F_calc, F_ans)
   do k=1,nk
     if ( F_calc(k) /= F_ans(k) ) then
       test_layer_fluxes = .true.
-      write(stdout,*) "MOM_lateral_boundary_diffusion, UNIT TEST FAILED: ", test_name
+      write(stdout,*) "MOM_hor_bnd_diffusion, UNIT TEST FAILED: ", test_name
       write(stdout,10) k, F_calc(k), F_ans(k)
     elseif (verbose) then
       write(stdout,10) k, F_calc(k), F_ans(k)
@@ -1026,13 +1097,55 @@ logical function test_boundary_k_range(k_top, zeta_top, k_bot, zeta_bot, k_top_a
 
 end function test_boundary_k_range
 
-!> \namespace mom_lateral_boundary_diffusion
+!> Same as hbd_grid, but only used in the unit tests.
+subroutine hbd_grid_test(boundary, hbl_L, hbl_R, h_L, h_R, CS)
+  integer,                 intent(in) :: boundary !< Which boundary layer SURFACE or BOTTOM    [nondim]
+  real,                    intent(in) :: hbl_L    !< Boundary layer depth, left                [H ~> m or kg m-2]
+  real,                    intent(in) :: hbl_R    !< Boundary layer depth, right               [H ~> m or kg m-2]
+  real, dimension(2),      intent(in) :: h_L      !< Layer thickness in the native grid, left  [H ~> m or kg m-2]
+  real, dimension(2),      intent(in) :: h_R      !< Layer thickness in the native grid, right [H ~> m or kg m-2]
+  type(hbd_CS),            pointer    :: CS       !< Horizontal diffusion control structure
+
+  ! Local variables
+  real, allocatable :: dz_top(:)     !< temporary HBD grid given by merge_interfaces       [H ~> m or kg m-2]
+  integer           :: nk, k         !< number of layers in the HBD grid, and integers used in do-loops
+
+  ! reset arrays
+  CS%hbd_grd_u(1,1,:) = 0.0
+  CS%hbd_u_kmax(1,1)  = 0
+
+  call merge_interfaces(2, h_L, h_R, hbl_L, hbl_R, CS%H_subroundoff, dz_top)
+  nk = SIZE(dz_top)
+  if (nk > CS%hbd_nk) then
+    write(*,*)'nk, CS%hbd_nk', nk, CS%hbd_nk
+    call MOM_error(FATAL,"Houston, we've had a problem in hbd_grid_test, (nk cannot be > CS%hbd_nk)")
+  endif
+
+  CS%hbd_u_kmax(1,1) = nk
+
+  ! set the HBD grid to dz_top
+  do k=1,nk
+    CS%hbd_grd_u(1,1,k) = dz_top(k)
+  enddo
+  deallocate(dz_top)
+
+end subroutine hbd_grid_test
+
+!> Deallocates hor_bnd_diffusion control structure
+subroutine hor_bnd_diffusion_end(CS)
+  type(hbd_CS), pointer :: CS  !< Horizontal boundary diffusion control structure
+
+  if (associated(CS)) deallocate(CS)
+
+end subroutine hor_bnd_diffusion_end
+
+!> \namespace mom_hor_bnd_diffusion
 !!
-!! \section section_LBD The Lateral Boundary Diffusion (LBD) framework
+!! \section section_HBD The Horizontal Boundary Diffusion (HBD) framework
 !!
-!! The LBD framework accounts for the effects of diabatic mesoscale fluxes
+!! The HBD framework accounts for the effects of diabatic mesoscale fluxes
 !! within surface and bottom boundary layers. Unlike the equivalent adiabatic
-!! fluxes, which is applied along neutral density surfaces, LBD is purely
+!! fluxes, which is applied along neutral density surfaces, HBD is purely
 !! horizontal. To assure that diffusive fluxes are strictly horizontal
 !! regardless of the vertical coordinate system, this method relies on
 !! regridding/remapping techniques.
@@ -1040,10 +1153,10 @@ end function test_boundary_k_range
 !! The bottom boundary layer fluxes remain to be implemented, although some
 !! of the steps needed to do so have already been added and tested.
 !!
-!! Boundary lateral diffusion is applied as follows:
+!! Horizontal boundary diffusion is applied as follows:
 !!
-!! 1) remap tracer to a z* grid (LBD grid)
-!! 2) calculate diffusive tracer fluxes (F) in the LBD grid using a layer by layer approach (@ref section_method)
+!! 1) remap tracer to a z* grid (HBD grid)
+!! 2) calculate diffusive tracer fluxes (F) in the HBD grid using a layer by layer approach (@ref section_method)
 !! 3) remap fluxes to the native grid
 !! 4) update tracer by adding the divergence of F
 !!
@@ -1067,7 +1180,7 @@ end function test_boundary_k_range
 !!
 !! Step #3: option to linearly decay the flux from k_bot_min to k_bot_max:
 !!
-!! If LBD_LINEAR_TRANSITION = True and k_bot_diff > 1, the diffusive flux will decay
+!! If HBD_LINEAR_TRANSITION = True and k_bot_diff > 1, the diffusive flux will decay
 !! linearly between the top interface of the layer containing the minimum boundary
 !! layer depth (k_bot_min) and the lower interface of the layer containing the
 !! maximum layer depth (k_bot_max).
@@ -1091,4 +1204,4 @@ end function test_boundary_k_range
 !!
 !! \f[ HM = \frac{2 \times h1 \times h2}{h1 + h2} \f]
 !!
-end module MOM_lateral_boundary_diffusion
+end module MOM_hor_bnd_diffusion

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -27,8 +27,8 @@ use regrid_edge_values,        only : edge_values_implicit_h4
 use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
 use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
 use MOM_diabatic_driver,       only : diabatic_CS, extract_diabatic_member
-use MOM_lateral_boundary_diffusion, only : boundary_k_range, SURFACE, BOTTOM
 use MOM_io,                    only : stdout, stderr
+use MOM_hor_bnd_diffusion,     only : boundary_k_range, SURFACE, BOTTOM
 
 implicit none ; private
 

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -45,7 +45,7 @@ use MOM_OCMIP2_CFC, only : register_OCMIP2_CFC, initialize_OCMIP2_CFC, flux_init
 use MOM_OCMIP2_CFC, only : OCMIP2_CFC_column_physics, OCMIP2_CFC_surface_state
 use MOM_OCMIP2_CFC, only : OCMIP2_CFC_stock, OCMIP2_CFC_end, OCMIP2_CFC_CS
 use MOM_CFC_cap, only : register_CFC_cap, initialize_CFC_cap
-use MOM_CFC_cap, only : CFC_cap_column_physics, CFC_cap_surface_state
+use MOM_CFC_cap, only : CFC_cap_column_physics, CFC_cap_set_forcing
 use MOM_CFC_cap, only : CFC_cap_stock, CFC_cap_end, CFC_cap_CS
 use oil_tracer, only : register_oil_tracer, initialize_oil_tracer
 use oil_tracer, only : oil_tracer_column_physics, oil_tracer_surface_state
@@ -401,7 +401,7 @@ end subroutine get_chl_from_model
 
 !> This subroutine calls the individual tracer modules' subroutines to
 !! specify or read quantities related to their surface forcing.
-subroutine call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G, CS)
+subroutine call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G, US, Rho0, CS)
 
   type(surface),                intent(inout) :: sfc_state !< A structure containing fields that
                                                            !! describe the surface state of the
@@ -413,6 +413,8 @@ subroutine call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G
   type(time_type),              intent(in)    :: day_interval !< Length of time over which these
                                                            !! fluxes will be applied.
   type(ocean_grid_type),        intent(in)    :: G         !< The ocean's grid structure.
+  type(unit_scale_type),        intent(in)    :: US        !< A dimensional unit scaling type
+  real,                         intent(in)    :: Rho0      !< The mean ocean density [R ~> kg m-3]
   type(tracer_flow_control_CS), pointer       :: CS        !< The control structure returned by a
                                                            !! previous call to call_tracer_register.
 
@@ -421,6 +423,9 @@ subroutine call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G
 !  if (CS%use_ideal_age) &
 !    call ideal_age_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, &
 !                                      G, CS%ideal_age_tracer_CSp)
+  if (CS%use_CFC_cap) &
+    call CFC_cap_set_forcing(sfc_state, fluxes, day_start, day_interval, G, US, Rho0, &
+                             CS%CFC_cap_CSp)
 
 end subroutine call_tracer_set_forcing
 
@@ -850,8 +855,6 @@ subroutine call_tracer_surface_state(sfc_state, h, G, GV, US, CS)
     call advection_test_tracer_surface_state(sfc_state, h, G, GV, CS%advection_test_tracer_CSp)
   if (CS%use_OCMIP2_CFC) &
     call OCMIP2_CFC_surface_state(sfc_state, h, G, GV, US, CS%OCMIP2_CFC_CSp)
-  if (CS%use_CFC_cap) &
-    call CFC_cap_surface_state(sfc_state, G, CS%CFC_cap_CSp)
   if (CS%use_MOM_generic_tracer) &
     call MOM_generic_tracer_surface_state(sfc_state, h, G, GV, CS%MOM_generic_tracer_CSp)
 

--- a/src/tracer/MOM_tracer_registry.F90
+++ b/src/tracer/MOM_tracer_registry.F90
@@ -358,14 +358,14 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
           diag%axesCvL, Time, trim(flux_longname)//" diffusive meridional flux" , &
           trim(flux_units), v_extensive=.true., x_cell_method='sum', &
           conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T)
-      Tr%id_lbd_dfx = register_diag_field("ocean_model", trim(shortnm)//"_lbd_diffx", &
-          diag%axesCuL, Time, trim(flux_longname)//" diffusive zonal flux from the lateral boundary diffusion "//&
-          "scheme", trim(flux_units), v_extensive=.true., y_cell_method='sum', &
-          conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T)
-      Tr%id_lbd_dfy = register_diag_field("ocean_model", trim(shortnm)//"_lbd_diffy", &
-          diag%axesCvL, Time, trim(flux_longname)//" diffusive meridional flux from the lateral boundary diffusion "//&
-          "scheme", trim(flux_units), v_extensive=.true., x_cell_method='sum', &
-          conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T)
+      Tr%id_hbd_dfx = register_diag_field("ocean_model", trim(shortnm)//"_hbd_diffx", &
+          diag%axesCuL, Time, trim(flux_longname)//" diffusive zonal flux " //&
+          "from the horizontal boundary diffusion scheme", trim(flux_units), v_extensive=.true., &
+          y_cell_method='sum', conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T)
+      Tr%id_hbd_dfy = register_diag_field("ocean_model", trim(shortnm)//"_hbd_diffy", &
+          diag%axesCvL, Time, trim(flux_longname)//" diffusive meridional " //&
+          "flux from the horizontal boundary diffusion scheme", trim(flux_units), v_extensive=.true., &
+          x_cell_method='sum', conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T)
     else
       Tr%id_adx = register_diag_field("ocean_model", trim(shortnm)//"_adx", &
           diag%axesCuL, Time, "Advective (by residual mean) Zonal Flux of "//trim(flux_longname), &
@@ -381,12 +381,12 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
           diag%axesCvL, Time, "Diffusive Meridional Flux of "//trim(flux_longname), &
           flux_units, v_extensive=.true., conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T, &
           x_cell_method='sum')
-      Tr%id_lbd_dfx = register_diag_field("ocean_model", trim(shortnm)//"_lbd_diffx", &
-          diag%axesCuL, Time, "Lateral Boundary Diffusive Zonal Flux of "//trim(flux_longname), &
+      Tr%id_hbd_dfx = register_diag_field("ocean_model", trim(shortnm)//"_hbd_diffx", &
+          diag%axesCuL, Time, "Horizontal Boundary Diffusive Zonal Flux of "//trim(flux_longname), &
           flux_units, v_extensive=.true., conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T, &
           y_cell_method='sum')
-      Tr%id_lbd_dfy = register_diag_field("ocean_model", trim(shortnm)//"_lbd_diffy", &
-          diag%axesCvL, Time, "Lateral Boundary Diffusive Meridional Flux of "//trim(flux_longname), &
+      Tr%id_hbd_dfy = register_diag_field("ocean_model", trim(shortnm)//"_hbd_diffy", &
+          diag%axesCvL, Time, "Horizontal Boundary Diffusive Meridional Flux of "//trim(flux_longname), &
           flux_units, v_extensive=.true., conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T, &
           x_cell_method='sum')
     endif
@@ -394,8 +394,8 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
     if (Tr%id_ady > 0) call safe_alloc_ptr(Tr%ad_y,isd,ied,JsdB,JedB,nz)
     if (Tr%id_dfx > 0) call safe_alloc_ptr(Tr%df_x,IsdB,IedB,jsd,jed,nz)
     if (Tr%id_dfy > 0) call safe_alloc_ptr(Tr%df_y,isd,ied,JsdB,JedB,nz)
-    if (Tr%id_lbd_dfx > 0) call safe_alloc_ptr(Tr%lbd_dfx,IsdB,IedB,jsd,jed,nz)
-    if (Tr%id_lbd_dfy > 0) call safe_alloc_ptr(Tr%lbd_dfy,isd,ied,JsdB,JedB,nz)
+    if (Tr%id_hbd_dfx > 0) call safe_alloc_ptr(Tr%hbd_dfx,IsdB,IedB,jsd,jed,nz)
+    if (Tr%id_hbd_dfy > 0) call safe_alloc_ptr(Tr%hbd_dfy,isd,ied,JsdB,JedB,nz)
 
     Tr%id_adx_2d = register_diag_field("ocean_model", trim(shortnm)//"_adx_2d", &
         diag%axesCu1, Time, &
@@ -415,22 +415,12 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
         "Vertically Integrated Diffusive Meridional Flux of "//trim(flux_longname), &
         flux_units, conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T, &
         x_cell_method='sum')
-    Tr%id_lbd_bulk_dfx = register_diag_field("ocean_model", trim(shortnm)//"_lbd_bulk_diffx", &
-        diag%axesCu1, Time, &
-        "Total Bulk Diffusive Zonal Flux of "//trim(flux_longname), &
-        flux_units, conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T, &
-        y_cell_method='sum')
-    Tr%id_lbd_bulk_dfy = register_diag_field("ocean_model", trim(shortnm)//"_lbd_bulk_diffy", &
-        diag%axesCv1, Time, &
-        "Total Bulk Diffusive Meridional Flux of "//trim(flux_longname), &
-        flux_units, conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T, &
-        x_cell_method='sum')
-    Tr%id_lbd_dfx_2d = register_diag_field("ocean_model", trim(shortnm)//"_lbd_diffx_2d", &
-        diag%axesCu1, Time, "Vertically-integrated zonal diffusive flux from the lateral boundary diffusion "//&
+    Tr%id_hbd_dfx_2d = register_diag_field("ocean_model", trim(shortnm)//"_hbd_diffx_2d", &
+        diag%axesCu1, Time, "Vertically-integrated zonal diffusive flux from the horizontal boundary diffusion "//&
         "scheme for "//trim(flux_longname), flux_units, conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T, &
         y_cell_method='sum')
-    Tr%id_lbd_dfy_2d = register_diag_field("ocean_model", trim(shortnm)//"_lbd_diffy_2d", &
-        diag%axesCv1, Time, "Vertically-integrated meridional diffusive flux from the lateral boundary diffusion "//&
+    Tr%id_hbd_dfy_2d = register_diag_field("ocean_model", trim(shortnm)//"_hbd_diffy_2d", &
+        diag%axesCv1, Time, "Vertically-integrated meridional diffusive flux from the horizontal boundary diffusion "//&
         "scheme for "//trim(flux_longname), flux_units, conversion=(US%L_to_m**2)*Tr%flux_scale*US%s_to_T, &
          x_cell_method='sum')
 
@@ -438,10 +428,8 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
     if (Tr%id_ady_2d > 0) call safe_alloc_ptr(Tr%ad2d_y,isd,ied,JsdB,JedB)
     if (Tr%id_dfx_2d > 0) call safe_alloc_ptr(Tr%df2d_x,IsdB,IedB,jsd,jed)
     if (Tr%id_dfy_2d > 0) call safe_alloc_ptr(Tr%df2d_y,isd,ied,JsdB,JedB)
-    if (Tr%id_lbd_bulk_dfx > 0) call safe_alloc_ptr(Tr%lbd_bulk_df_x,IsdB,IedB,jsd,jed)
-    if (Tr%id_lbd_bulk_dfy > 0) call safe_alloc_ptr(Tr%lbd_bulk_df_y,isd,ied,JsdB,JedB)
-    if (Tr%id_lbd_dfx_2d > 0) call safe_alloc_ptr(Tr%lbd_dfx_2d,IsdB,IedB,jsd,jed)
-    if (Tr%id_lbd_dfy_2d > 0) call safe_alloc_ptr(Tr%lbd_dfy_2d,isd,ied,JsdB,JedB)
+    if (Tr%id_hbd_dfx_2d > 0) call safe_alloc_ptr(Tr%hbd_dfx_2d,IsdB,IedB,jsd,jed)
+    if (Tr%id_hbd_dfy_2d > 0) call safe_alloc_ptr(Tr%hbd_dfy_2d,isd,ied,JsdB,JedB)
 
     Tr%id_adv_xy = register_diag_field('ocean_model', trim(shortnm)//"_advection_xy", &
         diag%axesTL, Time, &
@@ -466,7 +454,7 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
       enddo ; enddo ; enddo
     endif
 
-    ! Neutral/Lateral diffusion convergence tendencies
+    ! Neutral/Horizontal diffusion convergence tendencies
     if (Tr%diag_form == 1) then
       Tr%id_dfxy_cont = register_diag_field("ocean_model", trim(shortnm)//'_dfxy_cont_tendency', &
           diag%axesTL, Time, "Neutral diffusion tracer content tendency for "//trim(shortnm), &
@@ -477,12 +465,12 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
           "tendency for "//trim(shortnm), conv_units, conversion=Tr%conv_scale*US%s_to_T, &
           x_cell_method='sum', y_cell_method='sum')
 
-      Tr%id_lbdxy_cont = register_diag_field("ocean_model", trim(shortnm)//'_lbdxy_cont_tendency', &
-          diag%axesTL, Time, "Lateral diffusion tracer content tendency for "//trim(shortnm), &
+      Tr%id_hbdxy_cont = register_diag_field("ocean_model", trim(shortnm)//'_hbdxy_cont_tendency', &
+          diag%axesTL, Time, "Horizontal boundary diffusion tracer content tendency for "//trim(shortnm), &
           conv_units, conversion=Tr%conv_scale*US%s_to_T, x_cell_method='sum', y_cell_method='sum', v_extensive=.true.)
 
-      Tr%id_lbdxy_cont_2d = register_diag_field("ocean_model", trim(shortnm)//'_lbdxy_cont_tendency_2d', &
-          diag%axesT1, Time, "Depth integrated lateral diffusion tracer content "//&
+      Tr%id_hbdxy_cont_2d = register_diag_field("ocean_model", trim(shortnm)//'_hbdxy_cont_tendency_2d', &
+          diag%axesT1, Time, "Depth integrated horizontal boundary diffusion tracer content "//&
           "tendency for "//trim(shortnm), conv_units, conversion=Tr%conv_scale*US%s_to_T, &
           x_cell_method='sum', y_cell_method='sum')
     else
@@ -503,13 +491,13 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
           cmor_long_name=trim(cmor_var_lname), cmor_standard_name=trim(cmor_long_std(cmor_var_lname)), &
           x_cell_method='sum', y_cell_method='sum')
 
-      Tr%id_lbdxy_cont = register_diag_field("ocean_model", trim(shortnm)//'_lbdxy_cont_tendency', &
-          diag%axesTL, Time, "Lateral diffusion tracer content tendency for "//trim(shortnm), &
+      Tr%id_hbdxy_cont = register_diag_field("ocean_model", trim(shortnm)//'_hbdxy_cont_tendency', &
+          diag%axesTL, Time, "Horizontal boundary diffusion tracer content tendency for "//trim(shortnm), &
           conv_units, conversion=Tr%conv_scale*US%s_to_T, &
           x_cell_method='sum', y_cell_method='sum', v_extensive=.true.)
 
-      Tr%id_lbdxy_cont_2d = register_diag_field("ocean_model", trim(shortnm)//'_lbdxy_cont_tendency_2d', &
-          diag%axesT1, Time, "Depth integrated lateral diffusion tracer "//&
+      Tr%id_hbdxy_cont_2d = register_diag_field("ocean_model", trim(shortnm)//'_hbdxy_cont_tendency_2d', &
+          diag%axesT1, Time, "Depth integrated horizontal boundary diffusion of tracer "//&
           "content tendency for "//trim(shortnm), conv_units, conversion=Tr%conv_scale*US%s_to_T, &
           x_cell_method='sum', y_cell_method='sum')
     endif
@@ -517,8 +505,8 @@ subroutine register_tracer_diagnostics(Reg, h, Time, diag, G, GV, US, use_ALE, u
         diag%axesTL, Time, "Neutral diffusion tracer concentration tendency for "//trim(shortnm), &
         trim(units)//' s-1', conversion=Tr%conc_scale*US%s_to_T)
 
-    Tr%id_lbdxy_conc = register_diag_field("ocean_model", trim(shortnm)//'_lbdxy_conc_tendency', &
-        diag%axesTL, Time, "Lateral diffusion tracer concentration tendency for "//trim(shortnm), &
+    Tr%id_hbdxy_conc = register_diag_field("ocean_model", trim(shortnm)//'_hbdxy_conc_tendency', &
+        diag%axesTL, Time, "Horizontal diffusion tracer concentration tendency for "//trim(shortnm), &
         trim(units)//' s-1', conversion=Tr%conc_scale*US%s_to_T)
 
     var_lname = "Net time tendency for "//lowercase(flux_longname)

--- a/src/tracer/MOM_tracer_types.F90
+++ b/src/tracer/MOM_tracer_types.F90
@@ -27,20 +27,16 @@ type, public :: tracer_type
   real, dimension(:,:,:), pointer :: df_x           => NULL() !< diagnostic array for x-diffusive tracer flux
                                                               !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
   real, dimension(:,:,:), pointer :: df_y           => NULL() !< diagnostic array for y-diffusive tracer flux
-                                                              !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
-  real, dimension(:,:,:), pointer :: lbd_dfx       => NULL()  !< diagnostic array for x-diffusive tracer flux
-                                                              !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
-  real, dimension(:,:,:), pointer :: lbd_dfy       => NULL()  !< diagnostic array for y-diffusive tracer flux
-                                                              !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
-  real, dimension(:,:), pointer :: lbd_dfx_2d       => NULL() !< diagnostic array for x-diffusive tracer flux
-                                                              !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
-  real, dimension(:,:), pointer :: lbd_dfy_2d       => NULL() !< diagnostic array for y-diffusive tracer flux
-                                                              !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
-  !### These two arrays may be allocated but are never used.
-  real, dimension(:,:), pointer :: lbd_bulk_df_x       => NULL() !< diagnostic array for x-diffusive tracer flux
-                                                              !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
-  real, dimension(:,:), pointer :: lbd_bulk_df_y       => NULL() !< diagnostic array for y-diffusive tracer flux
-                                                              !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
+                                                              !! [conc H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
+  real, dimension(:,:,:), pointer :: hbd_dfx       => NULL()  !< diagnostic array for x-diffusive tracer flux
+                                                              !! [conc H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
+  real, dimension(:,:,:), pointer :: hbd_dfy       => NULL()  !< diagnostic array for y-diffusive tracer flux
+                                                              !! [conc H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
+  real, dimension(:,:),   pointer :: hbd_dfx_2d    => NULL()  !< diagnostic array for x-diffusive tracer flux
+                                                              !! [conc H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
+  real, dimension(:,:),   pointer :: hbd_dfy_2d    => NULL()  !< diagnostic array for y-diffusive tracer flux
+                                                              !! [conc H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
+                                                              !! [conc H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
   real, dimension(:,:),   pointer :: df2d_x         => NULL() !< diagnostic vertical sum x-diffusive flux
                                                               !! [CU H L2 T-1 ~> conc m3 s-1 or conc kg s-1]
   real, dimension(:,:),   pointer :: df2d_y         => NULL() !< diagnostic vertical sum y-diffusive flux
@@ -106,12 +102,12 @@ type, public :: tracer_type
   !>@{ Diagnostic IDs
   integer :: id_tr = -1, id_tr_post_horzn = -1
   integer :: id_adx = -1, id_ady = -1, id_dfx = -1, id_dfy = -1
-  integer :: id_lbd_bulk_dfx = -1, id_lbd_bulk_dfy = -1, id_lbd_dfx = -1, id_lbd_dfy = -1
-  integer :: id_lbd_dfx_2d = -1  , id_lbd_dfy_2d = -1
+  integer :: id_hbd_dfx = -1, id_hbd_dfy = -1
+  integer :: id_hbd_dfx_2d = -1, id_hbd_dfy_2d = -1
   integer :: id_adx_2d = -1, id_ady_2d = -1, id_dfx_2d = -1, id_dfy_2d = -1
   integer :: id_adv_xy = -1, id_adv_xy_2d = -1
   integer :: id_dfxy_cont = -1, id_dfxy_cont_2d = -1, id_dfxy_conc = -1
-  integer :: id_lbdxy_cont = -1, id_lbdxy_cont_2d = -1, id_lbdxy_conc = -1
+  integer :: id_hbdxy_cont = -1, id_hbdxy_cont_2d = -1, id_hbdxy_conc = -1
   integer :: id_remap_conc = -1, id_remap_cont = -1, id_remap_cont_2d = -1
   integer :: id_tendency = -1, id_trxh_tendency = -1, id_trxh_tendency_2d = -1
   integer :: id_tr_vardec = -1

--- a/src/tracer/oil_tracer.F90
+++ b/src/tracer/oil_tracer.F90
@@ -113,7 +113,7 @@ function register_oil_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
     ! Add the directory if CS%IC_file is not already a complete path.
     call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
     CS%IC_file = trim(slasher(inputdir))//trim(CS%IC_file)
-    call log_param(param_file, mdl, "INPUTDIR/CFC_IC_FILE", CS%IC_file)
+    call log_param(param_file, mdl, "INPUTDIR/OIL_IC_FILE", CS%IC_file)
   endif
   call get_param(param_file, mdl, "OIL_IC_FILE_IS_Z", CS%Z_IC_file, &
                  "If true, OIL_IC_FILE is in depth space, not layer space", &


### PR DESCRIPTION
This commit adds the 2D Leith+E closure, which uses a modified 2D Leith biharmonic viscosity paired with a harmonic backscatter. ('Modified' here is not used in the same sense as 'modified 2D Leith'; it just means that the biharmonic coefficient is modified to account for enstrophy backscatter.) Variables are often named 'leithy' to refer to Leith+E.

The parameterization is controlled by three main entries in user_nl_mom:
1. USE_LEITHY = True
2. LEITH_CK = 1.0
3. LEITH_BI_CONST = 8.0

To use Leith+E you should have LAPLACIAN=True and BIHARMONIC=True. (It doesn't hurt to be explicit and also set LEITH_AH=False, along with any other viscous closures, but this is not required. If USE_LEITHY=True it will not use any of the other schemes. It does use the background value of the biharmonic coefficient as a minimum, but ignores the
background harmonic value.) LEITH_CK is the fraction of energy dissipated by the biharmonic term that gets backscattered by the harmonic term (it's a target; the backscatter rate is not exact.) Recommended values between 0 and 1. LEITH_BI_CONST is Upsilon^6 where Upsilon is the ratio between the grid scale and the dissipation scale for enstrophy.
Values should be greater than or equal to 1; 8 is a good place to start.

The code is sensitive to the background value of Ah; specifically, if Ah is too large, the code is unstable. This is because the backscatter coefficient is proportional to Ah, and if Ah is large then you get large backscatter. If your code is unstable, consider reducing, e.g., `AH_VEL_SCALE`.