### PR TITLE
Write unmasked ocean geometry files

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,14 +31,7 @@ jobs:
     - name: Run (single processor) unit tests
       run: make run.unit
 
-    - name: Report unit test coverage to CI (PR)
-      if: github.event_name == 'pull_request'
-      run: make report.cov.unit REQUIRE_COVERAGE_UPLOAD=true
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Report unit test coverage to CI (Push)
-      if: github.event_name != 'pull_request'
+    - name: Report unit test coverage to CI
       run: make report.cov.unit
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -49,14 +42,7 @@ jobs:
     - name: Run coverage tests
       run: make -j -k run.cov
 
-    - name: Report coverage to CI (PR)
-      if: github.event_name == 'pull_request'
-      run: make report.cov REQUIRE_COVERAGE_UPLOAD=true
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Report coverage to CI (Push)
-      if: github.event_name != 'pull_request'
+    - name: Report coverage to CI
       run: make report.cov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/src/framework/MOM_domains.F90
+++ b/src/framework/MOM_domains.F90
@@ -65,7 +65,7 @@ contains
 !! properties of the domain type.
 subroutine MOM_domains_init(MOM_dom, US, param_file, symmetric, static_memory, &
                             NIHALO, NJHALO, NIGLOBAL, NJGLOBAL, NIPROC, NJPROC, &
-                            min_halo, domain_name, include_name, param_suffix)
+                            min_halo, domain_name, include_name, param_suffix, MOM_dom_unmasked)
   type(MOM_domain_type),           pointer       :: MOM_dom      !< A pointer to the MOM_domain_type
                                                                  !! being defined here.
   type(unit_scale_type),           pointer       :: US           !< A dimensional unit scaling type
@@ -99,10 +99,13 @@ subroutine MOM_domains_init(MOM_dom, US, param_file, symmetric, static_memory, &
                                                                  !! "MOM_memory.h" if missing.
   character(len=*),      optional, intent(in)    :: param_suffix !< A suffix to apply to
                                                                  !! layout-specific parameters.
+  type(MOM_domain_type), pointer, optional       :: MOM_dom_unmasked !< Unmasked MOM domain instance.
+                                                                 !! Set to null if masking is not enabled.
 
   ! Local variables
   integer, dimension(2) :: layout    ! The number of logical processors in the i- and j- directions
   integer, dimension(2) :: auto_layout ! The layout determined by the auto masking routine
+  integer, dimension(2) :: layout_unmasked ! A temporary layout for unmasked domain
   integer, dimension(2) :: io_layout ! The layout of logical processors for input and output
   !$ integer :: ocean_nthreads       ! Number of openMP threads
   !$ logical :: ocean_omp_hyper_thread ! If true use openMP hyper-threads
@@ -427,6 +430,16 @@ subroutine MOM_domains_init(MOM_dom, US, param_file, symmetric, static_memory, &
     call get_param(param_file, mdl, trim(io_layout_nm), io_layout, &
                    "The processor layout to be used, or 0,0 to automatically set the io_layout "//&
                    "to be the same as the layout.", default=1, layoutParam=.true.)
+  endif
+
+  ! Create an unmasked domain if requested. This is used for writing out unmasked ocean geometry.
+  if (present(MOM_dom_unmasked) .and. mask_table_exists) then
+    call MOM_define_layout(n_global, PEs_used, layout_unmasked)
+    call create_MOM_domain(MOM_dom_unmasked, n_global, n_halo, reentrant, tripolar_N, layout_unmasked, &
+                           domain_name=domain_name, symmetric=symmetric, thin_halos=thin_halos, &
+                           nonblocking=nonblocking)
+  else
+    MOM_dom_unmasked => null()
   endif
 
   call create_MOM_domain(MOM_dom, n_global, n_halo, reentrant, tripolar_N, layout, &


### PR DESCRIPTION
When masking is applied via auto or manual mask_table, create an unmasked MOM6 domain to be used for writing out an unmasked ocean geometry file.