### PR TITLE
Move instance suffix to correct position in restart filenames

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -1930,8 +1930,12 @@ subroutine ModelAdvance(gcomp, rc)
           rpointer_filename = trim(rpointer_filename//timestamp)
         endif
 
-        write(restartname,'(A,".mom6.r",A)') &
-             trim(casename), timestamp
+        if (len_trim(inst_suffix) == 0) then
+          write(restartname,'(A,".mom6.r",A)') trim(casename), timestamp
+        else
+          write(restartname,'(A,".mom6",A,".r",A)') trim(casename), trim(inst_suffix), timestamp
+        endif
+
         call ESMF_LogWrite("MOM_cap: Writing restart :  "//trim(restartname), ESMF_LOGMSG_INFO)
         ! write restart file(s)
         call ocean_model_restart(ocean_state, restartname=restartname, num_rest_files=num_rest_files)
@@ -1943,11 +1947,9 @@ subroutine ModelAdvance(gcomp, rc)
                  msg=subname//' ERROR opening '//rpointer_filename, line=__LINE__, file=u_FILE_u, rcToReturn=rc)
             return
           endif
-          if (len_trim(inst_suffix) == 0) then
-            write(writeunit,'(a)') trim(restartname)//'.nc'
-          else
-            write(writeunit,'(a)') trim(restartname)//'.'//trim(inst_suffix)//'.nc'
-          endif
+
+          ! write the restart file name to rpointer
+          write(writeunit,'(a)') trim(restartname)//'.nc'
 
           if (num_rest_files > 1) then
             ! append i.th restart file name to rpointer

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1410,11 +1410,13 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
   ! Determine if there is a filename_appendix (used for ensemble runs).
   call get_filename_appendix(filename_appendix)
   if (len_trim(filename_appendix) > 0) then
-    length = len_trim(restartname)
-    if (restartname(length-2:length) == '.nc') then
-      restartname = restartname(1:length-3)//'.'//trim(filename_appendix)//'.nc'
-    else
-      restartname = restartname(1:length)  //'.'//trim(filename_appendix)
+    if (index(restartname, trim(filename_appendix)) == 0) then ! appendix not yet added
+      length = len_trim(restartname)
+      if (restartname(length-2:length) == '.nc') then
+        restartname = restartname(1:length-3)//'.'//trim(filename_appendix)//'.nc'
+      else
+        restartname = restartname(1:length)  //'.'//trim(filename_appendix)
+      endif
     endif
   endif
 


### PR DESCRIPTION
This PR partially addresses https://github.com/ESCOMP/MOM_interface/issues/238 by including the instance number in the component name portion of the restart filenames, rather than appending it to the end of the filename.

To prevent re-inserting the instance number in the save_restart subroutine, I added a check to see if the filename already contains the instance suffix. However, this approach isn't very robust: Coincidentally, an existing substring in the filename matching the _000X pattern could be mistakenly interpreted as an existing instance suffix, causing the subroutine to skip adding it even when it should. I'll instead add a more robust check (possibly based on an optional argument.)