### PR TITLE
Add support for running MARBL with ladjust_bury_coeff = .true.

### DIFF
--- a/config_src/external/MARBL/marbl_interface.F90
+++ b/config_src/external/MARBL/marbl_interface.F90
@@ -9,6 +9,7 @@ module marbl_interface
     use marbl_interface_public_types, only : marbl_diagnostics_type
     use marbl_interface_public_types, only : marbl_domain_type
     use marbl_interface_public_types, only : marbl_output_for_GCM_type
+    use marbl_interface_public_types, only : marbl_running_mean_0d_type
     implicit none
     private ! Only want marbl_interface_class to be public, not supporting functions
 
@@ -33,6 +34,14 @@ module marbl_interface
         real, allocatable :: bot_flux_to_tend(:)      !< dummy array for bot flux to tendency wgts
         real, allocatable :: surface_fluxes(:,:)  !< dummy fluxes
         real, allocatable :: interior_tendencies(:,:)  !< dummy tendencies
+        real, allocatable :: glo_avg_fields_interior_tendency(:)  !< dummy tracer array
+        real, allocatable :: glo_avg_fields_surface_flux(:,:)  !< dummy tracer array
+        real, allocatable :: glo_avg_averages_interior_tendency(:)  !< dummy tracer array
+        real, allocatable :: glo_avg_averages_surface_flux(:)  !< dummy tracer array
+        type(marbl_running_mean_0d_type), allocatable  :: glo_avg_rmean_interior_tendency(:) !< dummy rmean array
+        type(marbl_running_mean_0d_type), allocatable  :: glo_avg_rmean_surface_flux(:) !< dummy rmean array
+        type(marbl_running_mean_0d_type), allocatable  :: glo_scalar_rmean_interior_tendency(:) !< dummy rmean array
+        type(marbl_running_mean_0d_type), allocatable  :: glo_scalar_rmean_surface_flux(:) !< dummy rmean array
        contains
         procedure, public  :: put_setting                !< dummy put_setting routine
         procedure, public  :: get_setting                !< dummy get_setting routine

--- a/config_src/external/MARBL/marbl_interface_public_types.F90
+++ b/config_src/external/MARBL/marbl_interface_public_types.F90
@@ -87,4 +87,10 @@ module marbl_interface_public_types
         type(marbl_single_output_type), dimension(:), pointer :: outputs_for_GCM => NULL()  !< dummy outputs_for_GCM
     end type marbl_output_for_GCM_type
 
+    !> A non-functioning template of MARBL running mean type
+    type, public :: marbl_running_mean_0d_type
+        character(len=0) :: sname  !< dummy shortname label
+        real :: rmean  !< dummy running mean values
+    end type marbl_running_mean_0d_type
+
 end module marbl_interface_public_types

--- a/src/tracer/MARBL_forcing_mod.F90
+++ b/src/tracer/MARBL_forcing_mod.F90
@@ -1,10 +1,8 @@
 !> This module provides a common datatype to provide forcing for MARBL tracers
-!! regardless of driver
+!! regardless of driver from config_src/
 module MARBL_forcing_mod
 
-!! This module exists to house code used by multiple drivers in config_src/
-!! for passing forcing fields to MARBL
-!! (This comment can go in the wiki on the NCAR fork?)
+! This file is part of MOM6. See LICENSE.md for the license.
 
 use MOM_diag_mediator,        only : safe_alloc_ptr, diag_ctrl, register_diag_field, post_data
 use MOM_time_manager,         only : time_type

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -25,7 +25,7 @@ use MOM_open_boundary,   only : ocean_OBC_type
 use MOM_remapping,       only : reintegrate_column
 use MOM_remapping,       only : remapping_CS, initialize_remapping, remapping_core_h
 use MOM_restart,         only : query_initialized, MOM_restart_CS, register_restart_field
-use MOM_spatial_means,   only : global_mass_int_EFP
+use MOM_spatial_means,   only : global_mass_int_EFP, global_area_mean
 use MOM_sponge,          only : set_up_sponge_field, sponge_CS
 use MOM_time_manager,    only : time_type
 use MOM_tracer_registry, only : register_tracer
@@ -1540,6 +1540,10 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
 
   ! Running mean variables
   do m=1,size(CS%glo_scalar_rmean_surface_id)
+    MARBL_instances%glo_avg_averages_surface_flux(m) = global_area_mean( &
+        CS%glo_avg_fields_surface(:,:,m), G)
+    ! TODO: this should actually be running mean
+    MARBL_instances%glo_avg_rmean_surface_flux(m)%rmean = MARBL_instances%glo_avg_averages_surface_flux(m)
     if (CS%glo_scalar_rmean_surface_id(m) > 0) &
       call post_data(CS%glo_scalar_rmean_surface_id(m), &
                      MARBL_instances%glo_scalar_rmean_surface_flux(m)%rmean, CS%diag)
@@ -1882,6 +1886,10 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
 
   ! Running mean variables
   do m=1,size(CS%glo_scalar_rmean_interior_id)
+    MARBL_instances%glo_avg_averages_interior_tendency(m) = global_area_mean( &
+        CS%glo_avg_fields_interior(:,:,m), G)
+    ! TODO: this should actually be running mean
+    MARBL_instances%glo_avg_rmean_interior_tendency(m)%rmean = MARBL_instances%glo_avg_averages_interior_tendency(m)
     if (CS%glo_scalar_rmean_interior_id(m) > 0) &
       call post_data(CS%glo_scalar_rmean_interior_id(m), &
                      MARBL_instances%glo_scalar_rmean_interior_tendency(m)%rmean, CS%diag)

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -304,7 +304,7 @@ subroutine tracer_flow_control_init(restart, day, G, GV, US, h, param_file, diag
                                          intent(in)    :: h       !< Layer thicknesses [H ~> m or kg m-2]
   type(param_file_type),                 intent(in)    :: param_file !< A structure to parse for
                                                                   !! run-time parameters
-  type(diag_ctrl), target,               intent(in)    :: diag    !< A structure that is used to
+  type(diag_ctrl), target,               intent(inout) :: diag    !< A structure that is used to
                                                                   !! regulate diagnostic output.
   type(ocean_OBC_type),                  pointer       :: OBC     !< This open boundary condition
                                                                   !! type specifies whether, where,


### PR DESCRIPTION
We need to tune the burial coefficients by running MARBL with `ladjust_bury_coeff = .true.`. This setting requires some features that were not implemented in the initial MARBL driver: there's a little more data passed back and forth between MARBL and MOM6 to make sure these parameters are computed correctly.

I'll take this out of draft mode and add reviewers when it is ready.