### PR TITLE
Add option to avoid negative MEKE

### DIFF
--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -81,7 +81,7 @@ type, public :: MEKE_CS ; private
   logical :: Rd_as_max_scale !< If true the length scale can not exceed the
                         !! first baroclinic deformation radius.
   logical :: use_old_lscale !< Use the old formula for mixing length scale.
-  logical :: use_min_lscale !< Use simple minimum for mixing l >= 0.
+  logical :: use_min_lscale !< Use simple minimum for mixing length scale.
   logical :: MEKE_positive  !< If true, it guarantees that MEKE will always be >= 0.
   real :: lscale_maxval !< The ceiling on the MEKE mixing length scale when use_min_lscale is true [L ~> m].
   real :: cdrag         !< The bottom drag coefficient for MEKE, times rescaling factors [H L-1 ~> nondim or kg m-3]

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -82,6 +82,7 @@ type, public :: MEKE_CS ; private
                         !! first baroclinic deformation radius.
   logical :: use_old_lscale !< Use the old formula for mixing length scale.
   logical :: use_min_lscale !< Use simple minimum for mixing l >= 0.
+  logical :: MEKE_positive  !< If true, it guarantees that MEKE will always be >= 0.
   real :: lscale_maxval !< The ceiling on the MEKE mixing length scale when use_min_lscale is true [L ~> m].
   real :: cdrag         !< The bottom drag coefficient for MEKE, times rescaling factors [H L-1 ~> nondim or kg m-3]
   real :: MEKE_BGsrc    !< Background energy source for MEKE [L2 T-3 ~> W kg-1] (= m2 s-3).

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -82,6 +82,7 @@ type, public :: MEKE_CS ; private
                         !! first baroclinic deformation radius.
   logical :: use_old_lscale !< Use the old formula for mixing length scale.
   logical :: use_min_lscale !< Use simple minimum for mixing length scale.
+  logical :: MEKE_positive  !< If true, it guarantees that MEKE will always be greater than zero.
   real :: lscale_maxval !< The ceiling on the MEKE mixing length scale when use_min_lscale is true [L ~> m].
   real :: cdrag         !< The bottom drag coefficient for MEKE, times rescaling factors [H L-1 ~> nondim or kg m-3]
   real :: MEKE_BGsrc    !< Background energy source for MEKE [L2 T-3 ~> W kg-1] (= m2 s-3).
@@ -647,6 +648,13 @@ subroutine step_forward_MEKE(MEKE, h, SN_u, SN_v, visc, dt, G, GV, US, CS, hu, h
   case default
     call MOM_error(FATAL,"Invalid method specified for calculating EKE")
   end select
+
+  if (CS%MEKE_positive) then
+    !$OMP parallel do default(shared)
+    do j=js,je ; do i=is,ie
+      MEKE%MEKE(i,j) = MAX(0., MEKE%MEKE(i,j))
+    enddo ; enddo
+  endif
 
   call cpu_clock_begin(CS%id_clock_pass)
   call do_group_pass(CS%pass_MEKE, G%Domain)
@@ -1228,6 +1236,9 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
     call get_param(param_file, mdl, "MEKE_DTSCALE", CS%MEKE_dtScale, &
                    "A scaling factor to accelerate the time evolution of MEKE.", &
                    units="nondim", default=1.0)
+    call get_param(param_file, mdl, "MEKE_POSITIVE", CS%MEKE_positive, &
+                   "If true, it guarantees that MEKE will always be greater than zero.", &
+                   default=.false.)
   case("dbclient")
     CS%eke_src = EKE_DBCLIENT
     call ML_MEKE_init(diag, G, US, Time, param_file, dbcomms_CS, CS)

--- a/src/parameterizations/lateral/MOM_MEKE.F90
+++ b/src/parameterizations/lateral/MOM_MEKE.F90
@@ -81,8 +81,7 @@ type, public :: MEKE_CS ; private
   logical :: Rd_as_max_scale !< If true the length scale can not exceed the
                         !! first baroclinic deformation radius.
   logical :: use_old_lscale !< Use the old formula for mixing length scale.
-  logical :: use_min_lscale !< Use simple minimum for mixing length scale.
-  logical :: MEKE_positive  !< If true, it guarantees that MEKE will always be greater than zero.
+  logical :: use_min_lscale !< Use simple minimum for mixing l >= 0.
   real :: lscale_maxval !< The ceiling on the MEKE mixing length scale when use_min_lscale is true [L ~> m].
   real :: cdrag         !< The bottom drag coefficient for MEKE, times rescaling factors [H L-1 ~> nondim or kg m-3]
   real :: MEKE_BGsrc    !< Background energy source for MEKE [L2 T-3 ~> W kg-1] (= m2 s-3).
@@ -1237,7 +1236,7 @@ logical function MEKE_init(Time, G, GV, US, param_file, diag, dbcomms_CS, CS, ME
                    "A scaling factor to accelerate the time evolution of MEKE.", &
                    units="nondim", default=1.0)
     call get_param(param_file, mdl, "MEKE_POSITIVE", CS%MEKE_positive, &
-                   "If true, it guarantees that MEKE will always be greater than zero.", &
+                   "If true, it guarantees that MEKE will always be >= 0.", &
                    default=.false.)
   case("dbclient")
     CS%eke_src = EKE_DBCLIENT


### PR DESCRIPTION
Add a new input parameter option called `MEKE_POSITIVE`. When this parameter is set to "true", it ensures that MEKE >= 0.