### PR TITLE
Add *_glc enthalpy terms in heat_in

### DIFF
--- a/src/diagnostics/MOM_sum_output.F90
+++ b/src/diagnostics/MOM_sum_output.F90
@@ -1089,7 +1089,8 @@ subroutine accumulate_net_input(fluxes, sfc_state, tv, dt, G, US, CS)
         heat_in(i,j) = heat_in(i,j) + dt * QRZL2_to_J * G%areaT(i,j) * &
                        (fluxes%heat_content_evap(i,j) + fluxes%heat_content_lprec(i,j) + &
                         fluxes%heat_content_cond(i,j) + fluxes%heat_content_fprec(i,j) + &
-                        fluxes%heat_content_lrunoff(i,j) + fluxes%heat_content_frunoff(i,j))
+                        fluxes%heat_content_lrunoff(i,j) + fluxes%heat_content_frunoff(i,j) + &
+                        fluxes%heat_content_lrunoff_glc(i,j) + fluxes%heat_content_frunoff_glc(i,j))
       enddo ; enddo
     elseif (associated(tv%TempxPmE)) then
       do j=js,je ; do i=is,ie


### PR DESCRIPTION
The *_glc heat terms were already implemented in MOM6 via [PR #288](https://github.com/NCAR/MOM6/pull/288). However, these terms were not included in the MOM6 "total heat" check in `write_energy`. This PR fixes that oversight by incorporating the *_glc enthalpy terms into `heat_in`.

I verified that this PR does not change the answers for compset `B1850C_LTso`.

Solves #363.