### PR TITLE
Enable relative path specification for IC files

### DIFF
--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -720,7 +720,10 @@ subroutine initialize_thickness_from_file(h, depth_tot, G, GV, US, param_file, f
                  "The name of the thickness file.", &
                  fail_if_missing=.not.just_read, do_not_log=just_read)
 
-  filename = trim(inputdir)//trim(thickness_file)
+  filename = trim(thickness_file)
+  if (scan(thickness_file, "/") == 0) then ! prepend inputdir if only a filename is given
+    filename = trim(inputdir)//trim(thickness_file)
+  endif
   if (.not.just_read) call log_param(param_file, mdl, "INPUTDIR/THICKNESS_FILE", filename)
 
   if ((.not.just_read) .and. (.not.file_exists(filename, G%Domain))) call MOM_error(FATAL, &
@@ -1446,7 +1449,10 @@ subroutine initialize_velocity_from_file(u, v, G, GV, US, param_file, just_read)
   call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
 
-  filename = trim(inputdir)//trim(velocity_file)
+  filename = trim(velocity_file)
+  if (scan(velocity_file, '/')== 0) then ! prepend inputdir if only a filename is given
+    filename = trim(inputdir)//trim(velocity_file)
+  endif
   if (.not.just_read) call log_param(param_file, mdl, "INPUTDIR/VELOCITY_FILE", filename)
 
   call get_param(param_file, mdl, "U_IC_VAR", u_IC_var, &
@@ -1627,7 +1633,10 @@ subroutine initialize_temp_salt_from_file(T, S, G, GV, US, param_file, just_read
   call get_param(param_file, mdl, "INPUTDIR", inputdir, default=".")
   inputdir = slasher(inputdir)
 
-  filename = trim(inputdir)//trim(ts_file)
+  filename = trim(ts_file)
+  if (scan(ts_file, '/')== 0) then ! prepend inputdir if only a filename is given
+    filename = trim(inputdir)//trim(ts_file)
+  endif
   if (.not.just_read) call log_param(param_file, mdl, "INPUTDIR/TS_FILE", filename)
   call get_param(param_file, mdl, "TEMP_IC_VAR", temp_var, &
                  "The initial condition variable for potential temperature.", &
@@ -1647,7 +1656,10 @@ subroutine initialize_temp_salt_from_file(T, S, G, GV, US, param_file, just_read
   ! Read the temperatures and salinities from netcdf files.
   call MOM_read_data(filename, temp_var, T(:,:,:), G%Domain, scale=US%degC_to_C)
 
-  salt_filename = trim(inputdir)//trim(salt_file)
+  salt_filename = trim(salt_file)
+  if (scan(salt_file, '/')== 0) then ! prepend inputdir if only a filename is given
+    salt_filename = trim(inputdir)//trim(salt_file)
+  endif
   if (.not.file_exists(salt_filename, G%Domain)) call MOM_error(FATAL, &
      " initialize_temp_salt_from_file: Unable to open "//trim(salt_filename))
 
@@ -1977,7 +1989,10 @@ subroutine initialize_sponges_file(G, GV, US, use_temperature, tv, u, v, depth_t
                  default=.false.)
 
   ! Read in sponge damping rate for tracers
-  filename = trim(inputdir)//trim(damping_file)
+  filename = trim(damping_file)
+  if (scan(damping_file, '/')== 0) then ! prepend inputdir if only a filename is given
+    filename = trim(inputdir)//trim(damping_file)
+  endif
   call log_param(param_file, mdl, "INPUTDIR/SPONGE_DAMPING_FILE", filename)
   if (.not.file_exists(filename, G%Domain)) &
     call MOM_error(FATAL, " initialize_sponges: Unable to open "//trim(filename))
@@ -2281,7 +2296,10 @@ subroutine initialize_oda_incupd_file(G, GV, US, use_temperature, tv, h, u, v, p
 !  call get_param(param_file, mdl, "USE_REGRIDDING", use_ALE, default=.false., do_not_log=.true.)
 
   ! Read in incremental update for tracers
-  filename = trim(inputdir)//trim(inc_file)
+  filename = trim(inc_file)
+  if (scan(inc_file, '/')== 0) then ! prepend inputdir if only a filename is given
+    filename = trim(inputdir)//trim(inc_file)
+  endif
   call log_param(param_file, mdl, "INPUTDIR/ODA_INCUPD_FILE", filename)
   if (.not.file_exists(filename, G%Domain)) &
     call MOM_error(FATAL, " initialize_oda_incupd: Unable to open "//trim(filename))


### PR DESCRIPTION
Enable relative path specification for  velocity, thickness, ts, salt, sponge, and ODA inc. files. This change is needed to enable hybrid CESM experiments, allowing the utilization of restart file(s) from different experiment(s).

This PR should be evaluated in conjunction with https://github.com/ESCOMP/MOM_interface/pull/159