### PR TITLE
*Updates in FPMix and Stokes Most

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -737,6 +737,10 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
              Ice_ocean_boundary% hrofi (isc:iec,jsc:jec),           &
              Ice_ocean_boundary% hevap (isc:iec,jsc:jec),           &
              Ice_ocean_boundary% hcond (isc:iec,jsc:jec),           &
+             Ice_ocean_boundary% lrunoff_glc (isc:iec,jsc:jec),     &
+             Ice_ocean_boundary% frunoff_glc (isc:iec,jsc:jec),     &
+             Ice_ocean_boundary% hrofl_glc (isc:iec,jsc:jec),       &
+             Ice_ocean_boundary% hrofi_glc (isc:iec,jsc:jec),       &
              source=0.0)
 
     ! Needed for MARBL
@@ -797,6 +801,10 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Sa_pslv"        , "will provide")
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"      , "will provide") !-> liquid runoff
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"      , "will provide") !-> ice runoff
+  if (cesm_coupled) then
+    call fld_list_add(fldsToOcn_num, fldsToOcn, "Forr_rofl_glc"  , "will provide") !-> liquid glc runoff
+    call fld_list_add(fldsToOcn_num, fldsToOcn, "Forr_rofi_glc"  , "will provide") !-> frozen glc runoff
+  endif
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Si_ifrac"       , "will provide") !-> ice fraction
   call fld_list_add(fldsToOcn_num, fldsToOcn, "So_duu10n"      , "will provide") !-> wind^2 at 10m
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_meltw"     , "will provide")
@@ -808,6 +816,10 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hcond"     , "will provide")
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hrofl"     , "will provide")
   call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hrofi"     , "will provide")
+  if (cesm_coupled) then
+    call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hrofl_glc" , "will provide")
+    call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_hrofi_glc" , "will provide")
+  endif
 
   if (Ice_ocean_boundary%ice_ncat > 0) then
     call fld_list_add(fldsToOcn_num, fldsToOcn, "Sf_afracr", "will provide")
@@ -2852,6 +2864,34 @@ end subroutine shr_log_setLogUnit
 !!     <td>kg m-2 s-1</td>
 !!     <td>runoff</td>
 !!     <td>mass flux of frozen runoff</td>
+!!     <td></td>
+!! </tr>
+!! <tr>
+!!     <td>Forr_rofl_glc</td>
+!!     <td>kg m-2 s-1</td>
+!!     <td>runoff</td>
+!!     <td>mass flux of liquid glc runoff</td>
+!!     <td></td>
+!! </tr>
+!! <tr>
+!!     <td>Forr_rofi_glc</td>
+!!     <td>kg m-2 s-1</td>
+!!     <td>runoff</td>
+!!     <td>mass flux of frozen glc runoff</td>
+!!     <td></td>
+!! </tr>
+!! <tr>
+!!     <td>Foxx_hrofi_glc</td>
+!!     <td>W m-2</td>
+!!     <td>hrofi_glc</td>
+!!     <td>heat content (enthalpy) of frozen glc runoff</td>
+!!     <td></td>
+!! </tr>
+!! <tr>
+!!     <td>Foxx_hrofl_glc</td>
+!!     <td>W m-2</td>
+!!     <td>hrofl_glc</td>
+!!     <td>heat content (enthalpy) of liquid glc runoff</td>
 !!     <td></td>
 !! </tr>
 !! <tr>

--- a/config_src/drivers/nuopc_cap/mom_cap_methods.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap_methods.F90
@@ -216,6 +216,22 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
        isc, iec, jsc, jec, ice_ocean_boundary%frunoff, areacor=med2mod_areacor, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
+  ! liquid glc runoff
+  if ( associated(ice_ocean_boundary%lrunoff_glc) ) then
+    ice_ocean_boundary%lrunoff_glc (:,:) = 0._ESMF_KIND_R8
+    call state_getimport(importState, 'Forr_rofl_glc',  &
+         isc, iec, jsc, jec, ice_ocean_boundary%lrunoff_glc, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  endif
+
+  ! frozen glc runoff
+  if ( associated(ice_ocean_boundary%frunoff_glc) ) then
+    ice_ocean_boundary%frunoff_glc (:,:) = 0._ESMF_KIND_R8
+    call state_getimport(importState, 'Forr_rofi_glc',  &
+         isc, iec, jsc, jec, ice_ocean_boundary%frunoff_glc, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  endif
+
   !----
   ! Enthalpy terms
   !----
@@ -256,6 +272,23 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
   end if
 
+  !----
+  ! enthalpy from liquid glc runoff (hrofl_glc)
+  !----
+  if ( associated(ice_ocean_boundary%hrofl_glc) ) then
+    call state_getimport(importState, 'Foxx_hrofl_glc', isc, iec, jsc, jec, &
+         ice_ocean_boundary%hrofl_glc, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  end if
+
+  !----
+  ! enthalpy from frozen glc runoff (hrofi_glc)
+  !----
+  if ( associated(ice_ocean_boundary%hrofi_glc) ) then
+    call state_getimport(importState, 'Foxx_hrofi_glc', isc, iec, jsc, jec, &
+         ice_ocean_boundary%hrofi_glc, areacor=med2mod_areacor, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+  end if
   !----
   ! enthalpy from evaporation (hevap)
   !----

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -164,6 +164,8 @@ end type surface_forcing_CS
 type, public :: ice_ocean_boundary_type
   real, pointer, dimension(:,:) :: lrunoff           =>NULL() !< liquid runoff [kg/m2/s]
   real, pointer, dimension(:,:) :: frunoff           =>NULL() !< ice runoff [kg/m2/s]
+  real, pointer, dimension(:,:) :: lrunoff_glc       =>NULL() !< liquid glc runoff via rof [kg/m2/s]
+  real, pointer, dimension(:,:) :: frunoff_glc       =>NULL() !< frozen glc runoff via rof [kg/m2/s]
   real, pointer, dimension(:,:) :: u_flux            =>NULL() !< i-direction wind stress [Pa]
   real, pointer, dimension(:,:) :: v_flux            =>NULL() !< j-direction wind stress [Pa]
   real, pointer, dimension(:,:) :: t_flux            =>NULL() !< sensible heat flux [W/m2]
@@ -183,6 +185,8 @@ type, public :: ice_ocean_boundary_type
   real, pointer, dimension(:,:) :: mass_berg         =>NULL() !< mass of icebergs(kg/m2)
   real, pointer, dimension(:,:) :: hrofl             =>NULL() !< heat content from liquid runoff [W/m2]
   real, pointer, dimension(:,:) :: hrofi             =>NULL() !< heat content from frozen runoff [W/m2]
+  real, pointer, dimension(:,:) :: hrofl_glc         =>NULL() !< heat content from liquid glc runoff [W/m2]
+  real, pointer, dimension(:,:) :: hrofi_glc         =>NULL() !< heat content from frozen glc runoff [W/m2]
   real, pointer, dimension(:,:) :: hrain             =>NULL() !< heat content from liquid precipitation [W/m2]
   real, pointer, dimension(:,:) :: hsnow             =>NULL() !< heat content from frozen precipitation [W/m2]
   real, pointer, dimension(:,:) :: hevap             =>NULL() !< heat content from evaporation [W/m2]
@@ -494,6 +498,16 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
       fluxes%frunoff(i,j) = kg_m2_s_conversion * IOB%frunoff(i-i0,j-j0) * G%mask2dT(i,j)
     endif
 
+    ! add liquid glc runoff flux via rof
+    if (associated(IOB%lrunoff_glc)) then
+      fluxes%lrunoff_glc(i,j) = kg_m2_s_conversion * IOB%lrunoff_glc(i-i0,j-j0) * G%mask2dT(i,j)
+    endif
+
+    ! ice glc runoff flux via rof
+    if (associated(IOB%frunoff_glc)) then
+      fluxes%frunoff_glc(i,j) = kg_m2_s_conversion * IOB%frunoff_glc(i-i0,j-j0) * G%mask2dT(i,j)
+    endif
+
     if (associated(IOB%ustar_berg)) &
       fluxes%ustar_berg(i,j) = US%m_to_Z*US%T_to_s * IOB%ustar_berg(i-i0,j-j0) * G%mask2dT(i,j)
 
@@ -530,6 +544,13 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
           IOB%frunoff(i-i0,j-j0) * US%W_m2_to_QRZ_T * CS%latent_heat_fusion
       fluxes%latent_frunoff_diag(i,j) = - G%mask2dT(i,j) * &
           IOB%frunoff(i-i0,j-j0) * US%W_m2_to_QRZ_T * CS%latent_heat_fusion
+    endif
+    ! notice minus sign since frunoff_glc is positive into the ocean
+    if (associated(IOB%frunoff_glc)) then
+      fluxes%latent(i,j)              = fluxes%latent(i,j) - &
+          IOB%frunoff_glc(i-i0,j-j0) * US%W_m2_to_QRZ_T * CS%latent_heat_fusion
+      fluxes%latent_frunoff_glc_diag(i,j) = fluxes%latent_frunoff_glc_diag(i,j) - G%mask2dT(i,j) * &
+          IOB%frunoff_glc(i-i0,j-j0) * US%W_m2_to_QRZ_T * CS%latent_heat_fusion
     endif
     if (associated(IOB%q_flux)) then
       fluxes%latent(i,j)           = fluxes%latent(i,j) + &
@@ -572,6 +593,12 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
        if (associated(IOB%hcond)) &
         fluxes%heat_content_cond(i,j)    = US%W_m2_to_QRZ_T * IOB%hcond(i-i0,j-j0) * G%mask2dT(i,j)
+
+       if (associated(IOB%hrofl_glc)) &
+        fluxes%heat_content_lrunoff_glc(i,j) = US%W_m2_to_QRZ_T * IOB%hrofl_glc(i-i0,j-j0) * G%mask2dT(i,j)
+
+       if (associated(IOB%hrofi_glc)) &
+        fluxes%heat_content_frunoff_glc(i,j) = US%W_m2_to_QRZ_T * IOB%hrofi_glc(i-i0,j-j0) * G%mask2dT(i,j)
     endif
 
     ! sea ice fraction [nondim]
@@ -633,7 +660,8 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     do j=js,je ; do i=is,ie
       net_FW(i,j) = US%RZ_T_to_kg_m2s * &
                     (((fluxes%lprec(i,j)   + fluxes%fprec(i,j) + fluxes%seaice_melt(i,j)) + &
-                      (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j))) + &
+                      (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j) + &
+                       fluxes%lrunoff_glc(i,j) + fluxes%frunoff_glc(i,j))) + &
                       (fluxes%evap(i,j)    + fluxes%vprec(i,j)) ) * US%L_to_m**2*G%areaT(i,j)
       net_FW2(i,j) = net_FW(i,j) / (US%L_to_m**2*G%areaT(i,j))
     enddo ; enddo
@@ -1133,7 +1161,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   ! Local variables
   real :: utide  ! The RMS tidal velocity [Z T-1 ~> m s-1].
   type(directories)  :: dirs
-  logical            :: new_sim, iceberg_flux_diags, fix_ustar_gustless_bug
+  logical            :: new_sim, iceberg_flux_diags, glc_runoff_diags, fix_ustar_gustless_bug
   logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
   logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   type(time_type)    :: Time_frc
@@ -1431,8 +1459,13 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
                  "If true, makes available diagnostics of fluxes from icebergs "//&
                  "as seen by MOM6.", default=.false.)
 
+  call get_param(param_file, mdl, "ALLOW_GLC_RUNOFF_DIAGNOSTICS", glc_runoff_diags, &
+                 "If true, makes available diagnostics of separate glacier runoff fluxes"//&
+                 "as seen by MOM6.", default=.false.)
+
   call register_forcing_type_diags(Time, diag, US, CS%use_temperature, CS%handles, &
-                                   use_berg_fluxes=iceberg_flux_diags, use_waves=use_waves, use_cfcs=CS%use_CFC)
+                                   use_berg_fluxes=iceberg_flux_diags, use_waves=use_waves, &
+                                   use_cfcs=CS%use_CFC, use_glc_runoff=glc_runoff_diags)
 
   call get_param(param_file, mdl, "ALLOW_FLUX_ADJUSTMENTS", CS%allow_flux_adjustments, &
                  "If true, allows flux adjustments to specified via the "//&
@@ -1541,6 +1574,8 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
   chks = field_chksum( iobt%fprec          ) ; if (root) write(outunit,100) 'iobt%fprec          ', chks
   chks = field_chksum( iobt%lrunoff        ) ; if (root) write(outunit,100) 'iobt%lrunoff        ', chks
   chks = field_chksum( iobt%frunoff        ) ; if (root) write(outunit,100) 'iobt%frunoff        ', chks
+  chks = field_chksum( iobt%lrunoff_glc    ) ; if (root) write(outunit,100) 'iobt%lrunoff_glc    ', chks
+  chks = field_chksum( iobt%frunoff_glc    ) ; if (root) write(outunit,100) 'iobt%frunoff_glc    ', chks
   chks = field_chksum( iobt%p              ) ; if (root) write(outunit,100) 'iobt%p              ', chks
   if (associated(iobt%ice_fraction)) then
     chks = field_chksum( iobt%ice_fraction ) ; if (root) write(outunit,100) 'iobt%ice_fraction   ', chks
@@ -1630,6 +1665,12 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
   endif
   if (associated(iobt%hcond)) then
     chks = field_chksum( iobt%hcond  ) ; if (root) write(outunit,100) 'iobt%hcond      ', chks
+  endif
+  if (associated(iobt%hrofl_glc)) then
+    chks = field_chksum( iobt%hrofl_glc  ) ; if (root) write(outunit,100) 'iobt%hrofl_glc      ', chks
+  endif
+  if (associated(iobt%hrofl_glc)) then
+    chks = field_chksum( iobt%hrofl_glc  ) ; if (root) write(outunit,100) 'iobt%hrofl_glc      ', chks
   endif
 
 100 FORMAT("   CHECKSUM::",A20," = ",Z20)

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -298,7 +298,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
     call allocate_forcing_type(G, fluxes, water=.true., heat=.true., ustar=.true., &
                                press=.true., fix_accum_bug=CS%fix_ustar_gustless_bug, &
                                cfc=CS%use_CFC, hevap=CS%enthalpy_cpl, tau_mag=.true.)
-    !call safe_alloc_ptr(fluxes%omega_w2x,isd,ied,jsd,jed)
+    call safe_alloc_ptr(fluxes%omega_w2x,isd,ied,jsd,jed)
 
     call safe_alloc_ptr(fluxes%sw_vis_dir,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%sw_vis_dif,isd,ied,jsd,jed)
@@ -704,7 +704,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
 
     call safe_alloc_ptr(forces%p_surf,isd,ied,jsd,jed)
     call safe_alloc_ptr(forces%p_surf_full,isd,ied,jsd,jed)
-    !call safe_alloc_ptr(forces%omega_w2x,isd,ied,jsd,jed)
+    call safe_alloc_ptr(forces%omega_w2x,isd,ied,jsd,jed)
 
     if (CS%rigid_sea_ice) then
       call safe_alloc_ptr(forces%rigidity_ice_u,IsdB,IedB,jsd,jed)
@@ -865,7 +865,7 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, US, CS)
       forces%tau_mag(i,j) = gustiness + G%mask2dT(i,j) * sqrt(taux_at_h(i,j)**2 + tauy_at_h(i,j)**2)
       forces%ustar(i,j) = sqrt(gustiness*Irho0 + Irho0 * G%mask2dT(i,j) * &
                                sqrt(taux_at_h(i,j)**2 + tauy_at_h(i,j)**2))
-      !forces%omega_w2x(i,j) = atan(tauy_at_h(i,j), taux_at_h(i,j))
+      forces%omega_w2x(i,j) = atan(tauy_at_h(i,j), taux_at_h(i,j))
     enddo ; enddo
     call pass_vector(forces%taux, forces%tauy, G%Domain, halo=1)
   else ! C-grid wind stresses.

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1513,7 +1513,6 @@ subroutine step_MOM_thermo(CS, G, GV, US, u, v, h, tv, fluxes, dtdia, &
                                                ! velocity points [H ~> m or kg m-2]
   logical :: PCM_cell(SZI_(G),SZJ_(G),SZK_(GV)) ! If true, PCM remapping should be used in a cell.
   logical :: use_ice_shelf ! Needed for selecting the right ALE interface.
-  logical :: fpmix ! Needed to decide if BLD should be passed to RK2.
   logical :: showCallTree
   type(group_pass_type) :: pass_T_S, pass_T_S_h, pass_uv_T_S_h
   integer :: dynamics_stencil  ! The computational stencil for the calculations
@@ -2071,6 +2070,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   logical :: symmetric         ! If true, use symmetric memory allocation.
   logical :: save_IC           ! If true, save the initial conditions.
   logical :: do_unit_tests     ! If true, call unit tests.
+  logical :: fpmix             ! Needed to decide if BLD should be passed to RK2.
   logical :: test_grid_copy = .false.
 
   logical :: bulkmixedlayer    ! If true, a refined bulk mixed layer scheme is used

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -3253,7 +3253,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                               CS%sponge_CSp, CS%ALE_sponge_CSp, CS%oda_incupd_CSp, CS%int_tide_CSp)
   endif
 
-  ! GMM
+  ! GMM, the following is needed to get BLDs into the dynamics module
   if (CS%split .and. fpmix) then
     call init_dyn_split_RK2_diabatic(CS%diabatic_CSp, CS%dyn_split_RK2_CSp)
   endif

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -397,7 +397,8 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
   logical :: Use_Stokes_PGF ! If true, add Stokes PGF to hydrostatic PGF
   !---For group halo pass
   logical :: showCallTree, sym
-  logical :: lFPpost        ! post diagnostics from vertFPmix when fpmix=true
+  logical :: lFPpost        ! Used to only post diagnostics in vertFPmix when fpmix=true and
+                            ! in the  corrector step (not the predict)
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: cont_stencil, obc_stencil
 
@@ -722,12 +723,12 @@ subroutine step_MOM_dyn_split_RK2(u, v, h, tv, visc, Time_local, dt, forces, p_s
     ! lFPpost must be false in the predictor step to avoid averaging into the diagnostics
     lFPpost = .false.
     call vertFPmix(up, vp, uold, vold, hbl, h, forces, dt_pred, lFPpost,  &
-                    G, GV, US, CS%vertvisc_CSp, CS%OBC, waves=waves)
+                   G, GV, US, CS%vertvisc_CSp, CS%OBC, waves=waves)
     call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%AD_pred, CS%CDp, G, &
-                    GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, fpmix=CS%fpmix, waves=waves)
+                  GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, fpmix=CS%fpmix, waves=waves)
   else
     call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%AD_pred, CS%CDp, G, &
-                GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
+                  GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
   endif
 
   if (showCallTree) call callTree_wayPoint("done with vertvisc (step_MOM_dyn_split_RK2)")
@@ -1295,6 +1296,7 @@ subroutine remap_dyn_split_RK2_aux_vars(G, GV, CS, h_old_u, h_old_v, h_new_u, h_
 end subroutine remap_dyn_split_RK2_aux_vars
 
 !> Initializes aspects of the dyn_split_RK2 that depend on diabatic processes.
+!! Needed when BLDs are used in the dynamics.
 subroutine init_dyn_split_RK2_diabatic(diabatic_CSp, CS)
   type(diabatic_CS),                intent(in) :: diabatic_CSp !< diabatic structure
   type(MOM_dyn_split_RK2_CS),       pointer    :: CS           !< module control structure

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -12,6 +12,7 @@ use MOM_checksum_packages, only : MOM_thermo_chksum, MOM_state_chksum, MOM_accel
 use MOM_cpu_clock,         only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,         only : CLOCK_COMPONENT, CLOCK_SUBCOMPONENT
 use MOM_cpu_clock,         only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
+use MOM_diabatic_driver,   only : diabatic_CS, extract_diabatic_member
 use MOM_diag_mediator,     only : diag_mediator_init, enable_averages
 use MOM_diag_mediator,     only : disable_averaging, post_data, safe_alloc_ptr
 use MOM_diag_mediator,     only : post_product_u, post_product_sum_u

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -12,6 +12,7 @@ use MOM_checksum_packages, only : MOM_thermo_chksum, MOM_state_chksum, MOM_accel
 use MOM_cpu_clock,         only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,         only : CLOCK_COMPONENT, CLOCK_SUBCOMPONENT
 use MOM_cpu_clock,         only : CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE
+use MOM_diabatic_driver,   only : diabatic_CS, extract_diabatic_member
 use MOM_diag_mediator,     only : diag_mediator_init, enable_averages
 use MOM_diag_mediator,     only : disable_averaging, post_data, safe_alloc_ptr
 use MOM_diag_mediator,     only : post_product_u, post_product_sum_u
@@ -45,7 +46,9 @@ use MOM_continuity,            only : continuity, continuity_CS
 use MOM_continuity,            only : continuity_init, continuity_stencil
 use MOM_CoriolisAdv,           only : CorAdCalc, CoriolisAdv_CS
 use MOM_CoriolisAdv,           only : CoriolisAdv_init, CoriolisAdv_end
+use MOM_CVMix_KPP,             only : KPP_get_BLD, KPP_CS
 use MOM_debugging,             only : check_redundant
+use MOM_energetic_PBL,         only : energetic_PBL_get_MLD, energetic_PBL_CS
 use MOM_grid,                  only : ocean_grid_type
 use MOM_hor_index,             only : hor_index_type
 use MOM_hor_visc,              only : horizontal_viscosity, hor_visc_CS, hor_visc_vel_stencil
@@ -137,14 +140,16 @@ type, public :: MOM_dyn_split_RK2_CS ; private
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_,NKMEM_)      :: pbce   !< pbce times eta gives the baroclinic pressure
                                                                   !! anomaly in each layer due to free surface height
                                                                   !! anomalies [L2 H-1 T-2 ~> m s-2 or m4 kg-1 s-2].
+  type(KPP_CS),           pointer :: KPP_CSp => NULL() !< KPP control structure needed to ge
+  type(energetic_PBL_CS), pointer :: energetic_PBL_CSp => NULL()  !< ePBL control structure
 
-  real, pointer, dimension(:,:) :: taux_bot => NULL() !< frictional x-bottom stress from the ocean
-                                                      !! to the seafloor [R L Z T-2 ~> Pa]
-  real, pointer, dimension(:,:) :: tauy_bot => NULL() !< frictional y-bottom stress from the ocean
-                                                      !! to the seafloor [R L Z T-2 ~> Pa]
-  type(BT_cont_type), pointer   :: BT_cont  => NULL() !<  A structure with elements that describe the
-                                                      !! effective summed open face areas as a function
-                                                      !! of barotropic flow.
+  real, pointer, dimension(:,:) :: taux_bot => NULL()  !< frictional x-bottom stress from the ocean
+                                                       !! to the seafloor [R L Z T-2 ~> Pa]
+  real, pointer, dimension(:,:) :: tauy_bot => NULL()  !< frictional y-bottom stress from the ocean
+                                                       !! to the seafloor [R L Z T-2 ~> Pa]
+  type(BT_cont_type), pointer   :: BT_cont  => NULL()  !<  A structure with elements that describe the
+                                                       !! effective summed open face areas as a function
+                                                       !! of barotropic flow.
 
   ! This is to allow the previous, velocity-based coupling with between the
   ! baroclinic and barotropic modes.
@@ -721,7 +726,7 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
     ! lFPpost must be false in the predictor step to avoid averaging into the diagnostics
     lFPpost = .false.
-    call vertFPmix(up, vp, uold, vold, hbl, h, forces, dt_pred, CS%Cemp_NL, lFPpost,  &
+    call vertFPmix(up, vp, uold, vold, hbl, h, forces, dt_pred, lFPpost, CS%Cemp_NL,  &
                    G, GV, US, CS%vertvisc_CSp, CS%OBC, waves=waves)
     call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%AD_pred, CS%CDp, G, &
                   GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, fpmix=CS%fpmix, waves=waves)
@@ -967,17 +972,17 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   endif
 
   call thickness_to_dz(h, tv, dz, G, GV, US, halo_size=1)
-  call vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
+  call vertvisc_coef(u_inst, v_inst, h, dz, forces, visc, tv, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
 
   if (CS%fpmix) then
     lFPpost = .true.
-    call vertFPmix(u, v, uold, vold, hbl, h, forces, dt, CS%Cemp_NL, lFPpost, &
+    call vertFPmix(u_inst, v_inst, uold, vold, hbl, h, forces, dt, lFPpost, CS%Cemp_NL, &
                    G, GV, US, CS%vertvisc_CSp, CS%OBC, Waves=Waves)
-    call vertvisc(u, v, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
+    call vertvisc(u_inst, v_inst, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
          CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, fpmix=CS%fpmix, waves=waves)
 
   else
-    call vertvisc(u, v, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
+    call vertvisc(u_inst, v_inst, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
                   CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
   endif
 

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -74,7 +74,7 @@ type, public :: forcing
 
   ! surface stress components and turbulent velocity scale
   real, pointer, dimension(:,:) :: &
-    !omega_w2x     => NULL(), & !< the counter-clockwise angle of the wind stress with respect
+    omega_w2x     => NULL(), & !< the counter-clockwise angle of the wind stress with respect
     ustar         => NULL(), & !< surface friction velocity scale [Z T-1 ~> m s-1].
     tau_mag       => NULL(), & !< Magnitude of the wind stress averaged over tracer cells,
                                !! including any contributions from sub-gridscale variability
@@ -239,8 +239,8 @@ type, public :: mech_forcing
     tau_mag => NULL(), & !< Magnitude of the wind stress averaged over tracer cells, including any
                        !! contributions from sub-gridscale variability or gustiness [R L Z T-2 ~> Pa]
     ustar => NULL(), & !< surface friction velocity scale [Z T-1 ~> m s-1].
-    net_mass_src => NULL() !< The net mass source to the ocean [R Z T-1 ~> kg m-2 s-1]
-    !omega_w2x    => NULL()    !< the counter-clockwise angle of the wind stress with respect
+    net_mass_src => NULL(), & !< The net mass source to the ocean [R Z T-1 ~> kg m-2 s-1]
+    omega_w2x    => NULL()    !< the counter-clockwise angle of the wind stress with respect
                               !! to the horizontal abscissa (x-coordinate) at tracer points [rad].
 
   ! applied surface pressure from other component models (e.g., atmos, sea ice, land ice)
@@ -378,7 +378,7 @@ type, public :: forcing_diags
   integer :: id_taux  = -1
   integer :: id_tauy  = -1
   integer :: id_ustar = -1
-  !integer :: id_omega_w2x = -1
+  integer :: id_omega_w2x = -1
   integer :: id_tau_mag = -1
   integer :: id_psurf     = -1
   integer :: id_TKE_tidal = -1
@@ -1506,8 +1506,8 @@ subroutine register_forcing_type_diags(Time, diag, US, use_temperature, handles,
       'Surface friction velocity = [(gustiness + tau_magnitude)/rho0]^(1/2)', &
       'm s-1', conversion=US%Z_to_m*US%s_to_T)
 
-  !handles%id_omega_w2x = register_diag_field('ocean_model', 'omega_w2x', diag%axesT1, Time, &
-  !    'Counter-clockwise angle of the wind stress from the horizontal axis.', 'rad')
+  handles%id_omega_w2x = register_diag_field('ocean_model', 'omega_w2x', diag%axesT1, Time, &
+      'Counter-clockwise angle of the wind stress from the horizontal axis.', 'rad')
 
   if (present(use_berg_fluxes)) then
     if (use_berg_fluxes) then
@@ -2370,11 +2370,11 @@ subroutine copy_common_forcing_fields(forces, fluxes, G, skip_pres)
       fluxes%ustar(i,j) = forces%ustar(i,j)
     enddo ; enddo
   endif
-  !if (associated(forces%omega_w2x) .and. associated(fluxes%omega_w2x)) then
-  !  do j=js,je ; do i=is,ie
-  !    fluxes%omega_w2x(i,j) = forces%omega_w2x(i,j)
-  !  enddo ; enddo
-  !endif
+  if (associated(forces%omega_w2x) .and. associated(fluxes%omega_w2x)) then
+    do j=js,je ; do i=is,ie
+      fluxes%omega_w2x(i,j) = forces%omega_w2x(i,j)
+    enddo ; enddo
+  endif
   if (associated(forces%tau_mag) .and. associated(fluxes%tau_mag)) then
     do j=js,je ; do i=is,ie
       fluxes%tau_mag(i,j) = forces%tau_mag(i,j)
@@ -2516,11 +2516,11 @@ subroutine copy_back_forcing_fields(fluxes, forces, G)
       forces%ustar(i,j) = fluxes%ustar(i,j)
     enddo ; enddo
   endif
-  !if (associated(forces%omega_w2x) .and. associated(fluxes%omega_w2x)) then
-  !  do j=js,je ; do i=is,ie
-  !    forces%omega_w2x(i,j) = fluxes%omega_w2x(i,j)
-  !  enddo ; enddo
-  !endif
+  if (associated(forces%omega_w2x) .and. associated(fluxes%omega_w2x)) then
+    do j=js,je ; do i=is,ie
+      forces%omega_w2x(i,j) = fluxes%omega_w2x(i,j)
+    enddo ; enddo
+  endif
   if (associated(forces%tau_mag) .and. associated(fluxes%tau_mag)) then
     do j=js,je ; do i=is,ie
       forces%tau_mag(i,j) = fluxes%tau_mag(i,j)
@@ -3172,8 +3172,8 @@ subroutine forcing_diagnostics(fluxes_in, sfc_state, G_in, US, time_end, diag, h
     if ((handles%id_ustar > 0) .and. associated(fluxes%ustar)) &
       call post_data(handles%id_ustar, fluxes%ustar, diag)
 
-    !if ((handles%id_omega_w2x > 0) .and. associated(fluxes%omega_w2x)) &
-    !  call post_data(handles%id_omega_w2x, fluxes%omega_w2x, diag)
+    if ((handles%id_omega_w2x > 0) .and. associated(fluxes%omega_w2x)) &
+      call post_data(handles%id_omega_w2x, fluxes%omega_w2x, diag)
 
     if ((handles%id_ustar_berg > 0) .and. associated(fluxes%ustar_berg)) &
       call post_data(handles%id_ustar_berg, fluxes%ustar_berg, diag)
@@ -3512,7 +3512,7 @@ end subroutine myAlloc
 subroutine deallocate_forcing_type(fluxes)
   type(forcing), intent(inout) :: fluxes !< Forcing fields structure
 
-  !if (associated(fluxes%omega_w2x))            deallocate(fluxes%omega_w2x)
+  if (associated(fluxes%omega_w2x))            deallocate(fluxes%omega_w2x)
   if (associated(fluxes%ustar))                deallocate(fluxes%ustar)
   if (associated(fluxes%ustar_gustless))       deallocate(fluxes%ustar_gustless)
   if (associated(fluxes%tau_mag))              deallocate(fluxes%tau_mag)
@@ -3572,7 +3572,7 @@ end subroutine deallocate_forcing_type
 subroutine deallocate_mech_forcing(forces)
   type(mech_forcing), intent(inout) :: forces  !< Forcing fields structure
 
-  !if (associated(forces%omega_w2x))      deallocate(forces%omega_w2x)
+  if (associated(forces%omega_w2x))      deallocate(forces%omega_w2x)
   if (associated(forces%taux))           deallocate(forces%taux)
   if (associated(forces%tauy))           deallocate(forces%tauy)
   if (associated(forces%ustar))          deallocate(forces%ustar)

--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -966,8 +966,8 @@ subroutine accumulate_net_input(fluxes, sfc_state, tv, dt, G, US, CS)
     if (associated(fluxes%lprec) .and. associated(fluxes%fprec)) then
       do j=js,je ; do i=is,ie
         FW_in(i,j) = RZL2_to_kg * dt*G%areaT(i,j)*(fluxes%evap(i,j) + &
-            (((fluxes%lprec(i,j) + fluxes%vprec(i,j)) + fluxes%lrunoff(i,j)) + &
-              (fluxes%fprec(i,j) + fluxes%frunoff(i,j))))
+            (((fluxes%lprec(i,j) + fluxes%vprec(i,j)) + fluxes%lrunoff(i,j) + fluxes%lrunoff_glc(i,j)) + &
+              (fluxes%fprec(i,j) + fluxes%frunoff(i,j) + fluxes%frunoff_glc(i,j))))
       enddo ; enddo
     else
       call MOM_error(WARNING, &

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1080,7 +1080,10 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   !$OMP                           surfUs, surfVs, Uk, Vk, deltaU2, km1, kk, pres_1D, N_col, &
   !$OMP                           Temp_1D, salt_1D, surfBuoyFlux2, MLD_guess, LA, rho_1D,   &
   !$OMP                           deltarho, deltaBuoy, N2_1d, ws_1d, LangEnhVT2,KPP_OBL_depth, z_cell, &
-  !$OMP                           z_inter, OBL_depth, BulkRi_1d, zBottomMinusOffset)        &
+  !$OMP                           z_inter, OBL_depth, BulkRi_1d, zBottomMinusOffset, uE_H, vE_H, &
+  !$OMP                           uS_H, vS_H, uSbar_H, vSbar_H , uS_Hi, vS_Hi, &
+  !$OMP                           uS_SLD, vS_SLD, uS_SLC, vS_SLC, uSbar_SLD, vSbar_SLD, &
+  !$OMP                           StokesXI, StokesXI_1d, StokesVt_1d, kbl) &
   !$OMP                           shared(G, GV, CS, US, uStar, h, dz, buoy_scale, buoyFlux, &
   !$OMP                           Temp, Salt, waves, tv, GoRho, GoRho_Z_L2, u, v, lamult)
   do j = G%jsc, G%jec

--- a/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
+++ b/src/parameterizations/vertical/MOM_bulk_mixed_layer.F90
@@ -528,13 +528,15 @@ subroutine bulkmixedlayer(h_3d, u_3d, v_3d, tv, fluxes, dt, ea, eb, G, GV, US, C
         RmixConst = -0.5*CS%rivermix_depth * GV%g_Earth
         do i=is,ie
           TKE_river(i) = max(0.0, RmixConst * dSpV0_dS(i) * &
-                        (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j)) * S(i,1))
+                        (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j) + &
+                         fluxes%lrunoff_glc(i,j) + fluxes%frunoff_glc(i,j)) * S(i,1))
         enddo
       else
         RmixConst = 0.5*CS%rivermix_depth * GV%g_Earth * Irho0**2
         do i=is,ie
           TKE_river(i) = max(0.0, RmixConst*dR0_dS(i)* &
-                        (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j)) * S(i,1))
+                        (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j) + &
+                         fluxes%lrunoff_glc(i,j) + fluxes%frunoff_glc(i,j)) * S(i,1))
         enddo
       endif
     else

--- a/src/parameterizations/vertical/MOM_diabatic_aux.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_aux.F90
@@ -1431,7 +1431,8 @@ subroutine applyBoundaryFluxesInOut(CS, G, GV, US, dt, fluxes, optics, nsw, h, t
               RivermixConst = -0.5*(CS%rivermix_depth*dt) * GV%Rho0 * ( US%L_to_Z**2*GV%g_Earth )
             endif
             cTKE(i,j,k) = cTKE(i,j,k) + max(0.0, RivermixConst*dSV_dS(i,j,1) * &
-                            (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j)) * tv%S(i,j,1))
+                            (fluxes%lrunoff(i,j) + fluxes%frunoff(i,j) + &
+                             fluxes%lrunoff_glc(i,j) + fluxes%frunoff_glc(i,j)) * tv%S(i,j,1))
           endif
 
           ! Update state

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -548,7 +548,7 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
   real, dimension(SZI_(G),SZJB_(G)), &
                    optional, intent(out) :: tauy_bot !< Meridional bottom stress from ocean to
                                                      !! rock [R L Z T-2 ~> Pa]
-  logical,         optional, intent(in)  :: fpmix    ! fpmix along Eulerian shear
+  logical,         optional, intent(in)  :: fpmix !< fpmix along Eulerian shear
   type(wave_parameters_CS), &
                    optional, pointer     :: Waves !< Container for wave/Stokes information
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -31,6 +31,8 @@ use MOM_wave_interface, only : wave_parameters_CS
 use MOM_set_visc,      only : set_v_at_u, set_u_at_v
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 
+use CVMix_kpp,         only : cvmix_kpp_composite_Gshape
+
 implicit none ; private
 
 #include <MOM_memory.h>
@@ -170,9 +172,11 @@ type, public :: vertvisc_CS ; private
   integer :: id_au_vv = -1, id_av_vv = -1, id_au_gl90_vv = -1, id_av_gl90_vv = -1
   integer :: id_du_dt_str = -1, id_dv_dt_str = -1
   integer :: id_h_u = -1, id_h_v = -1, id_hML_u = -1 , id_hML_v = -1
-  integer :: id_FPw2x = -1    !W id_FPhbl_u = -1, id_FPhbl_v = -1
-  integer :: id_tauFP_u = -1, id_tauFP_v = -1  !W,    id_FPtau2x_u = -1, id_FPtau2x_v = -1
-  integer :: id_FPtau2s_u = -1, id_FPtau2s_v = -1, id_FPtau2w_u = -1, id_FPtau2w_v = -1
+  integer :: id_Omega_w2x = -1, id_FPtau2s  = -1 , id_FPtau2w = -1
+  integer :: id_uE_h  = -1, id_vE_h  = -1
+  integer :: id_uStk  = -1, id_vStk  = -1
+  integer :: id_uStk0 = -1, id_vStk0 = -1
+  integer :: id_uInc_h= -1, id_vInc_h= -1
   integer :: id_taux_bot = -1, id_tauy_bot = -1
   integer :: id_Kv_slow = -1, id_Kv_u = -1, id_Kv_v = -1
   integer :: id_Kv_gl90_u = -1, id_Kv_gl90_v = -1
@@ -191,14 +195,14 @@ end type vertvisc_CS
 
 contains
 
-!> Add nonlocal stress increments to u^n (uold) and v^n (vold) using ui and vi.
-subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OBC)
+!> Add nonlocal stress increments to ui^n and vi^n.
+subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, lpost, G, GV, US, CS, OBC, Waves)
   type(ocean_grid_type),   intent(in)    :: G      !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV     !< Ocean vertical grid structure
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
                            intent(inout) :: ui     !< Zonal velocity after vertvisc [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
-                           intent(inout) :: vi      !< Meridional velocity after vertvisc [L T-1 ~> m s-1]
+                           intent(inout) :: vi     !< Meridional velocity after vertvisc [L T-1 ~> m s-1]
   real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)), &
                            intent(inout) :: uold   !< Old Zonal velocity [L T-1 ~> m s-1]
   real, dimension(SZI_(G),SZJB_(G),SZK_(GV)), &
@@ -208,363 +212,198 @@ subroutine vertFPmix(ui, vi, uold, vold, hbl_h, h, forces, dt, G, GV, US, CS, OB
                            intent(in) :: h      !< Layer thicknesses [H ~> m or kg m-2]
   type(mech_forcing),      intent(in) :: forces !< A structure with the driving mechanical forces
   real,                    intent(in) :: dt     !< Time increment [T ~> s]
+  logical,                 intent(in) :: lpost  !< Compute and make available FPMix diagnostics
   type(unit_scale_type),   intent(in) :: US     !< A dimensional unit scaling type
   type(vertvisc_CS),       pointer    :: CS     !< Vertical viscosity control structure
   type(ocean_OBC_type),    pointer    :: OBC    !< Open boundary condition structure
+  type(wave_parameters_CS), &
+                   optional, pointer  :: Waves  !< Container for wave/Stokes information
 
   ! local variables
-  real, dimension(SZIB_(G),SZJ_(G))  :: hbl_u   !< boundary layer depth at u-pts [H ~> m]
-  real, dimension(SZI_(G),SZJB_(G))  :: hbl_v   !< boundary layer depth at v-pts [H ~> m]
-  integer, dimension(SZIB_(G),SZJ_(G)) :: kbl_u !< index of the BLD at u-pts     [nondim]
-  integer, dimension(SZI_(G),SZJB_(G)) :: kbl_v !< index of the BLD at v-pts     [nondim]
-  real, dimension(SZIB_(G),SZJ_(G))  :: ustar2_u !< ustar squared at u-pts   [L2 T-2 ~> m2 s-2]
-  real, dimension(SZI_(G),SZJB_(G))  :: ustar2_v !< ustar squared at v-pts   [L2 T-2 ~> m2 s-2]
-  real, dimension(SZIB_(G),SZJ_(G))  :: taux_u   !< zonal wind stress at u-pts  [R L Z T-2 ~> Pa]
-  real, dimension(SZI_(G),SZJB_(G))  :: tauy_v   !< meridional wind stress at v-pts  [R L Z T-2 ~> Pa]
-  !real, dimension(SZIB_(G),SZJ_(G))  :: omega_w2x_u !< angle between wind and x-axis at u-pts [rad]
-  !real, dimension(SZI_(G),SZJB_(G))  :: omega_w2x_v !< angle between wind and y-axis at v-pts [rad]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: tau_u !< kinematic zonal mtm flux at u-pts [L2 T-2 ~> m2 s-2]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: tau_v !< kinematic mer. mtm flux at v-pts [L2 T-2 ~> m2 s-2]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: tauxDG_u !< downgradient zonal mtm flux at u-pts [L2 T-2 ~> m2 s-2]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: tauyDG_u !< downgradient meri mtm flux at u-pts [L2 T-2 ~> m2 s-2]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: tauxDG_v !< downgradient zonal mtm flux at v-pts [L2 T-2 ~> m2 s-2]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: tauyDG_v !< downgradient meri mtm flux at v-pts [L2 T-2 ~> m2 s-2]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: omega_tau2s_u !< angle between mtm flux and vert shear at u-pts [rad]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: omega_tau2s_v !< angle between mtm flux and vert shear at v-pts [rad]
-  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)+1) :: omega_tau2w_u !< angle between mtm flux and wind at u-pts [rad]
-  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)+1) :: omega_tau2w_v !< angle between mtm flux and wind at v-pts [rad]
+  real, dimension(SZIB_(G),SZJ_(G))  :: hbl_u   !< boundary layer depth (u-pts) [H ~> m]
+  real, dimension(SZI_(G),SZJB_(G))  :: hbl_v   !< boundary layer depth (v-pts) [H ~> m]
+  real, dimension(SZIB_(G),SZJ_(G))  :: taux_u  !< kinematic zonal wind stress (u-pts) [L2 T-2 ~> m2 s-2]
+  real, dimension(SZI_(G),SZJB_(G))  :: tauy_v  !< kinematic merid wind stress (v-pts) [L2 T-2 ~> m2 s-2]
+  real, dimension(SZI_(G),SZJB_(G))  :: uS0     !< surface zonal Stokes drift [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G))  :: vS0     !< surface zonal Stokes drift [L T-1 ~> m s-1]
 
-  real :: pi, Cemp_CG, tmp, cos_tmp, sin_tmp, omega_tmp !< constants and dummy variables
-  real :: du, dv, depth, sigma, Wind_x, Wind_y          !< intermediate variables
-  real :: taux, tauy, tauxDG, tauyDG, tauxDGup, tauyDGup, ustar2, tauh !< intermediate variables
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: uE_u    !< zonal Eulerian u-pts [L T-1 ~> m s-1]
+  real, dimension(SZI_(G) ,SZJ_(G),SZK_(GV)) :: uE_h    !< zonal Eulerian h-pts [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vE_v    !< merid Eulerian v-pts [L T-1 ~> m s-1]
+  real, dimension(SZI_(G) ,SZJ_(G),SZK_(GV)) :: vE_h    !< merid Eulerian h-pts [L T-1 ~> m s-1]
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: uInc_u  !< zonal Eulerian u-pts [L T-1 ~> m s-1]
+  real, dimension(SZI_(G) ,SZJ_(G),SZK_(GV)) :: uInc_h  !< zonal Eulerian h-pts [L T-1 ~> m s-1]
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vInc_v  !< merid Eulerian v-pts [L T-1 ~> m s-1]
+  real, dimension(SZI_(G) ,SZJ_(G),SZK_(GV)) :: vInc_h  !< merid Eulerian h-pts [L T-1 ~> m s-1]
+  real, dimension(SZI_(G) ,SZJ_(G),SZK_(GV)) :: uStk    !< zonal Stokes Drift (h-pts) [L T-1 ~> m s-1]
+  real, dimension(SZI_(G) ,SZJ_(G),SZK_(GV)) :: vStk    !< merid Stokes Drift (h-pts) [L T-1 ~> m s-1]
+
+  real, dimension(SZI_(G) ,SZJ_(G),SZK_(GV)+1) :: omega_tau2s !< angle stress to shear (h-pts) [rad]
+  real, dimension(SZI_(G) ,SZJ_(G),SZK_(GV)+1) :: omega_tau2w !< angle stress to wind  (h-pts) [rad]
+
+  real :: pi, Cemp_NL, tmp_u, tmp_v, omega_tmp, Irho0, fexp      !< constants and dummy variables
+  real :: sigma,Gat1,Gsig,dGdsig                                !< Shape parameters
+  real :: du, dv, depth, Wind_x, Wind_y                         !< intermediate variables
+  real :: taux, tauy, tauxDG, tauyDG, tauxDGup, tauyDGup, ustar2, ustar2min, tauh !< intermediate variables
   real :: tauNLup, tauNLdn, tauNL_CG, tauNL_DG, tauNL_X, tauNL_Y, tau_MAG !< intermediate variables
-  real :: omega_w2s, omega_tau2s, omega_s2x, omega_tau2x, omega_tau2w, omega_s2w !< intermediate angles
-  integer :: kblmin, kbld, kp1, k, nz !< vertical indices
+  real :: omega_w2s, omega_s2x, omega_tau2x, omega_s2w ,  omega_e2x, omega_l2x  !< intermediate angles
+  integer :: b, kbld, kp1, k, nz !< band and vertical indices
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq ! horizontal indices
 
   is = G%isc ; ie = G%iec; js = G%jsc; je = G%jec
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB ; nz = GV%ke
 
   pi = 4. * atan2(1.,1.)
-  Cemp_CG = 3.6
-  kblmin  = 1
-  taux_u(:,:)    = 0.
-  tauy_v(:,:)    = 0.
+  ! empirical coefficient of non-local momentum mixing
+  Cemp_NL = 3.6
+  Irho0 = 1.0 / GV%Rho0
 
+  call pass_var(hbl_h , G%Domain, halo=1)
+
+  ! u-points
   do j = js,je
     do I = Isq,Ieq
-      taux_u(I,j)  = forces%taux(I,j) / GV%H_to_RZ    !W rho0=1035.
+      taux_u(I,j)  = forces%taux(I,j) * Irho0
+      if ( (G%mask2dCu(I,j) > 0.5) ) then
+        ! h to u-pts
+        tmp_u  = MAX (1.0 ,(G%mask2dT(i,j) + G%mask2dT(i+1,j) ) )
+        hbl_u(I,j) = (G%mask2dT(i,j)*  hbl_h(i,j) + G%mask2dT(i+1,j) * hbl_h(i+1,j)) / tmp_u
+      endif
+      depth   = 0.
+      Gat1  = 0.
+      do k=1, nz
+        ! cell center
+        depth = depth + 0.5*CS%h_u(I,j,k)
+        uE_u(I,j,k) = ui(I,j,k) - waves%Us_x(I,j,k)
+        if ( depth < hbl_u(I,j) )     then
+          sigma = depth / hbl_u(i,j)
+          ! cell bottom
+          depth = depth + 0.5*CS%h_u(I,j,k)
+          call cvmix_kpp_composite_Gshape(sigma,Gat1,Gsig,dGdsig)
+          ! nonlocal boundary-layer increment
+          uInc_u(I,j,k)  = dt * Cemp_NL * taux_u(I,j) * dGdsig / hbl_u(I,j)
+          ui(I,j,k) = ui(I,j,k) + uInc_u(I,j,k)
+        else
+          uInc_u(I,j,k) = 0.0
+        endif
+      enddo
     enddo
   enddo
 
+  ! v-points
   do J = Jsq,Jeq
     do i = is,ie
-      tauy_v(i,J)  = forces%tauy(i,J) / GV%H_to_RZ
+      tauy_v(i,J)  = forces%tauy(i,J) * Irho0
+      if ( (G%mask2dCv(i,J) > 0.5) ) then
+        ! h to v-pts
+        tmp_v  = max( 1.0 ,(G%mask2dT(i,j) + G%mask2dT(i,j+1)))
+        hbl_v(i,J) = (G%mask2dT(i,j) * hbl_h(i,J) + G%mask2dT(i,j+1) * hbl_h(i,j+1)) / tmp_v
+      endif
+      depth = 0.
+      Gat1  = 0.
+      do k=1, nz
+        ! cell center
+        depth = depth + 0.5* CS%h_v(i,J,k)
+        vE_v(i,J,k) = vi(i,J,k) - waves%Us_y(i,J,k)
+        if ( depth < hbl_v(i,J) )    then
+          sigma = depth / hbl_v(i,J)
+          ! cell bottom
+          depth = depth + 0.5* CS%h_v(i,J,k)
+          call cvmix_kpp_composite_Gshape(sigma,Gat1,Gsig,dGdsig)
+          ! nonlocal boundary-layer increment
+          vInc_v(i,J,k) = dt * Cemp_NL * tauy_v(i,J) * dGdsig / hbl_v(i,J)
+          vi(i,J,k) = vi(i,J,k) + vInc_v(i,J,k)
+        else
+          vInc_v(i,J,k)  = 0.0
+        endif
+      enddo
     enddo
   enddo
 
-  call pass_var( hbl_h      ,G%Domain, halo=1 )
-  call pass_vector(taux_u , tauy_v, G%Domain, To_All )
-  ustar2_u(:,:)  = 0.
-  ustar2_v(:,:)  = 0.
-  hbl_u(:,:)     = 0.
-  hbl_v(:,:)     = 0.
-  kbl_u(:,:)     = 0
-  kbl_v(:,:)     = 0
-  !omega_w2x_u(:,:) = 0.0
-  !omega_w2x_v(:,:) = 0.0
-  tauxDG_u(:,:,:) = 0.0
-  tauyDG_v(:,:,:) = 0.0
-  do j = js,je
-    do I = Isq,Ieq
-      if( (G%mask2dCu(I,j) > 0.5) ) then
-        tmp  = MAX (1.0 ,(G%mask2dT(i,j)             + G%mask2dT(i+1,j)    ) )
-        hbl_u(I,j)   = (G%mask2dT(i,j)*   hbl_h(i,j) + G%mask2dT(i+1,j) *   hbl_h(i+1,j)) /tmp
-        tmp  = MAX(1.0, (G%mask2dCv(i,j) + G%mask2dCv(i,j-1) + G%mask2dCv(i+1,j) + G%mask2dCv(i+1,j-1) ) )
-        tauy = ( G%mask2dCv(i  ,j  )*tauy_v(i  ,j  ) + G%mask2dCv(i  ,j-1)*tauy_v(i  ,j-1) &
-             +   G%mask2dCv(i+1,j  )*tauy_v(i+1,j  ) + G%mask2dCv(i+1,j-1)*tauy_v(i+1,j-1) ) / tmp
-        ustar2_u(I,j) = sqrt( taux_u(I,j)*taux_u(I,j)  + tauy*tauy )
-        !omega_w2x_u(I,j) = atan2( tauy , taux_u(I,j) )
-        tauxDG_u(I,j,1)  = taux_u(I,j)
+  ! Compute and store diagnostics, only during the corrector step.
+  if (lpost)  then
+    call pass_vector(uE_u  ,  vE_v  , G%Domain, To_All)
+    call pass_vector(uInc_u, vInc_v , G%Domain, To_All)
+    uStk = 0.0
+    vStk = 0.0
+    uS0  = 0.0
+    vS0  = 0.0
+
+    do j = js,je
+      do i = is,ie
+        if (G%mask2dT(i,j) > 0.5)  then
+          ! u to h-pts
+          tmp_u  = max( 1.0 ,(G%mask2dCu(i,j) + G%mask2dCu(i-1,j)))
+          ! v to h-pts
+          tmp_v  = max( 1.0 ,(G%mask2dCv(i,j) + G%mask2dCv(i,j-1)))
+          do k = 1,nz
+            uE_h(i,j,k)   = (G%mask2dCu(i,j) *   uE_u(i,j,k) + G%mask2dCu(i-1,j) *   uE_u(i-1,j,k)) / tmp_u
+            uInc_h(i,j,k) = (G%mask2dCu(i,j) * uInc_u(i,j,k) + G%mask2dCu(i-1,j) * uInc_u(i-1,j,k)) / tmp_u
+            vE_h(i,j,k)   = (G%mask2dCv(i,j) *   vE_v(i,j,k) + G%mask2dCv(i,j-1) *   vE_v(i,j-1,k)) / tmp_v
+            vInc_h(i,j,k) = (G%mask2dCv(i,j) * vInc_v(i,j,k) + G%mask2dCv(i,j-1) * vInc_v(i,j-1,k)) / tmp_v
+          enddo
+          ! Wind, Stress and Shear align at surface
+          Omega_tau2w(i,j,1) = 0.0
+          Omega_tau2s(i,j,1) = 0.0
+          do k = 1,nz
+            kp1 = min( nz , k+1)
+            du = uE_h(i,j,k) - uE_h(i,j,kp1)
+            dv = vE_h(i,j,k) - vE_h(i,j,kp1)
+            omega_s2x = atan2( dv , du )
+
+            du = du + uInc_h(i,j,k) - uInc_h(i,j,kp1)
+            dv = dv + vInc_h(i,j,k) - vInc_h(i,j,kp1)
+            omega_tau2x = atan2( dv , du )
+
+            omega_tmp = omega_tau2x - forces%omega_w2x(i,j)
+            if ( (omega_tmp  >   pi   ) )  omega_tmp = omega_tmp - 2.*pi
+            if ( (omega_tmp  < (0.-pi)) )  omega_tmp = omega_tmp + 2.*pi
+            Omega_tau2w(i,j,kp1) = omega_tmp
+
+            omega_tmp = omega_tau2x - omega_s2x
+            if ( (omega_tmp  >   pi   ) )  omega_tmp = omega_tmp - 2.*pi
+            if ( (omega_tmp  < (0.-pi)) )  omega_tmp = omega_tmp + 2.*pi
+            Omega_tau2s(i,j,kp1) = omega_tmp
+
+          enddo
+        endif
+
+        ! Stokes drift
+        do b=1,waves%NumBands
+          uS0(i,j)  = uS0(i,j) + waves%UStk_Hb(i,j,b)    ! or forces%UStkb(i,j,b)
+          vS0(i,j)  = vS0(i,j) + waves%VStk_Hb(i,j,b)    ! or forces%VStkb(i,j,b)
+        enddo
         depth = 0.0
-        do k = 1, nz
-          depth = depth + CS%h_u(I,j,k)
-          if( (depth >= hbl_u(I,j)) .and. (kbl_u(I,j) == 0 ) .and. (k > (kblmin-1)) ) then
-            kbl_u(I,j)  = k
-            hbl_u(I,j)  = depth
-          endif
+        do k = 1,nz
+          do b  = 1, waves%NumBands
+            ! cell center
+            fexp = exp(-2. * waves%WaveNum_Cen(b) * (depth+0.5*h(i,j,k)) )
+            uStk(i,j,k) = uStk(i,j,k) + waves%UStk_Hb(i,j,b) * fexp
+            vStk(i,j,k) = vStk(i,j,k) + waves%VStk_Hb(i,j,b) * fexp
+          enddo
+          ! cell bottom
+          depth = depth + h(i,j,k)
         enddo
-      endif
-    enddo
-  enddo
-  do J = Jsq,Jeq
-    do i = is,ie
-      if( (G%mask2dCv(i,J) > 0.5) ) then
-        tmp  = max( 1.0 ,(G%mask2dT(i,j) + G%mask2dT(i,j+1)))
-        hbl_v(i,J) = (G%mask2dT(i,j) * hbl_h(i,J) + G%mask2dT(i,j+1) * hbl_h(i,j+1)) /tmp
-        tmp  = max(1.0, (G%mask2dCu(i,j) + G%mask2dCu(i,j+1) + G%mask2dCu(i-1,j) + G%mask2dCu(i-1,j+1)))
-        taux = ( G%mask2dCu(i  ,j) * taux_u(i  ,j) + G%mask2dCu(i  ,j+1) * taux_u(i  ,j+1) &
-             +   G%mask2dCu(i-1,j) * taux_u(i-1,j) + G%mask2dCu(i-1,j+1) * taux_u(i-1,j+1)) / tmp
-        ustar2_v(i,J)  = sqrt(tauy_v(i,J)*tauy_v(i,J) + taux*taux)
-        !omega_w2x_v(i,J) = atan2( tauy_v(i,J), taux )
-        tauyDG_v(i,J,1)  = tauy_v(i,J)
-        depth = 0.0
-        do k = 1, nz
-          depth = depth + CS%h_v(i,J,k)
-          if( (depth >= hbl_v(i,J)) .and. (kbl_v(i,J) == 0) .and. (k > (kblmin-1))) then
-            kbl_v(i,J)  = k
-            hbl_v(i,J)  = depth
-          endif
-        enddo
-      endif
-    enddo
-  enddo
 
-  if (CS%debug) then
-    call uvchksum("surface tau[xy]_[uv] ", taux_u, tauy_v, G%HI, haloshift=1, scalar_pair=.true.)
-    call uvchksum("ustar2", ustar2_u, ustar2_v, G%HI, haloshift=0, scalar_pair=.true.)
-    call uvchksum(" hbl", hbl_u ,   hbl_v , G%HI, haloshift=0, scalar_pair=.true.)
+      enddo
+    enddo
+
+    ! post FPmix diagnostics
+    if (CS%id_uE_h    > 0) call post_data(CS%id_uE_h     , uE_h   , CS%diag)
+    if (CS%id_vE_h    > 0) call post_data(CS%id_vE_h   , vE_h   , CS%diag)
+    if (CS%id_uInc_h  > 0) call post_data(CS%id_uInc_h , uInc_h , CS%diag)
+    if (CS%id_vInc_h  > 0) call post_data(CS%id_vInc_h , vInc_h , CS%diag)
+    if (CS%id_FPtau2s > 0) call post_data(CS%id_FPtau2s, Omega_tau2s, CS%diag)
+    if (CS%id_FPtau2w > 0) call post_data(CS%id_FPtau2w, Omega_tau2w, CS%diag)
+    if (CS%id_uStk0   > 0) call post_data(CS%id_uStk0  , uS0 , CS%diag)
+    if (CS%id_vStk0   > 0) call post_data(CS%id_vStk0  , vS0    , CS%diag)
+    if (CS%id_uStk    > 0) call post_data(CS%id_uStk   , uStk   , CS%diag)
+    if (CS%id_vStk    > 0) call post_data(CS%id_vStk   , vStk   , CS%diag)
+    if (CS%id_Omega_w2x > 0) call post_data(CS%id_Omega_w2x, forces%omega_w2x, CS%diag)
+
   endif
-
-  !   Compute downgradient stresses
-  do k = 1, nz
-    kp1 = min( k+1 , nz)
-    do j =  js   ,je
-      do I = Isq  , Ieq
-        tauxDG_u(I,j,k+1) = CS%a_u(I,j,kp1) * (ui(I,j,k) - ui(I,j,kp1))
-      enddo
-    enddo
-    do J = Jsq  , Jeq
-      do i = is  , ie
-        tauyDG_v(i,J,k+1) = CS%a_v(i,J,kp1) * (vi(i,J,k) - vi(i,J,kp1))
-      enddo
-    enddo
-  enddo
-
-  call pass_vector(tauxDG_u, tauyDG_v , G%Domain, To_All)
-  call pass_vector(ui,vi, G%Domain, To_All)
-  tauxDG_v(:,:,:)   = 0.
-  tauyDG_u(:,:,:)   = 0.
-
-  ! Thickness weighted interpolations
-  do k = 1, nz
-    ! v to u points
-    do j = js , je
-      do I = Isq, Ieq
-        tauyDG_u(I,j,k)   = set_v_at_u(tauyDG_v, h, G, GV, I, j, k, G%mask2dCv, OBC)
-      enddo
-    enddo
-    ! u to v points
-    do J = Jsq, Jeq
-      do i = is, ie
-        tauxDG_v(i,J,k)   = set_u_at_v(tauxDG_u, h, G, GV, i, J, k, G%mask2dCu, OBC)
-      enddo
-    enddo
-  enddo
-  if (CS%debug) then
-    call uvchksum(" tauyDG_u tauxDG_v",tauyDG_u,tauxDG_v, G%HI, haloshift=0, scalar_pair=.true.)
-  endif
-
-  ! compute angles, tau2x_[u,v], tau2w_[u,v], tau2s_[u,v], s2w_[u,v] and stress mag tau_[u,v]
-  omega_tau2w_u(:,:,:) = 0.0
-  omega_tau2w_v(:,:,:) = 0.0
-  omega_tau2s_u(:,:,:) = 0.0
-  omega_tau2s_v(:,:,:) = 0.0
-  tau_u(:,:,:)     = 0.0
-  tau_v(:,:,:)     = 0.0
-
-  ! stress magnitude tau_[uv] & direction Omega_tau2(w,s,x)_[uv]
-  do j = js,je
-    do I = Isq,Ieq
-      if( (G%mask2dCu(I,j) > 0.5) ) then
-        ! SURFACE
-        tauyDG_u(I,j,1) = ustar2_u(I,j) !* cos(omega_w2x_u(I,j))
-        tau_u(I,j,1)    = ustar2_u(I,j)
-        Omega_tau2w_u(I,j,1) =  0.0
-        Omega_tau2s_u(I,j,1) =  0.0
-
-        do k=1,nz
-          kp1 = MIN(k+1 , nz)
-          tau_u(I,j,k+1) = sqrt( tauxDG_u(I,j,k+1)*tauxDG_u(I,j,k+1) + tauyDG_u(I,j,k+1)*tauyDG_u(I,j,k+1))
-          Omega_tau2x  = atan2( tauyDG_u(I,j,k+1) , tauxDG_u(I,j,k+1) )
-          omega_tmp = Omega_tau2x !- omega_w2x_u(I,j)
-          if ( (omega_tmp  >   pi   ) )  omega_tmp = omega_tmp - 2.*pi
-          if ( (omega_tmp  < (0.-pi)) )  omega_tmp = omega_tmp + 2.*pi
-          Omega_tau2w_u(I,j,k+1)   =     omega_tmp
-          Omega_tau2s_u(I,j,k+1) = 0.0
-        enddo
-      endif
-    enddo
-  enddo
-  do J = Jsq, Jeq
-    do i = is, ie
-      if( (G%mask2dCv(i,J) > 0.5) ) then
-        ! SURFACE
-        tauxDG_v(i,J,1) = ustar2_v(i,J) !* sin(omega_w2x_v(i,J))
-        tau_v(i,J,1)    = ustar2_v(i,J)
-        Omega_tau2w_v(i,J,1)   = 0.0
-        Omega_tau2s_v(i,J,1)   = 0.0
-
-        do k=1,nz-1
-          kp1 = MIN(k+1 , nz)
-          tau_v(i,J,k+1) = sqrt ( tauxDG_v(i,J,k+1)*tauxDG_v(i,J,k+1) + tauyDG_v(i,J,k+1)*tauyDG_v(i,J,k+1) )
-          omega_tau2x  =  atan2( tauyDG_v(i,J,k+1) , tauxDG_v(i,J,k+1) )
-          omega_tmp  = omega_tau2x !- omega_w2x_v(i,J)
-          if ( (omega_tmp  >   pi   ) )  omega_tmp = omega_tmp - 2.*pi
-          if ( (omega_tmp  < (0.-pi)) )  omega_tmp = omega_tmp + 2.*pi
-          Omega_tau2w_v(i,J,k+1)   =     omega_tmp
-          Omega_tau2s_v(i,J,k+1) = 0.0
-        enddo
-      endif
-    enddo
-  enddo
-
-  ! Parameterized stress orientation from the wind at interfaces (tau2x)
-  ! and centers (tau2x) OVERWRITE to kbl-interface above hbl
-  do j = js,je
-    do I = Isq,Ieq
-      if( (G%mask2dCu(I,j) > 0.5) ) then
-        kbld  = min( (kbl_u(I,j)) , (nz-2) )
-        if ( tau_u(I,j,kbld+2) > tau_u(I,j,kbld+1) ) kbld = kbld + 1
-
-        tauh  =  tau_u(I,j,kbld+1) + GV%H_subroundoff
-        ! surface boundary conditions
-        depth   = 0.
-        tauNLup = 0.0
-        do k=1, kbld
-          depth = depth + CS%h_u(I,j,k)
-          sigma  = min( 1.0 , depth / hbl_u(i,j) )
-
-          ! linear stress mag
-          tau_MAG   = (ustar2_u(I,j) * (1.-sigma) )  + (tauh * sigma )
-          cos_tmp   = tauxDG_u(I,j,k+1) / (tau_u(I,j,k+1) + GV%H_subroundoff)
-          sin_tmp   = tauyDG_u(I,j,k+1) / (tau_u(I,j,k+1) + GV%H_subroundoff)
-
-          ! rotate to wind coordinates
-          Wind_x    = ustar2_u(I,j) !* cos(omega_w2x_u(I,j))
-          Wind_y    = ustar2_u(I,j) !* sin(omega_w2x_u(I,j))
-          tauNL_DG  = (Wind_x * cos_tmp + Wind_y * sin_tmp)
-          tauNL_CG  = (Wind_y * cos_tmp - Wind_x * sin_tmp)
-          omega_w2s = atan2(tauNL_CG, tauNL_DG)
-          omega_s2w = 0.0-omega_w2s
-          tauNL_CG  = Cemp_CG * G_sig(sigma) * tauNL_CG
-          tau_MAG   = max(tau_MAG, tauNL_CG)
-          tauNL_DG  = sqrt(tau_MAG*tau_MAG - tauNL_CG*tauNL_CG) - tau_u(I,j,k+1)
-
-          ! back to x,y coordinates
-          tauNL_X  = (tauNL_DG * cos_tmp - tauNL_CG * sin_tmp)
-          tauNL_Y  = (tauNL_DG * sin_tmp + tauNL_CG * cos_tmp)
-          tauNLdn  = tauNL_X
-
-          ! nonlocal increment and update to uold
-          du = (tauNLup - tauNLdn) * (dt/CS%h_u(I,j,k) + GV%H_subroundoff)
-          ui(I,j,k)    = uold(I,j,k)  + du
-          uold(I,j,k)  = du
-          tauNLup      = tauNLdn
-
-          ! diagnostics
-          Omega_tau2s_u(I,j,k+1) = atan2(tauNL_CG  , (tau_u(I,j,k+1)+tauNL_DG))
-          tau_u(I,j,k+1)         = sqrt((tauxDG_u(I,j,k+1) + tauNL_X)**2 + (tauyDG_u(I,j,k+1) + tauNL_Y)**2)
-          omega_tau2x            = atan2((tauyDG_u(I,j,k+1) + tauNL_Y), (tauxDG_u(I,j,k+1) + tauNL_X))
-          omega_tau2w            = omega_tau2x !-  omega_w2x_u(I,j)
-          if (omega_tau2w >= pi ) omega_tau2w = omega_tau2w - 2.*pi
-          if (omega_tau2w <= (0.-pi) )  omega_tau2w = omega_tau2w + 2.*pi
-          Omega_tau2w_u(I,j,k+1) = omega_tau2w
-        enddo
-        do k= kbld+1, nz
-          ui(I,j,k)  = uold(I,j,k)
-          uold(I,j,k)  = 0.0
-        enddo
-      endif
-    enddo
-  enddo
-
-  ! v-point dv increment
-  do J = Jsq,Jeq
-    do i = is,ie
-      if( (G%mask2dCv(i,J) > 0.5) ) then
-        kbld  = min((kbl_v(i,J)), (nz-2))
-        if (tau_v(i,J,kbld+2) > tau_v(i,J,kbld+1)) kbld = kbld + 1
-        tauh  = tau_v(i,J,kbld+1)
-
-        !surface boundary conditions
-        depth = 0.
-        tauNLup = 0.0
-        do k=1, kbld
-          depth = depth + CS%h_v(i,J,k)
-          sigma  = min(1.0, depth/ hbl_v(I,J))
-
-          ! linear stress
-          tau_MAG   = (ustar2_v(i,J) * (1.-sigma))  + (tauh * sigma)
-          cos_tmp   = tauxDG_v(i,J,k+1) / (tau_v(i,J,k+1)  + GV%H_subroundoff)
-          sin_tmp   = tauyDG_v(i,J,k+1) / (tau_v(i,J,k+1)  + GV%H_subroundoff)
-
-          ! rotate into wind coordinate
-          Wind_x    = ustar2_v(i,J) !* cos(omega_w2x_v(i,J))
-          Wind_y    = ustar2_v(i,J) !* sin(omega_w2x_v(i,J))
-          tauNL_DG  = (Wind_x * cos_tmp + Wind_y * sin_tmp)
-          tauNL_CG  = (Wind_y * cos_tmp - Wind_x * sin_tmp)
-          omega_w2s = atan2(tauNL_CG , tauNL_DG)
-          omega_s2w = 0.0 - omega_w2s
-          tauNL_CG  = Cemp_CG * G_sig(sigma) * tauNL_CG
-          tau_MAG   = max( tau_MAG , tauNL_CG )
-          tauNL_DG  = 0.0 - tau_v(i,J,k+1) + sqrt(tau_MAG*tau_MAG - tauNL_CG*tauNL_CG)
-
-          ! back to x,y coordinate
-          tauNL_X  = (tauNL_DG * cos_tmp - tauNL_CG * sin_tmp)
-          tauNL_Y  = (tauNL_DG * sin_tmp + tauNL_CG * cos_tmp)
-          tauNLdn  = tauNL_Y
-          dv            = (tauNLup - tauNLdn) * (dt/(CS%h_v(i,J,k)) )
-          vi(i,J,k)    = vold(i,J,k) + dv
-          vold(i,J,k)  = dv
-          tauNLup       = tauNLdn
-
-          ! diagnostics
-          Omega_tau2s_v(i,J,k+1) = atan2(tauNL_CG, tau_v(i,J,k+1) + tauNL_DG)
-          tau_v(i,J,k+1)         = sqrt((tauxDG_v(i,J,k+1) + tauNL_X)**2 + (tauyDG_v(i,J,k+1) + tauNL_Y)**2)
-          !omega_tau2x            = atan2((tauyDG_v(i,J,k+1) + tauNL_Y) , (tauxDG_v(i,J,k+1) + tauNL_X))
-          !omega_tau2w            = omega_tau2x - omega_w2x_v(i,J)
-          if (omega_tau2w > pi)  omega_tau2w = omega_tau2w - 2.*pi
-          if (omega_tau2w .le. (0.-pi) )  omega_tau2w = omega_tau2w + 2.*pi
-          Omega_tau2w_v(i,J,k+1) = omega_tau2w
-        enddo
-
-        do k= kbld+1, nz
-          vi(i,J,k)    = vold(i,J,k)
-          vold(i,J,k)  = 0.0
-        enddo
-      endif
-    enddo
-  enddo
-
-  if (CS%debug) then
-    call uvchksum("FP-tau_[uv]  ", tau_u, tau_v, G%HI, haloshift=0, scalar_pair=.true.)
-  endif
-
-  if (CS%id_tauFP_u > 0)   call post_data(CS%id_tauFP_u, tau_u, CS%diag)
-  if (CS%id_tauFP_v > 0)   call post_data(CS%id_tauFP_v, tau_v, CS%diag)
-  if (CS%id_FPtau2s_u > 0) call post_data(CS%id_FPtau2s_u, omega_tau2s_u, CS%diag)
-  if (CS%id_FPtau2s_v > 0) call post_data(CS%id_FPtau2s_v, omega_tau2s_v, CS%diag)
-  if (CS%id_FPtau2w_u > 0) call post_data(CS%id_FPtau2w_u, omega_tau2w_u, CS%diag)
-  if (CS%id_FPtau2w_v > 0) call post_data(CS%id_FPtau2w_v, omega_tau2w_v, CS%diag)
-  !if (CS%id_FPw2x   > 0)   call post_data(CS%id_FPw2x, forces%omega_w2x , CS%diag)
 
 end subroutine vertFPmix
-
-!> Returns the empirical shape-function given sigma.
-real function G_sig(sigma)
-  real , intent(in) :: sigma   !< non-dimensional normalized boundary layer depth [m]
-
-  ! local variables
-  real :: p1, c2, c3  !< parameters used to fit and match empirycal shape-functions.
-
-  ! parabola
-  p1 = 0.287
-  ! cubic function
-  c2 = 1.74392
-  c3 = 2.58538
-  G_sig  = min( p1 * (1.-sigma)*(1.-sigma) , sigma * (1. + sigma * (c2*sigma - c3) ) )
-end function G_sig
 
 !> Compute coupling coefficient associated with vertical viscosity parameterization as in Greatbatch and Lamb
 !! (1990), hereafter referred to as the GL90 vertical viscosity parameterization. This vertical viscosity scheme
@@ -690,7 +529,7 @@ end subroutine find_coupling_coef_gl90
 !! if DIRECT_STRESS is true, applied to the surface layer.
 
 subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
-                    taux_bot, tauy_bot, Waves)
+                    taux_bot, tauy_bot, fpmix, Waves)
   type(ocean_grid_type),   intent(in)    :: G      !< Ocean grid structure
   type(verticalGrid_type), intent(in)    :: GV     !< Ocean vertical grid structure
   type(unit_scale_type),   intent(in)    :: US     !< A dimensional unit scaling type
@@ -714,6 +553,7 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
   real, dimension(SZI_(G),SZJB_(G)), &
                    optional, intent(out) :: tauy_bot !< Meridional bottom stress from ocean to
                                                      !! rock [R L Z T-2 ~> Pa]
+  logical,         optional, intent(in)  :: fpmix    ! fpmix along Eulerian shear
   type(wave_parameters_CS), &
                    optional, pointer     :: Waves !< Container for wave/Stokes information
 
@@ -754,6 +594,7 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
 
   logical :: do_i(SZIB_(G))
   logical :: DoStokesMixing
+  logical :: lfpmix
 
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz, n
   is = G%isc ; ie = G%iec; js = G%jsc; je = G%jec
@@ -791,6 +632,8 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
       call MOM_error(FATAL,"Stokes Mixing called without allocated"//&
                      "Waves Control Structure")
   endif
+  lfpmix = .false.
+  if ( present(fpmix) ) lfpmix = fpmix
 
   do k=1,nz ; do i=Isq,Ieq ; Ray(i,k) = 0.0 ; enddo ; enddo
 
@@ -806,6 +649,10 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
     ! When mixing down Eulerian current + Stokes drift add before calling solver
     if (DoStokesMixing) then ; do k=1,nz ; do I=Isq,Ieq
       if (do_i(I)) u(I,j,k) = u(I,j,k) + Waves%Us_x(I,j,k)
+    enddo ; enddo ; endif
+
+    if ( lfpmix  ) then ;  do k=1,nz ; do I=Isq,Ieq
+      if (do_i(I)) u(I,j,k) = u(I,j,k) - Waves%Us_x(I,j,k)
     enddo ; enddo ; endif
 
     if (associated(ADp%du_dt_visc)) then ; do k=1,nz ; do I=Isq,Ieq
@@ -965,6 +812,10 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
       if (do_i(I)) u(I,j,k) = u(I,j,k) - Waves%Us_x(I,j,k)
     enddo ; enddo ; endif
 
+    if ( lfpmix ) then ; do k=1,nz ; do I=Isq,Ieq
+      if (do_i(I)) u(I,j,k) = u(I,j,k) + Waves%Us_x(I,j,k)
+    enddo ; enddo ; endif
+
   enddo ! end u-component j loop
 
   ! Now work on the meridional velocity component.
@@ -978,6 +829,10 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
     ! When mixing down Eulerian current + Stokes drift add before calling solver
     if (DoStokesMixing) then ; do k=1,nz ; do i=is,ie
       if (do_i(i)) v(i,j,k) = v(i,j,k) + Waves%Us_y(i,j,k)
+    enddo ; enddo ; endif
+
+    if ( lfpmix ) then ; do k=1,nz ; do i=is,ie
+      if (do_i(i)) v(i,j,k) = v(i,j,k) - Waves%Us_y(i,j,k)
     enddo ; enddo ; endif
 
     if (associated(ADp%dv_dt_visc)) then ; do k=1,nz ; do i=is,ie
@@ -1106,6 +961,10 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
     ! When mixing down Eulerian current + Stokes drift subtract after calling solver
     if (DoStokesMixing) then ; do k=1,nz ; do i=is,ie
       if (do_i(i)) v(i,J,k) = v(i,J,k) - Waves%Us_y(i,J,k)
+    enddo ; enddo ; endif
+
+    if ( lfpmix )  then ; do k=1,nz ; do i=is,ie
+      if (do_i(i)) v(i,J,k) = v(i,J,k) + Waves%Us_y(i,J,k)
     enddo ; enddo ; endif
 
   enddo ! end of v-component J loop
@@ -2607,7 +2466,7 @@ end subroutine vertvisc_limit_vel
 
 !> Initialize the vertical friction module
 subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
-                         ntrunc, CS)
+                          ntrunc, CS, fpmix)
   type(ocean_internal_state), &
                    target, intent(in)    :: MIS    !< The "MOM Internal State", a set of pointers
                                                    !! to the fields and accelerations that make
@@ -2622,6 +2481,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
   type(directories),       intent(in)    :: dirs   !< Relevant directory paths
   integer, target,         intent(inout) :: ntrunc !< Number of velocity truncations
   type(vertvisc_CS),       pointer       :: CS     !< Vertical viscosity control structure
+  logical, optional,       intent(in)    :: fpmix  !< Nonlocal momentum mixing
 
   ! Local variables
 
@@ -2629,6 +2489,7 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
   real :: Kv_back_z  ! A background kinematic viscosity [Z2 T-1 ~> m2 s-1]
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags.
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, nz
+  logical :: lfpmix
   character(len=200) :: kappa_gl90_file, inputdir, kdgl90_varname
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -2652,6 +2513,9 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
 
   CS%diag => diag ; CS%ntrunc => ntrunc ; ntrunc = 0
+
+  lfpmix = .false.
+  if (present(fpmix)) lfpmix = fpmix
 
 ! Default, read and log parameters
   call log_version(param_file, mdl, version, "", log_to_all=.true., debugging=.true.)
@@ -2955,20 +2819,29 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
       'Mixed Layer Thickness at Meridional Velocity Points for Viscosity', &
       thickness_units, conversion=US%Z_to_m)
 
-  CS%id_FPw2x   = register_diag_field('ocean_model', 'FPw2x', diag%axesT1, Time, &
-      'Wind direction from x-axis','radians')
-  CS%id_tauFP_u = register_diag_field('ocean_model', 'tauFP_u', diag%axesCui, Time, &
-      'Stress Mag Profile  (u-points)', 'm2 s-2')
-  CS%id_tauFP_v = register_diag_field('ocean_model', 'tauFP_v', diag%axesCvi, Time, &
-      'Stress Mag Profile  (v-points)', 'm2 s-2')
-  CS%id_FPtau2s_u = register_diag_field('ocean_model', 'FPtau2s_u', diag%axesCui, Time, &
-      'stress from shear direction (u-points)', 'radians ')
-  CS%id_FPtau2s_v = register_diag_field('ocean_model', 'FPtau2s_v', diag%axesCvi, Time, &
-      'stress from shear direction (v-points)', 'radians')
-  CS%id_FPtau2w_u = register_diag_field('ocean_model', 'FPtau2w_u', diag%axesCui, Time, &
-      'stress from wind  direction (u-points)', 'radians')
-  CS%id_FPtau2w_v = register_diag_field('ocean_model', 'FPtau2w_v', diag%axesCvi, Time, &
-      'stress from wind  direction (v-points)', 'radians')
+ if (lfpmix) then
+  CS%id_uE_h = register_diag_field('ocean_model', 'uE_h' , CS%diag%axesTL, &
+      Time, 'x-zonal Eulerian' , 'm s-1', conversion=US%L_T_to_m_s)
+  CS%id_vE_h = register_diag_field('ocean_model', 'vE_h' , CS%diag%axesTL, &
+      Time, 'y-merid Eulerian' , 'm s-1', conversion=US%L_T_to_m_s)
+  CS%id_uInc_h = register_diag_field('ocean_model','uInc_h',CS%diag%axesTL, &
+      Time, 'x-zonal Eulerian' , 'm s-1', conversion=US%L_T_to_m_s)
+  CS%id_vInc_h = register_diag_field('ocean_model','vInc_h',CS%diag%axesTL, &
+      Time, 'x-zonal Eulerian' , 'm s-1', conversion=US%L_T_to_m_s)
+  CS%id_uStk = register_diag_field('ocean_model', 'uStk' , CS%diag%axesTL, &
+      Time, 'x-FP du increment' , 'm s-1', conversion=US%L_T_to_m_s)
+  CS%id_vStk = register_diag_field('ocean_model', 'vStk' , CS%diag%axesTL, &
+      Time, 'y-FP dv increment' , 'm s-1', conversion=US%L_T_to_m_s)
+
+  CS%id_FPtau2s = register_diag_field('ocean_model','Omega_tau2s',CS%diag%axesTi, &
+      Time, 'Stress direction from shear','radians')
+  CS%id_FPtau2w = register_diag_field('ocean_model','Omega_tau2w',CS%diag%axesTi, &
+      Time, 'Stress direction from wind','radians')
+  CS%id_uStk0 = register_diag_field('ocean_model', 'uStk0' , diag%axesT1, &
+      Time, 'Zonal Surface Stokes', 'm s-1', conversion=US%L_T_to_m_s)
+  CS%id_vStk0 = register_diag_field('ocean_model', 'vStk0' , diag%axesT1, &
+      Time, 'Merid Surface Stokes', 'm s-1', conversion=US%L_T_to_m_s)
+  endif
 
   CS%id_du_dt_visc = register_diag_field('ocean_model', 'du_dt_visc', diag%axesCuL, Time, &
       'Zonal Acceleration from Vertical Viscosity', 'm s-2', conversion=US%L_T2_to_m_s2)

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -646,6 +646,8 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
   do j=G%jsc,G%jec
     do I=Isq,Ieq ; do_i(I) = (G%mask2dCu(I,j) > 0.0) ; enddo
 
+    ! WGL: Brandon Reichl says the following is obsolete. u(I,j,k) already
+    ! includes Stokes.
     ! When mixing down Eulerian current + Stokes drift add before calling solver
     if (DoStokesMixing) then ; do k=1,nz ; do I=Isq,Ieq
       if (do_i(I)) u(I,j,k) = u(I,j,k) + Waves%Us_x(I,j,k)

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -1257,12 +1257,12 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
   real,          optional, intent(in) :: minimum_forcing_depth !< The smallest depth over which
                                               !! fluxes can be applied [m]
 
-! Local variables
+  ! Local variables
   character(len=256) :: log_message
-  real, dimension(SZI_(G),SZJ_(G)) :: net_salt_rate  !< Surface salt flux into the ocean
-                                                     !! [S H T-1 ~> ppt m s-1 or ppt kg m-2 s-1].
-  real, dimension(SZI_(G),SZJ_(G)) :: flux_from_salt_flux !< Surface tracer flux from salt flux
-                                                     !! [conc Z T-1 ~> conc m s-1].
+  real, dimension(SZI_(G),SZJ_(G)) :: net_salt_rate  ! Surface salt flux into the ocean
+                                                     ! [S H T-1 ~> ppt m s-1 or ppt kg m-2 s-1].
+  real, dimension(SZI_(G),SZJ_(G)) :: flux_from_salt_flux ! Surface tracer flux from salt flux
+                                                          ! [conc Z T-1 ~> conc m s-1].
   real, dimension(SZI_(G),SZJ_(G)) :: ref_mask ! Mask for 2D MARBL diags using ref_depth
   real, dimension(SZI_(G),SZJ_(G)) :: riv_flux_loc ! Local copy of CS%RIV_FLUXES*dt
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)) :: h_work ! Used so that h can be modified
@@ -2010,7 +2010,7 @@ function MARBL_tracers_stock(h, stocks, G, GV, CS, names, units, stock_index)
   integer                                              :: MARBL_tracers_stock   !< Return value: the number of stocks
                                                                                 !! calculated here.
 
-! Local variables
+  ! Local variables
   integer :: i, j, k, is, ie, js, je, nz, m
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -715,7 +715,7 @@ subroutine Update_Surface_Waves(G, GV, US, Time_present, dt, CS, forces)
       enddo
       do jj=G%jsc,G%jec
         do ii=G%isc,G%iec
-          !CS%Omega_w2x(ii,jj)   = forces%omega_w2x(ii,jj)
+          CS%Omega_w2x(ii,jj)   = forces%omega_w2x(ii,jj)
           do b=1,CS%NumBands
             CS%UStk_Hb(ii,jj,b) = US%m_s_to_L_T*forces%UStkb(ii,jj,b)
             CS%VStk_Hb(ii,jj,b) = US%m_s_to_L_T*forces%VStkb(ii,jj,b)


### PR DESCRIPTION
This PR revises the formulation of the legacy K-profile parameterization (KPP) ocean boundary layer scheme. It incorporates:

1.  a non-local momentum flux—the Flux-profile parameterization (`FPMIX`); when the local shear is not aligned with the wind, this scheme adds a non-local momentum flux in the direction of the wind; and 
2.  mixing with and without waves following the Monin-Obukhov Similarity Theory expanded to include Stokes drift (`STOKES_MOST`). This option provides the transition from waveless to ocean surface waves in any stage of growth or decay.

**Summary:**

* Uncomment omega w2x entries;
* Simplify the nonlocal increments in `vertFPMix`;
* In the call to `CVmix_kpp_compute_unresolved_shear`, passes the 2D surface buoyancy flux (`surfBuoyFlux2`) instead of the 1D version (`surfBuoyFlux`), which is preferable. **This is answer changing**;
* Remove `uold` and `vold` diagnostics. These were used in an alternative time-stepping scheme that is now obsolete; 
* Pass boundary layer depths to the RK2 and add consistency check to make sure `FPMix` is always used with `SPLIT`;
* Add the capability to mix down the Eulerian gradient instead of the Lagrangian;
* Make a minimum set of `FPMix` diagnostics available.

This PR relies on https://github.com/CVMix/CVMix-src/pull/94/. 

New diagnostics:
```

"StokesXI"  
    ! modules: {ocean_model,ocean_model_d2}
    ! long_name: Stokes Similarity Parameter
    ! units: nondim
    ! cell_methods: xh:mean yh:mean area:mean

"Lam2"  
    ! modules: {ocean_model,ocean_model_d2}
    ! long_name: Ustk0_ustar
    ! units: nondim
    ! cell_methods: xh:mean yh:mean area:mean

"uE_h" 
    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
    ! long_name: x-zonal Eulerian
    ! units: m s-1
    ! cell_methods: xh:mean yh:mean zl:mean area:mean
    ! variants: {uE_h,uE_h_xyave}

"vE_h" 
    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
    ! long_name: y-merid Eulerian
    ! units: m s-1
    ! cell_methods: xh:mean yh:mean zl:mean area:mean
    ! variants: {vE_h,vE_h_xyave}

"uInc_h"  
    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
    ! long_name: x-zonal Eulerian
    ! units: m s-1
    ! cell_methods: xh:mean yh:mean zl:mean area:mean
    ! variants: {uInc_h,uInc_h_xyave}

"vInc_h"  
    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
    ! long_name: x-zonal Eulerian
    ! units: m s-1
    ! cell_methods: xh:mean yh:mean zl:mean area:mean
    ! variants: {vInc_h,vInc_h_xyave}

"uStk" 
    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
    ! long_name: x-FP du increment
    ! units: m s-1
    ! cell_methods: xh:mean yh:mean zl:mean area:mean
    ! variants: {uStk,uStk_xyave}

"vStk"  
    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
    ! long_name: y-FP dv increment
    ! units: m s-1
    ! cell_methods: xh:mean yh:mean zl:mean area:mean
    ! variants: {vStk,vStk_xyave}

"Omega_tau2s" 
    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
    ! long_name: Stress direction from shear
    ! units: radians
    ! cell_methods: xh:mean yh:mean zi:point area:mean
    ! variants: {Omega_tau2s,Omega_tau2s_xyave}

"Omega_tau2w"  
    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
    ! long_name: Stress direction from wind
    ! units: radians
    ! cell_methods: xh:mean yh:mean zi:point area:mean
    ! variants: {Omega_tau2w,Omega_tau2w_xyave}

"uStk0"  
    ! modules: {ocean_model,ocean_model_d2}
    ! long_name: Zonal Surface Stokes
    ! units: m s-1
    ! cell_methods: xh:mean yh:mean area:mean

"vStk0"  
    ! modules: {ocean_model,ocean_model_d2}
    ! long_name: Merid Surface Stokes
    ! units: m s-1
    ! cell_methods: xh:mean yh:mean area:mean
```
