### PR TITLE
Fix intraday CESM restart file names

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -1779,7 +1779,7 @@ subroutine ModelAdvance(gcomp, rc)
         rpointer_filename = 'rpointer.ocn'//trim(inst_suffix)
 
         write(restartname,'(A,".mom6.r.",I4.4,"-",I2.2,"-",I2.2,"-",I5.5)') &
-             trim(casename), year, month, day, seconds
+             trim(casename), year, month, day, hour * 3600 + minute * 60 + seconds
         call ESMF_LogWrite("MOM_cap: Writing restart :  "//trim(restartname), ESMF_LOGMSG_INFO)
         ! write restart file(s)
         call ocean_model_restart(ocean_state, restartname=restartname, num_rest_files=num_rest_files)


### PR DESCRIPTION
This PR fixes intraday CESM restart file names.
Note that, to short-term archive interim restart fiesl, `DOUT_S_SAVE_INTERIM_RESTART_FILES` xml variable must be set to True. This PR should be evaulated in conjunction with https://github.com/ESCOMP/MOM_interface/pull/155

testing: aux_mom.derecho
no answer changes.