### PR TITLE
Avoid kbl > GV%ke in StokesMOST

### DIFF
--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1376,7 +1376,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
       CS%OBLdepth(i,j) = US%m_to_Z * KPP_OBL_depth
 
     if (CS%StokesMOST) then
-      kbl = nint(CS%kOBL(i,j))
+      kbl = min(nint(CS%kOBL(i,j)), GV%ke)
       SLdepth_0d = CS%surf_layer_ext*CS%OBLdepth(i,j)
       surfBuoyFlux = surfBuoyFlux2(kbl)
         ! find ksfc for cell where "surface layer" sits


### PR DESCRIPTION
The calculation of kbl in StokesMOST could be > GV%ke. This patch avoids this issue.