### PR TITLE
Fix label allocation in register_netcdf_ functions.

### DIFF
--- a/src/framework/MOM_netcdf.F90
+++ b/src/framework/MOM_netcdf.F90
@@ -217,6 +217,8 @@ function register_netcdf_field(handle, label, axes, longname, units) &
   allocate(dimids(size(axes)))
   dimids(:) = [(axes(i)%dimid, i = 1, size(axes))]
 
+  field%label = label
+
   ! Determine the corresponding netCDF data type
   ! TODO: Support a `pack`-like argument
   select case (kind(1.0))
@@ -225,7 +227,7 @@ function register_netcdf_field(handle, label, axes, longname, units) &
     case (real64)
       xtype = NF90_DOUBLE
     case default
-      call MOM_error(FATAL, "register_netcdf_axis: Unknown kind(real).")
+      call MOM_error(FATAL, "register_netcdf_field: Unknown kind(real).")
   end select
 
   ! Register the field variable
@@ -292,6 +294,8 @@ function register_netcdf_axis(handle, label, units, longname, points, &
     call MOM_error(FATAL, &
         "Axis must either have explicit points or be a time axis ('T').")
   endif
+
+  axis%label = label
 
   if (present(points)) then
     axis_size = size(points)


### PR DESCRIPTION
Set %label in `register_netcdf_axis` and `register_netcdf_field` functions. 

This PR solves the issue described in [#261](https://github.com/NCAR/MOM6/issues/261)

Testing: pr_mom.derecho_intel & ERS.TL319_t061.CMOM_JRA.derecho_intel