### PR TITLE
Use SST and SSS consistent with MARBL tracers

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -387,7 +387,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   ! vertical integrals, since the related 3-d sums are not negligible in cost.
   call allocate_surface_state(OS%sfc_state, OS%grid, use_temperature, &
                               do_integrals=.true., gas_fields_ocn=gas_fields_ocn, &
-                              use_meltpot=use_melt_pot, use_marbl_tracers=OS%use_MARBL)
+                              use_meltpot=use_melt_pot, use_MARBL_tracers=OS%use_MARBL)
 
   call surface_forcing_init(Time_in, OS%grid, OS%US, param_file, OS%diag, &
                             OS%forcing_CSp, OS%restore_salinity, OS%restore_temp, OS%use_waves)

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -81,7 +81,7 @@ type, public :: surface_forcing_CS ; private
                                 !! pressure limited by max_p_surf instead of the
                                 !! full atmospheric pressure.  The default is true.
   logical :: use_CFC            !< enables the MOM_CFC_cap tracer package.
-  logical :: use_marbl_tracers  !< enables the MARBL tracer package.
+  logical :: use_MARBL_tracers  !< enables the MARBL tracer package.
   logical :: enthalpy_cpl       !< Controls if enthalpy terms are provided by the coupler or computed
                                 !! internally.
   real :: gust_const            !< constant unresolved background gustiness for ustar [R L Z T-2 ~> Pa]
@@ -326,7 +326,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   if (fluxes%dt_buoy_accum < 0) then
     call allocate_forcing_type(G, fluxes, water=.true., heat=.true., ustar=.true., &
                                press=.true., fix_accum_bug=.not.CS%ustar_gustless_bug, &
-                               cfc=CS%use_CFC, marbl=CS%use_marbl_tracers, hevap=CS%enthalpy_cpl, &
+                               cfc=CS%use_CFC, marbl=CS%use_MARBL_tracers, hevap=CS%enthalpy_cpl, &
                                tau_mag=.true., ice_ncat=IOB%ice_ncat)
     call safe_alloc_ptr(fluxes%omega_w2x,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%sw_vis_dir,isd,ied,jsd,jed)
@@ -615,7 +615,7 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
 
   ! Copy MARBL-specific IOB fields into fluxes; also set some MARBL-specific forcings to other values
   ! (constants, values from netCDF, etc)
-  if (CS%use_marbl_tracers) &
+  if (CS%use_MARBL_tracers) &
     call convert_driver_fields_to_forcings(IOB%atm_fine_dust_flux, IOB%atm_coarse_dust_flux, &
                                            IOB%seaice_dust_flux, IOB%atm_bc_flux, IOB%seaice_bc_flux, &
                                            IOB%nhx_dep, IOB%noy_dep, IOB%atm_co2_prog, IOB%atm_co2_diag, &
@@ -1272,7 +1272,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   call get_param(param_file, mdl, "USE_CFC_CAP", CS%use_CFC, &
                  default=.false., do_not_log=.true.)
 
-  call get_param(param_file, mdl, "USE_MARBL_TRACERS", CS%use_marbl_tracers, &
+  call get_param(param_file, mdl, "USE_MARBL_TRACERS", CS%use_MARBL_tracers, &
                  default=.false., do_not_log=.true.)
 
   call get_param(param_file, mdl, "ENTHALPY_FROM_COUPLER", CS%enthalpy_cpl, &
@@ -1483,7 +1483,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
   endif
 
   ! Set up MARBL forcing control structure
-  call MARBL_forcing_init(G, US, param_file, diag, Time, CS%inputdir, CS%use_marbl_tracers, &
+  call MARBL_forcing_init(G, US, param_file, diag, Time, CS%inputdir, CS%use_MARBL_tracers, &
       CS%marbl_forcing_CSp)
 
   if (present(restore_salt)) then ; if (restore_salt) then

--- a/config_src/drivers/solo_driver/MOM_surface_forcing.F90
+++ b/config_src/drivers/solo_driver/MOM_surface_forcing.F90
@@ -116,7 +116,7 @@ type, public :: surface_forcing_CS ; private
                              !! rotationally invariant and more likely to be the same between compilers.
   logical :: ustar_gustless_bug   !< If true, include a bug in the time-averaging of the
                                   !! gustless wind friction velocity.
-  logical :: use_marbl_tracers              !< If true, allocate memory for forcing needed by MARBL
+  logical :: use_MARBL_tracers              !< If true, allocate memory for forcing needed by MARBL
   ! if WIND_CONFIG=='scurves' then use the following to define a piecewise scurve profile
   real :: scurves_ydata(20) = 90. !< Latitudes of scurve nodes [degreesN]
   real :: scurves_taux(20) = 0.   !< Zonal wind stress values at scurve nodes [R L Z T-2 ~> Pa]
@@ -287,7 +287,7 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
     ! Allocate memory for the mechanical and thermodynamic forcing fields.
     call allocate_mech_forcing(G, forces, stress=.true., ustar=.not.CS%nonBous, press=.true., tau_mag=CS%nonBous)
 
-    call allocate_forcing_type(G, fluxes, ustar=.not.CS%nonBous, marbl=CS%use_marbl_tracers, tau_mag=CS%nonBous, &
+    call allocate_forcing_type(G, fluxes, ustar=.not.CS%nonBous, marbl=CS%use_MARBL_tracers, tau_mag=CS%nonBous, &
                                fix_accum_bug=.not.CS%ustar_gustless_bug)
     if (trim(CS%buoy_config) /= "NONE") then
       if ( CS%use_temperature ) then
@@ -384,7 +384,7 @@ subroutine set_forcing(sfc_state, forces, fluxes, day_start, day_interval, G, US
     endif
   endif
 
-  if (CS%use_marbl_tracers) then
+  if (CS%use_MARBL_tracers) then
     call MARBL_forcing_from_data_override(fluxes, day_center, G, US, CS)
   endif
 
@@ -2148,7 +2148,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
     call read_netCDF_data(filename, 'gustiness', CS%gust, G%Domain, &
                           rescale=US%Pa_to_RLZ_T2*US%L_to_Z) ! units in file should be [Pa]
   endif
-  call get_param(param_file, mdl, "USE_MARBL_TRACERS", CS%use_marbl_tracers, &
+  call get_param(param_file, mdl, "USE_MARBL_TRACERS", CS%use_MARBL_tracers, &
                   default=.false., do_not_log=.true.)
 
 !  All parameter settings are now known.
@@ -2181,7 +2181,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, tracer_flow_C
   endif
 
   ! Set up MARBL forcing control structure
-  call MARBL_forcing_init(G, US, param_file, diag, Time, CS%inputdir, CS%use_marbl_tracers, &
+  call MARBL_forcing_init(G, US, param_file, diag, Time, CS%inputdir, CS%use_MARBL_tracers, &
       CS%marbl_forcing_CSp)
 
   call register_forcing_type_diags(Time, diag, US, CS%use_temperature, CS%handles)

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -3524,7 +3524,7 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
 
   if (present(fix_accum_bug)) fluxes%gustless_accum_bug = .not.fix_accum_bug
 
-  !These fields should only be allocated when USE_MARBL is activated.
+  !These fields should only be allocated when USE_MARBL_TRACERS is activated.
   call myAlloc(fluxes%ice_fraction,isd,ied,jsd,jed, marbl)
   call myAlloc(fluxes%u10_sqr,isd,ied,jsd,jed, marbl)
   call myAlloc(fluxes%noy_dep,isd,ied,jsd,jed, marbl)

--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -364,7 +364,7 @@ contains
 !! the ocean model. Unused fields are unallocated.
 subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
                                   gas_fields_ocn, use_meltpot, use_iceshelves, &
-                                  omit_frazil, sfc_state_in, turns, use_marbl_tracers)
+                                  omit_frazil, sfc_state_in, turns, use_MARBL_tracers)
   type(ocean_grid_type), intent(in)    :: G                !< ocean grid structure
   type(surface),         intent(inout) :: sfc_state        !< ocean surface state type to be allocated.
   logical,     optional, intent(in)    :: use_temperature  !< If true, allocate the space for thermodynamic variables.
@@ -390,7 +390,7 @@ subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
                                               !! is present, it is used and tr_fields_in is ignored.
   integer,     optional, intent(in)    :: turns  !< If present, the number of counterclockwise quarter
                                                  !! turns to use on the new grid.
-  logical,     optional, intent(in)    :: use_marbl_tracers  !< If true, allocate the space for CO2 flux from MARBL
+  logical,     optional, intent(in)    :: use_MARBL_tracers  !< If true, allocate the space for CO2 flux from MARBL
 
   ! local variables
   logical :: use_temp, alloc_integ, use_melt_potential, alloc_iceshelves, alloc_frazil, alloc_fco2
@@ -408,7 +408,7 @@ subroutine allocate_surface_state(sfc_state, G, use_temperature, do_integrals, &
   use_melt_potential = .false. ; if (present(use_meltpot)) use_melt_potential = use_meltpot
   alloc_iceshelves = .false. ; if (present(use_iceshelves)) alloc_iceshelves = use_iceshelves
   alloc_frazil = .true. ; if (present(omit_frazil)) alloc_frazil = .not.omit_frazil
-  alloc_fco2 = .false. ; if (present(use_marbl_tracers)) alloc_fco2 = use_marbl_tracers
+  alloc_fco2 = .false. ; if (present(use_MARBL_tracers)) alloc_fco2 = use_MARBL_tracers
 
   if (sfc_state%arrays_allocated) return
 

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -67,7 +67,7 @@ use MOM_set_diffusivity,     only : set_diffusivity_CS
 use MOM_sponge,              only : apply_sponge, sponge_CS
 use MOM_ALE_sponge,          only : apply_ALE_sponge, ALE_sponge_CS
 use MOM_time_manager,        only : time_type, real_to_time, operator(-), operator(<=)
-use MOM_tracer_flow_control, only : call_tracer_column_fns, tracer_flow_control_CS
+use MOM_tracer_flow_control, only : call_tracer_column_fns, tracer_flow_control_CS, extract_tracer_flow_member
 use MOM_tracer_diabatic,     only : tracer_vertdiff, tracer_vertdiff_Eulerian
 use MOM_unit_scaling,        only : unit_scale_type
 use MOM_variables,           only : thermo_var_ptrs, vertvisc_type, accel_diag_ptrs
@@ -182,6 +182,10 @@ type, public :: diabatic_CS ; private
                                      !! MLD calculation [Z ~> m].
   logical :: Use_KdWork_diag = .false.  !< Logical flag to indicate if any Kd_work diagnostics are on.
   logical :: Use_N2_diag = .false.   !< Logical flag to indicate if any N2 diagnostics are on.
+
+  ! MARBL needs T & S from before the tracer_vertdiff call
+  real, allocatable, dimension(:,:,:) :: prediabatic_T  !< Temperature prior to calling diabatic driver [C ~> degC]
+  real, allocatable, dimension(:,:,:) :: prediabatic_S  !< Salinity prior to calling diabatic driver [S ~> ppt]
 
   !>@{ Diagnostic IDs
   integer :: id_ea       = -1, id_eb       = -1 ! used by layer diabatic
@@ -1346,6 +1350,11 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
   Kd_heat(:,:,:) = 0.0 ; Kd_salt(:,:,:) = 0.0
   ent_s(:,:,:) = 0.0 ; ent_t(:,:,:) = 0.0
 
+  if (allocated(CS%prediabatic_T)) &
+    CS%prediabatic_T(:,:,:) = tv%T(:,:,:)
+  if (allocated(CS%prediabatic_S)) &
+    CS%prediabatic_S(:,:,:) = tv%S(:,:,:)
+
   showCallTree = callTree_showQuery()
   if (showCallTree) call callTree_enter("diabatic_ALE(), MOM_diabatic_driver.F90")
 
@@ -1818,7 +1827,8 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
                               KPP_CSp=CS%KPP_CSp, &
                               nonLocalTrans=KPP_NLTscalar, &
                               evap_CFL_limit=CS%evap_CFL_limit, &
-                              minimum_forcing_depth=CS%minimum_forcing_depth, h_BL=visc%h_ML)
+                              minimum_forcing_depth=CS%minimum_forcing_depth, h_BL=visc%h_ML, &
+                              prediabatic_T=CS%prediabatic_T, prediabatic_S=CS%prediabatic_S)
 
   call cpu_clock_end(id_clock_tracers)
 
@@ -3227,7 +3237,7 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
 
   ! Local variables
   real    :: Kd  ! A diffusivity used in the default for other tracer diffusivities [Z2 T-1 ~> m2 s-1]
-  logical :: use_temperature
+  logical :: use_temperature, use_MARBL_tracers
   character(len=20) :: EN1, EN2, EN3
 
   ! This "include" declares and sets the variable "version".
@@ -3246,7 +3256,12 @@ subroutine diabatic_driver_init(Time, G, GV, US, param_file, useALEalgorithm, di
   CS%diag => diag
   CS%Time => Time
 
-  if (associated(tracer_flow_CSp)) CS%tracer_flow_CSp => tracer_flow_CSp
+  if (associated(tracer_flow_CSp)) then
+    CS%tracer_flow_CSp => tracer_flow_CSp
+    call extract_tracer_flow_member(tracer_flow_CSp, use_MARBL_tracers=use_MARBL_tracers)
+    if (use_MARBL_tracers) &
+      allocate(CS%prediabatic_T(SZI_(G),SZJ_(G), SZK_(G)), CS%prediabatic_S(SZI_(G),SZJ_(G), SZK_(G)))
+  end if
   if (associated(sponge_CSp))      CS%sponge_CSp      => sponge_CSp
   if (associated(ALE_sponge_CSp))  CS%ALE_sponge_CSp  => ALE_sponge_CSp
   if (associated(oda_incupd_CSp))  CS%oda_incupd_CSp  => oda_incupd_CSp
@@ -3841,6 +3856,9 @@ subroutine diabatic_driver_end(CS)
     call opacity_end(CS%opacity, CS%optics)
     deallocate(CS%optics)
   endif
+
+  if (allocated(CS%prediabatic_T)) deallocate(CS%prediabatic_T)
+  if (allocated(CS%prediabatic_S)) deallocate(CS%prediabatic_S)
 
   if (CS%debug_energy_req) &
     call diapyc_energy_req_end(CS%diapyc_en_rec_CSp)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -641,6 +641,22 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
   showCallTree = callTree_showQuery()
   if (showCallTree) call callTree_enter("diabatic_ALE_legacy(), MOM_diabatic_driver.F90")
 
+  ! Some tracer packages require T & S from the beginning of the diabatic step to
+  ! provide forcing consistent with the passive tracer values. The initialization
+  ! routine will allocate prediabatic_T and prediabatic_S if the tracer flow control
+  ! structure indicates it is necessary. If these arrays are allocated, they will store
+  ! a copy of tv%T & tv%S before this subroutine modifies the tv structure.
+  if (allocated(CS%prediabatic_T)) then
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      CS%prediabatic_T(i,j,k) = tv%T(i,j,k)
+    enddo ; enddo ; enddo
+  endif
+  if (allocated(CS%prediabatic_S)) then
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      CS%prediabatic_S(i,j,k) = tv%S(i,j,k)
+    enddo ; enddo ; enddo
+  endif
+
   ! For all other diabatic subroutines, the averaging window should be the entire diabatic timestep
   call enable_averages(dt, Time_end, CS%diag)
 
@@ -1196,7 +1212,8 @@ subroutine diabatic_ALE_legacy(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Tim
                               KPP_CSp=CS%KPP_CSp, &
                               nonLocalTrans=KPP_NLTscalar, &
                               evap_CFL_limit=CS%evap_CFL_limit, &
-                              minimum_forcing_depth=CS%minimum_forcing_depth, h_BL=visc%h_ML)
+                              minimum_forcing_depth=CS%minimum_forcing_depth, h_BL=visc%h_ML, &
+                              prediabatic_T=CS%prediabatic_T, prediabatic_S=CS%prediabatic_S)
 
   call cpu_clock_end(id_clock_tracers)
 
@@ -1350,21 +1367,27 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
   Kd_heat(:,:,:) = 0.0 ; Kd_salt(:,:,:) = 0.0
   ent_s(:,:,:) = 0.0 ; ent_t(:,:,:) = 0.0
 
-  ! Some tracer packages require T & S from the beginning of the diabatic step to
-  ! provide forcing consistent with the passive tracer values. The initialization
-  ! routine will allocate prediabatic_T and prediabatic_S if the tracer flow control
-  ! structure indicates it is necessary. If these arrays are allocated, they will store
-  ! a copy of tv%T & tv%S before this subroutine modifies the tv structure.
-  if (allocated(CS%prediabatic_T)) &
-    CS%prediabatic_T(:,:,:) = tv%T(:,:,:)
-  if (allocated(CS%prediabatic_S)) &
-    CS%prediabatic_S(:,:,:) = tv%S(:,:,:)
-
   showCallTree = callTree_showQuery()
   if (showCallTree) call callTree_enter("diabatic_ALE(), MOM_diabatic_driver.F90")
 
   if (.not. (CS%useALEalgorithm)) call MOM_error(FATAL, "MOM_diabatic_driver: "// &
          "The ALE algorithm must be enabled when using MOM_diabatic_driver.")
+
+  ! Some tracer packages require T & S from the beginning of the diabatic step to
+  ! provide forcing consistent with the passive tracer values. The initialization
+  ! routine will allocate prediabatic_T and prediabatic_S if the tracer flow control
+  ! structure indicates it is necessary. If these arrays are allocated, they will store
+  ! a copy of tv%T & tv%S before this subroutine modifies the tv structure.
+  if (allocated(CS%prediabatic_T)) then
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      CS%prediabatic_T(i,j,k) = tv%T(i,j,k)
+    enddo ; enddo ; enddo
+  endif
+  if (allocated(CS%prediabatic_S)) then
+    do k=1,nz ; do j=js,je ; do i=is,ie
+      CS%prediabatic_S(i,j,k) = tv%S(i,j,k)
+    enddo ; enddo ; enddo
+  endif
 
   ! For all other diabatic subroutines, the averaging window should be the entire diabatic timestep
   call enable_averages(dt, Time_end, CS%diag)

--- a/src/parameterizations/vertical/MOM_diabatic_driver.F90
+++ b/src/parameterizations/vertical/MOM_diabatic_driver.F90
@@ -1350,6 +1350,11 @@ subroutine diabatic_ALE(u, v, h, tv, BLD, fluxes, visc, ADp, CDp, dt, Time_end, 
   Kd_heat(:,:,:) = 0.0 ; Kd_salt(:,:,:) = 0.0
   ent_s(:,:,:) = 0.0 ; ent_t(:,:,:) = 0.0
 
+  ! Some tracer packages require T & S from the beginning of the diabatic step to
+  ! provide forcing consistent with the passive tracer values. The initialization
+  ! routine will allocate prediabatic_T and prediabatic_S if the tracer flow control
+  ! structure indicates it is necessary. If these arrays are allocated, they will store
+  ! a copy of tv%T & tv%S before this subroutine modifies the tv structure.
   if (allocated(CS%prediabatic_T)) &
     CS%prediabatic_T(:,:,:) = tv%T(:,:,:)
   if (allocated(CS%prediabatic_S)) &

--- a/src/tracer/MARBL_forcing_mod.F90
+++ b/src/tracer/MARBL_forcing_mod.F90
@@ -55,7 +55,7 @@ type, public :: marbl_forcing_CS ; private
 
   type(marbl_forcing_diag_ids) :: diag_ids  !< used for registering and posting some MARBL forcing fields as diagnostics
 
-  logical :: use_marbl_tracers    !< most functions can return immediately
+  logical :: use_MARBL_tracers    !< most functions can return immediately
                                   !! MARBL tracers are turned off
   integer :: atm_co2_iopt         !< Integer version of atm_co2_opt, which determines source of atm_co2
   integer :: atm_alt_co2_iopt     !< Integer version of atm_alt_co2_opt, which determines source of atm_alt_co2
@@ -69,14 +69,14 @@ integer, parameter :: atm_co2_diagnostic_iopt = 2   !< module parameter denoting
 
 contains
 
-  subroutine MARBL_forcing_init(G, US, param_file, diag, day, inputdir, use_marbl, CS)
+  subroutine MARBL_forcing_init(G, US, param_file, diag, day, inputdir, use_MARBL_tracers, CS)
     type(ocean_grid_type),           intent(in)    :: G           !< The ocean's grid structure
     type(unit_scale_type),           intent(in)    :: US          !< A dimensional unit scaling type
     type(param_file_type),           intent(in)    :: param_file  !< A structure to parse for run-time parameters
     type(diag_ctrl), target,         intent(in)    :: diag        !< Structure used to regulate diagnostic output.
     type(time_type), target,         intent(in)    :: day         !< Time of the start of the run.
     character(len=*),                intent(in)    :: inputdir    !< Directory containing input files
-    logical,                         intent(in)    :: use_marbl   !< Is MARBL tracer package active?
+    logical,                         intent(in)    :: use_MARBL_tracers   !< Is MARBL tracer package active?
     type(marbl_forcing_CS), pointer, intent(inout) :: CS          !< A pointer that is set to point to control
                                                                   !! structure for MARBL forcing
 
@@ -92,9 +92,9 @@ contains
     allocate(CS)
     CS%diag => diag
 
-    CS%use_marbl_tracers = .true.
-    if (.not. use_marbl) then
-      CS%use_marbl_tracers = .false.
+    CS%use_MARBL_tracers = .true.
+    if (.not. use_MARBL_tracers) then
+      CS%use_MARBL_tracers = .false.
       return
     endif
 
@@ -229,7 +229,7 @@ contains
     real :: ndep_conversion          !< Factor to convert nitrogen deposition from kg m-2 s-1 -> mmol m-3 (m s-1)
                                      !! [s m2 kg-1 conc Z T-1 ~> mmol kg-1]
 
-    if (.not. CS%use_marbl_tracers) return
+    if (.not. CS%use_MARBL_tracers) return
 
     is   = G%isc   ; ie   = G%iec    ; js   = G%jsc   ; je   = G%jec
     ndep_conversion = (1.e6/14.) * (US%m_to_Z * US%T_to_s)

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -34,7 +34,7 @@ use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
 use MOM_tracer_initialization_from_Z, only : MOM_initialize_tracer_from_Z
 use MOM_tracer_Z_init,   only : read_Z_edges
 use MOM_unit_scaling,    only : unit_scale_type
-use MOM_variables,       only : surface, thermo_var_ptrs
+use MOM_variables,       only : surface
 use MOM_verticalGrid,    only : verticalGrid_type
 use MOM_diag_mediator,   only : register_diag_field, post_data!, safe_alloc_ptr
 
@@ -1270,15 +1270,13 @@ end subroutine setup_saved_state
 
 !> This subroutine applies diapycnal diffusion and any other column
 !! tracer physics or chemistry to the tracers from this file.
-subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, CS, tv, &
+subroutine MARBL_tracers_column_physics(h_old, ea, eb, fluxes, dt, G, GV, US, CS, &
     prediabatic_T, prediabatic_S, KPP_CSp, nonLocalTrans, evap_CFL_limit, minimum_forcing_depth)
 
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(in) :: h_old !< Layer thickness before entrainment [H ~> m or kg m-2].
-  real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
-                           intent(in) :: h_new !< Layer thickness after entrainment [H ~> m or kg m-2].
   real, dimension(SZI_(G),SZJ_(G),SZK_(G)), &
                            intent(in) :: ea   !< an array to which the amount of fluid entrained
                                               !! from the layer above during this call will be
@@ -1293,7 +1291,6 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
   type(unit_scale_type),   intent(in) :: US   !< A dimensional unit scaling type
   type(MARBL_tracers_CS),     pointer :: CS   !< The control structure returned by a previous
                                               !! call to register_MARBL_tracers.
-  type(thermo_var_ptrs),   intent(in) :: tv   !< A structure pointing to various thermodynamic variables
   real, dimension(:,:,:),  intent(in) :: prediabatic_T   !< Temperature prior to calling diabatic driver [C ~> degC]
   real, dimension(:,:,:),  intent(in) :: prediabatic_S   !< Salinity prior to calling diabatic driver [S ~> ppt]
 
@@ -1325,11 +1322,13 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
 
   if (.not.associated(CS)) return
 
-  ! (1) Compute surface fluxes
+  ! (1) Compute surface fluxes and interior tendencies
   ! FIXME: MARBL can handle computing surface fluxes for all columns simultaneously
   !        I was just thinking going column-by-column at first might be easier
+  bot_flux_to_tend(:, :, :) = 0.
   do j=js,je
     do i=is,ie
+      ! Surface fluxes
       ! i. only want ocean points in this loop
       if (G%mask2dT(i,j) == 0) cycle
 
@@ -1433,8 +1432,207 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
         CS%SFO(i,j,m) = MARBL_instances%surface_flux_output%outputs_for_GCM(m)%forcing_field_0d(1)
       enddo
 
+      ! interior tendencies
+      ! i. Set up vertical domain and bot_flux_to_tend
+      ! Calculate depth of interface by building up thicknesses from the bottom (top interface is always 0)
+      ! MARBL wants this to be positive-down
+      zi(GV%ke) = G%bathyT(i,j)
+      MARBL_instances%bot_flux_to_tend(:) = 0.
+      cum_bftt_dz = 0.
+      do k = GV%ke, 1, -1
+        dz(k) = h_old(i,j,k) ! cell thickness
+        zc(k) = zi(k) - 0.5 * (dz(k)*GV%H_to_Z)
+        zi(k-1) = zi(k) - (dz(k)*GV%H_to_Z)
+        if (G%bathyT(i,j) - zi(k-1) <= CS%bot_flux_mix_thickness) then
+          MARBL_instances%bot_flux_to_tend(k) = US%m_to_Z * CS%Ibfmt
+          cum_bftt_dz = cum_bftt_dz + MARBL_instances%bot_flux_to_tend(k) * (GV%H_to_m * dz(k))
+        elseif (G%bathyT(i,j) - zi(k) < CS%bot_flux_mix_thickness) then
+          ! MARBL_instances%bot_flux_to_tend(k) = (1. - (G%bathyT(i,j) - zi(k)) * CS%Ibfmt) / dz(k)
+          MARBL_instances%bot_flux_to_tend(k) = (1. - cum_bftt_dz) / (GV%H_to_m * dz(k))
+        endif
+      enddo
+      if (G%bathyT(i,j) - zi(0) < CS%bot_flux_mix_thickness) &
+        MARBL_instances%bot_flux_to_tend(:) = MARBL_instances%bot_flux_to_tend(:) * &
+            CS%bot_flux_mix_thickness / (G%bathyT(i,j) - zi(0))
+      if (CS%bot_flux_to_tend_id > 0) &
+        bot_flux_to_tend(i, j, :) = MARBL_instances%bot_flux_to_tend(:)
+
+      ! zw(1:nz) is bottom cell depth so no element of zw = 0, it is assumed to be top layer depth
+      MARBL_instances%domain%zw(:) = US%Z_to_m * zi(1:GV%ke)
+      MARBL_instances%domain%zt(:) = US%Z_to_m * zc(:)
+      MARBL_instances%domain%delta_z(:) = GV%H_to_m * dz(:)
+
+      ! ii. Load proper column data
+      !     * Forcing Fields
+      !       These fields are getting the correct data
+      if (CS%potemp_ind > 0) &
+        MARBL_instances%interior_tendency_forcings(CS%potemp_ind)%field_1d(1,:) = prediabatic_T(i,j,:) * US%C_to_degC
+      if (CS%salinity_ind > 0) &
+        MARBL_instances%interior_tendency_forcings(CS%salinity_ind)%field_1d(1,:) = prediabatic_S(i,j,:) * US%S_to_ppt
+
+      !       This is okay, but need option to read in from file
+      !       (Same as dust_dep_ind for surface_flux_forcings)
+      if (CS%dustflux_ind > 0) &
+        MARBL_instances%interior_tendency_forcings(CS%dustflux_ind)%field_0d(1) = &
+            fluxes%dust_flux(i,j) * US%RZ_T_to_kg_m2s
+
+      !       TODO: Support PAR (currently just using single subcolumn)
+      !             (Look for Pen_sw_bnd?)
+      if (CS%PAR_col_frac_ind > 0) then
+        ! second index is num_subcols, not depth
+        !MARBL_instances%interior_tendency_forcings(CS%PAR_col_frac_ind)%field_1d(1,:) = fluxes%fracr_cat(i,j,:)
+        if (CS%use_ice_category_fields) then
+          MARBL_instances%interior_tendency_forcings(CS%PAR_col_frac_ind)%field_1d(1,:) = &
+              fluxes%fracr_cat(i,j,:)
+        else
+          MARBL_instances%interior_tendency_forcings(CS%PAR_col_frac_ind)%field_1d(1,1) = 1.
+        endif
+      endif
+
+      if (CS%surf_shortwave_ind > 0) then
+        ! second index is num_subcols, not depth
+        if (CS%use_ice_category_fields) then
+          MARBL_instances%interior_tendency_forcings(CS%surf_shortwave_ind)%field_1d(1,:) = &
+              fluxes%qsw_cat(i,j,:) * US%QRZ_T_to_W_m2
+        else
+          MARBL_instances%interior_tendency_forcings(CS%surf_shortwave_ind)%field_1d(1,1) = &
+              fluxes%sw(i,j) * US%QRZ_T_to_W_m2
+        endif
+      endif
+      ! Tracer restoring
+      do m=1,CS%restore_count
+        MARBL_instances%interior_tendency_forcings(CS%tracer_restoring_ind(m))%field_1d(1,:) = 0.
+        call remapping_core_h(CS%restoring_remapCS, CS%restoring_nz, CS%restoring_dz(:), &
+            CS%restoring_in(i,j,:,m), GV%ke, dz(:), &
+            MARBL_instances%interior_tendency_forcings(CS%tracer_restoring_ind(m))%field_1d(1,:))
+        if (m==1) then
+          call remapping_core_h(CS%restoring_remapCS, CS%restoring_timescale_nz, &
+              CS%restoring_timescale_dz(:), CS%I_tau(i,j,:), GV%ke, dz(:), &
+              MARBL_instances%interior_tendency_forcings(CS%tracer_I_tau_ind(m))%field_1d(1,:))
+        else
+          MARBL_instances%interior_tendency_forcings(CS%tracer_I_tau_ind(m))%field_1d(1,:) = &
+              MARBL_instances%interior_tendency_forcings(CS%tracer_I_tau_ind(1))%field_1d(1,:)
+        endif
+      enddo
+
+      !        TODO: In POP, pressure comes from a function in state_mod.F90; I don't see a similar function here
+      !              This formulation is from Levitus 1994, and I think it belongs in MOM_EOS.F90?
+      !              Converts depth [m] -> pressure [bars]
+      !        NOTE: Andrew recommends using GV%H_to_Pa
+      if (CS%pressure_ind > 0) &
+        MARBL_instances%interior_tendency_forcings(CS%pressure_ind)%field_1d(1,:) = &
+            (0.0598088 * (exp(-0.025*US%Z_to_m * zc(:)) - 1.)) + &
+            (0.100766 * US%Z_to_m * zc(:)) + (2.28405e-7*((US%Z_to_m * zc(:))**2))
+
+      if (CS%fesedflux_ind > 0) then
+        MARBL_instances%interior_tendency_forcings(CS%fesedflux_ind)%field_1d(1,:) = 0.
+        call reintegrate_column(CS%fesedflux_nz, &
+            CS%fesedflux_dz(i,j,:) * (sum(dz(:) * GV%H_to_Z) / G%bathyT(i,j)), &
+            CS%fesedflux_in(i,j,:) + CS%feventflux_in(i,j,:), GV%ke, dz(:), &
+            MARBL_instances%interior_tendency_forcings(CS%fesedflux_ind)%field_1d(1,:))
+      endif
+
+      !        TODO: add ability to read these fields from file
+      !              also, add constant values to CS
+      if (CS%o2_scalef_ind > 0) &
+        MARBL_instances%interior_tendency_forcings(CS%o2_scalef_ind)%field_1d(1,:) = 1.
+      if (CS%remin_scalef_ind > 0) &
+        MARBL_instances%interior_tendency_forcings(CS%remin_scalef_ind)%field_1d(1,:) = 1.
+
+      !      * Column Tracers
+      do m=1,CS%ntr
+        MARBL_instances%tracers(m, :) = CS%tracer_data(m)%tr(i,j,:)
+      enddo
+
+      !     * interior tendency saved state
+      !       (currently only 3D fields are saved from interior_tendency_compute())
+      do m=1,size(MARBL_instances%interior_tendency_saved_state%state)
+        MARBL_instances%interior_tendency_saved_state%state(m)%field_3d(:,1) = &
+            CS%interior_tendency_saved_state(m)%field_3d(i,j,:)
+      enddo
+
+      ! iii. Compute interior tendencies in MARBL
+      call MARBL_instances%interior_tendency_compute()
+      if (MARBL_instances%StatusLog%labort_marbl) then
+        call MARBL_instances%StatusLog%log_error_trace(&
+            "MARBL_instances%interior_tendency_compute()", "MARBL_tracers_column_physics")
+      endif
+      call print_marbl_log(MARBL_instances%StatusLog, G, i, j)
+      call MARBL_instances%StatusLog%erase()
+
+      ! iv. Apply tendencies immediately
+      !     First pass - Euler step; if stability issues, we can do something different (subcycle?)
+      do m=1,CS%ntr
+        CS%tracer_data(m)%tr(i,j,:) = CS%tracer_data(m)%tr(i,j,:) + (dt * US%T_to_s) * &
+            MARBL_instances%interior_tendencies(m,:)
+      enddo
+
+      ! v. Copy output that MOM6 needs to hold on to
+      !    * saved state
+      do m=1,size(MARBL_instances%interior_tendency_saved_state%state)
+        CS%interior_tendency_saved_state(m)%field_3d(i,j,:) = &
+            MARBL_instances%interior_tendency_saved_state%state(m)%field_3d(:,1)
+      enddo
+
+      !    * diagnostics
+      do m=1,size(MARBL_instances%interior_tendency_diags%diags)
+        if (CS%interior_tendency_diags(m)%id > 0) then
+          if (allocated(CS%interior_tendency_diags(m)%field_2d)) then
+            ! Only copy values if ref_depth < bathyT
+            if (G%bathyT(i,j) > real(MARBL_instances%interior_tendency_diags%diags(m)%ref_depth)) then
+              CS%interior_tendency_diags(m)%field_2d(i,j) = &
+                  real(MARBL_instances%interior_tendency_diags%diags(m)%field_2d(1))
+            endif
+          else ! not a 2D diagnostic
+            CS%interior_tendency_diags(m)%field_3d(i,j,:) = &
+                real(MARBL_instances%interior_tendency_diags%diags(m)%field_3d(:,1))
+          endif
+        endif
+      enddo
+
+      !  * tendency values themselves (and vertical integrals of them)
+      do m=1,CS%ntr
+        if (allocated(CS%interior_tendency_out(m)%field_3d)) &
+          CS%interior_tendency_out(m)%field_3d(i,j,:) = MARBL_instances%interior_tendencies(m,:)
+
+        if (allocated(CS%interior_tendency_out_zint(m)%field_2d)) &
+          CS%interior_tendency_out_zint(m)%field_2d(i,j) = (sum(dz(:) * &
+              MARBL_instances%interior_tendencies(m,:)))
+
+        if (allocated(CS%interior_tendency_out_zint_100m(m)%field_2d)) then
+          CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) = 0.
+          do k=1,GV%ke
+            if (zi(k) < US%m_to_Z * 100.) then
+              CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) = &
+                  CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) + GV%H_to_m * dz(k) * &
+                  MARBL_instances%interior_tendencies(m,k)
+            elseif (zi(k-1) < US%m_to_Z * 100.) then
+              CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) = &
+                  CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) + GV%H_to_m * dz(k) * &
+                  ((US%m_to_Z * 100. - zi(k-1)) / (zi(k) - zi(k-1))) * &
+                  MARBL_instances%interior_tendencies(m,k)
+            else
+              exit
+            endif
+          enddo
+        endif
+      enddo
+
+      !  * Interior tendency output
+      do m=1,CS%ito_cnt
+        CS%ITO(i,j,:,m) = &
+            MARBL_instances%interior_tendency_output%outputs_for_GCM(m)%forcing_field_1d(1,:)
+      enddo
+
     enddo
   enddo
+
+  if (CS%debug) then
+    do m=1,CS%ntr
+      call hchksum(CS%tracer_data(m)%tr(:,:,m), &
+          trim(MARBL_instances%tracer_metadata(m)%short_name)//' post source-sink', G%HI)
+    enddo
+  endif
 
   if (associated(fluxes%salt_flux)) then
     ! convert salt flux to tracer fluxes and add to STF
@@ -1509,17 +1707,7 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
     enddo
   endif
 
-  ! (2) Post surface fluxes and their diagnostics (currently all 2D)
-  do m=1,CS%ntr
-    if (CS%id_surface_flux_out(m) > 0) &
-      call post_data(CS%id_surface_flux_out(m), CS%STF(:,:,m), CS%diag)
-  enddo
-  do m=1,size(CS%surface_flux_diags)
-    if (CS%surface_flux_diags(m)%id > 0) &
-      call post_data(CS%surface_flux_diags(m)%id, CS%surface_flux_diags(m)%field_2d(:,:), CS%diag)
-  enddo
-
-  ! (3) Apply surface fluxes via vertical diffusion
+  ! (2) Apply surface fluxes via vertical diffusion
   ! Compute KPP nonlocal term if necessary
   if (present(KPP_CSp)) then
     if (associated(KPP_CSp) .and. present(nonLocalTrans)) then
@@ -1555,6 +1743,10 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
           sfc_flux=GV%Rho0 * CS%STF(:,:,m))
     enddo
   else
+    ! TODO: do we want to support these options? does not apply river fluxes!
+    !       an alternative would be to require evap_CFL_limit and minimum_forcing_depth.
+    !       Much like we now require prediabatic_T and prediabatic_S, we can abort
+    !       in tracer flow control if they are not present.
     do m=1,CS%ntr
       call tracer_vertdiff(h_old, ea, eb, dt, CS%tracer_data(m)%tr(:,:,:), G, GV, &
           sfc_flux=GV%Rho0 * CS%STF(:,:,m))
@@ -1568,220 +1760,21 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
     enddo
   endif
 
-  ! (4) Compute interior tendencies
-
-  bot_flux_to_tend(:, :, :) = 0.
-  do j=js,je
-    do i=is,ie
-      ! i. only want ocean points in this loop
-      if (G%mask2dT(i,j) == 0) cycle
-
-      ! ii. Set up vertical domain and bot_flux_to_tend
-      ! Calculate depth of interface by building up thicknesses from the bottom (top interface is always 0)
-      ! MARBL wants this to be positive-down
-      zi(GV%ke) = G%bathyT(i,j)
-      MARBL_instances%bot_flux_to_tend(:) = 0.
-      cum_bftt_dz = 0.
-      do k = GV%ke, 1, -1
-        ! TODO: if we move this above vertical mixing, use h_old
-        dz(k) = h_new(i,j,k) ! cell thickness
-        zc(k) = zi(k) - 0.5 * (dz(k)*GV%H_to_Z)
-        zi(k-1) = zi(k) - (dz(k)*GV%H_to_Z)
-        if (G%bathyT(i,j) - zi(k-1) <= CS%bot_flux_mix_thickness) then
-          MARBL_instances%bot_flux_to_tend(k) = US%m_to_Z * CS%Ibfmt
-          cum_bftt_dz = cum_bftt_dz + MARBL_instances%bot_flux_to_tend(k) * (GV%H_to_m * dz(k))
-        elseif (G%bathyT(i,j) - zi(k) < CS%bot_flux_mix_thickness) then
-          ! MARBL_instances%bot_flux_to_tend(k) = (1. - (G%bathyT(i,j) - zi(k)) * CS%Ibfmt) / dz(k)
-          MARBL_instances%bot_flux_to_tend(k) = (1. - cum_bftt_dz) / (GV%H_to_m * dz(k))
-        endif
-      enddo
-      if (G%bathyT(i,j) - zi(0) < CS%bot_flux_mix_thickness) &
-        MARBL_instances%bot_flux_to_tend(:) = MARBL_instances%bot_flux_to_tend(:) * &
-            CS%bot_flux_mix_thickness / (G%bathyT(i,j) - zi(0))
-      if (CS%bot_flux_to_tend_id > 0) &
-        bot_flux_to_tend(i, j, :) = MARBL_instances%bot_flux_to_tend(:)
-
-      ! zw(1:nz) is bottom cell depth so no element of zw = 0, it is assumed to be top layer depth
-      MARBL_instances%domain%zw(:) = US%Z_to_m * zi(1:GV%ke)
-      MARBL_instances%domain%zt(:) = US%Z_to_m * zc(:)
-      MARBL_instances%domain%delta_z(:) = GV%H_to_m * dz(:)
-
-      ! iii. Load proper column data
-      !      * Forcing Fields
-      !       These fields are getting the correct data
-      if (CS%potemp_ind > 0) &
-        MARBL_instances%interior_tendency_forcings(CS%potemp_ind)%field_1d(1,:) = tv%T(i,j,:) * US%C_to_degC
-      if (CS%salinity_ind > 0) &
-        MARBL_instances%interior_tendency_forcings(CS%salinity_ind)%field_1d(1,:) = tv%S(i,j,:) * US%S_to_ppt
-
-      !       This are okay, but need option to read in from file
-      !       (Same as dust_dep_ind for surface_flux_forcings)
-      if (CS%dustflux_ind > 0) &
-        MARBL_instances%interior_tendency_forcings(CS%dustflux_ind)%field_0d(1) = &
-            fluxes%dust_flux(i,j) * US%RZ_T_to_kg_m2s
-
-      !        TODO: Support PAR (currently just using single subcolumn)
-      !              (Look for Pen_sw_bnd?)
-      if (CS%PAR_col_frac_ind > 0) then
-        ! second index is num_subcols, not depth
-        !MARBL_instances%interior_tendency_forcings(CS%PAR_col_frac_ind)%field_1d(1,:) = fluxes%fracr_cat(i,j,:)
-        if (CS%use_ice_category_fields) then
-          MARBL_instances%interior_tendency_forcings(CS%PAR_col_frac_ind)%field_1d(1,:) = &
-              fluxes%fracr_cat(i,j,:)
-        else
-          MARBL_instances%interior_tendency_forcings(CS%PAR_col_frac_ind)%field_1d(1,1) = 1.
-        endif
-      endif
-
-      if (CS%surf_shortwave_ind > 0) then
-        ! second index is num_subcols, not depth
-        if (CS%use_ice_category_fields) then
-          MARBL_instances%interior_tendency_forcings(CS%surf_shortwave_ind)%field_1d(1,:) = &
-              fluxes%qsw_cat(i,j,:) * US%QRZ_T_to_W_m2
-        else
-          MARBL_instances%interior_tendency_forcings(CS%surf_shortwave_ind)%field_1d(1,1) = &
-              fluxes%sw(i,j) * US%QRZ_T_to_W_m2
-        endif
-      endif
-      ! Tracer restoring
-      do m=1,CS%restore_count
-        MARBL_instances%interior_tendency_forcings(CS%tracer_restoring_ind(m))%field_1d(1,:) = 0.
-        call remapping_core_h(CS%restoring_remapCS, CS%restoring_nz, CS%restoring_dz(:), &
-            CS%restoring_in(i,j,:,m), GV%ke, dz(:), &
-            MARBL_instances%interior_tendency_forcings(CS%tracer_restoring_ind(m))%field_1d(1,:))
-        if (m==1) then
-          call remapping_core_h(CS%restoring_remapCS, CS%restoring_timescale_nz, &
-              CS%restoring_timescale_dz(:), CS%I_tau(i,j,:), GV%ke, dz(:), &
-              MARBL_instances%interior_tendency_forcings(CS%tracer_I_tau_ind(m))%field_1d(1,:))
-        else
-          MARBL_instances%interior_tendency_forcings(CS%tracer_I_tau_ind(m))%field_1d(1,:) = &
-              MARBL_instances%interior_tendency_forcings(CS%tracer_I_tau_ind(1))%field_1d(1,:)
-        endif
-      enddo
-
-      !        TODO: In POP, pressure comes from a function in state_mod.F90; I don't see a similar function here
-      !              This formulation is from Levitus 1994, and I think it belongs in MOM_EOS.F90?
-      !              Converts depth [m] -> pressure [bars]
-      !        NOTE: Andrew recommends using GV%H_to_Pa
-      if (CS%pressure_ind > 0) &
-        MARBL_instances%interior_tendency_forcings(CS%pressure_ind)%field_1d(1,:) = &
-            (0.0598088 * (exp(-0.025*US%Z_to_m * zc(:)) - 1.)) + &
-            (0.100766 * US%Z_to_m * zc(:)) + (2.28405e-7*((US%Z_to_m * zc(:))**2))
-
-      if (CS%fesedflux_ind > 0) then
-        MARBL_instances%interior_tendency_forcings(CS%fesedflux_ind)%field_1d(1,:) = 0.
-        call reintegrate_column(CS%fesedflux_nz, &
-            CS%fesedflux_dz(i,j,:) * (sum(dz(:) * GV%H_to_Z) / G%bathyT(i,j)), &
-            CS%fesedflux_in(i,j,:) + CS%feventflux_in(i,j,:), GV%ke, dz(:), &
-            MARBL_instances%interior_tendency_forcings(CS%fesedflux_ind)%field_1d(1,:))
-      endif
-
-      !        TODO: add ability to read these fields from file
-      !              also, add constant values to CS
-      if (CS%o2_scalef_ind > 0) &
-        MARBL_instances%interior_tendency_forcings(CS%o2_scalef_ind)%field_1d(1,:) = 1.
-      if (CS%remin_scalef_ind > 0) &
-        MARBL_instances%interior_tendency_forcings(CS%remin_scalef_ind)%field_1d(1,:) = 1.
-
-      !      * Column Tracers
-      do m=1,CS%ntr
-        MARBL_instances%tracers(m, :) = CS%tracer_data(m)%tr(i,j,:)
-      enddo
-
-      !     * interior tendency saved state
-      !       (currently only 3D fields are saved from interior_tendency_compute())
-      do m=1,size(MARBL_instances%interior_tendency_saved_state%state)
-        MARBL_instances%interior_tendency_saved_state%state(m)%field_3d(:,1) = &
-            CS%interior_tendency_saved_state(m)%field_3d(i,j,:)
-      enddo
-
-      ! iv. Compute interior tendencies in MARBL
-      call MARBL_instances%interior_tendency_compute()
-      if (MARBL_instances%StatusLog%labort_marbl) then
-        call MARBL_instances%StatusLog%log_error_trace(&
-            "MARBL_instances%interior_tendency_compute()", "MARBL_tracers_column_physics")
-      endif
-      call print_marbl_log(MARBL_instances%StatusLog, G, i, j)
-      call MARBL_instances%StatusLog%erase()
-
-      ! v. Apply tendencies immediately
-      !    First pass - Euler step; if stability issues, we can do something different (subcycle?)
-      do m=1,CS%ntr
-        CS%tracer_data(m)%tr(i,j,:) = CS%tracer_data(m)%tr(i,j,:) + (dt * US%T_to_s) * &
-            MARBL_instances%interior_tendencies(m,:)
-      enddo
-
-      ! vi. Copy output that MOM6 needs to hold on to
-      !     * saved state
-      do m=1,size(MARBL_instances%interior_tendency_saved_state%state)
-        CS%interior_tendency_saved_state(m)%field_3d(i,j,:) = &
-            MARBL_instances%interior_tendency_saved_state%state(m)%field_3d(:,1)
-      enddo
-
-      !     * diagnostics
-      do m=1,size(MARBL_instances%interior_tendency_diags%diags)
-        if (CS%interior_tendency_diags(m)%id > 0) then
-          if (allocated(CS%interior_tendency_diags(m)%field_2d)) then
-            ! Only copy values if ref_depth < bathyT
-            if (G%bathyT(i,j) > real(MARBL_instances%interior_tendency_diags%diags(m)%ref_depth)) then
-              CS%interior_tendency_diags(m)%field_2d(i,j) = &
-                  real(MARBL_instances%interior_tendency_diags%diags(m)%field_2d(1))
-            endif
-          else ! not a 2D diagnostic
-            CS%interior_tendency_diags(m)%field_3d(i,j,:) = &
-                real(MARBL_instances%interior_tendency_diags%diags(m)%field_3d(:,1))
-          endif
-        endif
-      enddo
-
-      !     * tendency values themselves (and vertical integrals of them)
-      do m=1,CS%ntr
-        if (allocated(CS%interior_tendency_out(m)%field_3d)) &
-          CS%interior_tendency_out(m)%field_3d(i,j,:) = MARBL_instances%interior_tendencies(m,:)
-
-        if (allocated(CS%interior_tendency_out_zint(m)%field_2d)) &
-          CS%interior_tendency_out_zint(m)%field_2d(i,j) = (sum(dz(:) * &
-              MARBL_instances%interior_tendencies(m,:)))
-
-        if (allocated(CS%interior_tendency_out_zint_100m(m)%field_2d)) then
-          CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) = 0.
-          do k=1,GV%ke
-            if (zi(k) < US%m_to_Z * 100.) then
-              CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) = &
-                  CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) + GV%H_to_m * dz(k) * &
-                  MARBL_instances%interior_tendencies(m,k)
-            elseif (zi(k-1) < US%m_to_Z * 100.) then
-              CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) = &
-                  CS%interior_tendency_out_zint_100m(m)%field_2d(i,j) + GV%H_to_m * dz(k) * &
-                  ((US%m_to_Z * 100. - zi(k-1)) / (zi(k) - zi(k-1))) * &
-                  MARBL_instances%interior_tendencies(m,k)
-            else
-              exit
-            endif
-          enddo
-        endif
-      enddo
-
-      !     * Interior tendency output
-      do m=1,CS%ito_cnt
-        CS%ITO(i,j,:,m) = &
-            MARBL_instances%interior_tendency_output%outputs_for_GCM(m)%forcing_field_1d(1,:)
-      enddo
-
-    enddo
+  ! (3) Post diagnostics from our buffer
+  !     i.   surface fluxes and their diagnostics (currently all 2D)
+  !     ii.  Interior tendency diagnostics (mix of 2D and 3D)
+  !     iii. Interior tendencies themselves
+  !     iv.  Forcing fields
+  do m=1,CS%ntr
+    if (CS%id_surface_flux_out(m) > 0) &
+      call post_data(CS%id_surface_flux_out(m), CS%STF(:,:,m), CS%diag)
   enddo
 
-  if (CS%debug) then
-    do m=1,CS%ntr
-      call hchksum(CS%tracer_data(m)%tr(:,:,m), &
-          trim(MARBL_instances%tracer_metadata(m)%short_name)//' post source-sink', G%HI)
-    enddo
-  endif
+  do m=1,size(CS%surface_flux_diags)
+    if (CS%surface_flux_diags(m)%id > 0) &
+      call post_data(CS%surface_flux_diags(m)%id, CS%surface_flux_diags(m)%field_2d(:,:), CS%diag)
+  enddo
 
-  ! (5) Post diagnostics from our buffer
-  !     i. Interior tendency diagnostics (mix of 2D and 3D)
-  !     ii. Interior tendencies themselves
-  !     iii. Forcing fields
   if (CS%bot_flux_to_tend_id > 0) &
     call post_data(CS%bot_flux_to_tend_id, bot_flux_to_tend(:, :, :), CS%diag)
 

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -1271,7 +1271,7 @@ end subroutine setup_saved_state
 !> This subroutine applies diapycnal diffusion and any other column
 !! tracer physics or chemistry to the tracers from this file.
 subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, CS, tv, &
-    KPP_CSp, nonLocalTrans, evap_CFL_limit, minimum_forcing_depth)
+    prediabatic_T, prediabatic_S, KPP_CSp, nonLocalTrans, evap_CFL_limit, minimum_forcing_depth)
 
   type(ocean_grid_type),   intent(in) :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
@@ -1294,6 +1294,9 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
   type(MARBL_tracers_CS),     pointer :: CS   !< The control structure returned by a previous
                                               !! call to register_MARBL_tracers.
   type(thermo_var_ptrs),   intent(in) :: tv   !< A structure pointing to various thermodynamic variables
+  real, dimension(:,:,:),  intent(in) :: prediabatic_T   !< Temperature prior to calling diabatic driver [C ~> degC]
+  real, dimension(:,:,:),  intent(in) :: prediabatic_S   !< Salinity prior to calling diabatic driver [S ~> ppt]
+
   type(KPP_CS),  optional, pointer    :: KPP_CSp  !< KPP control structure
   real,          optional, intent(in) :: nonLocalTrans(:,:,:) !< Non-local transport [1]
   real,          optional, intent(in) :: evap_CFL_limit !< Limit on the fraction of the water that can
@@ -1336,9 +1339,9 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
       !       TODO: if top layer is vanishly thin, do we actually want (e.g.) top 5m average temp / salinity?
       !             How does MOM pass SST and SSS to GFDL coupler? (look in core.F90?)
       if (CS%sss_ind > 0) &
-        MARBL_instances%surface_flux_forcings(CS%sss_ind)%field_0d(1) = tv%S(i,j,1) * US%S_to_ppt
+        MARBL_instances%surface_flux_forcings(CS%sss_ind)%field_0d(1) = prediabatic_S(i,j,1) * US%S_to_ppt
       if (CS%sst_ind > 0) &
-        MARBL_instances%surface_flux_forcings(CS%sst_ind)%field_0d(1) = tv%T(i,j,1) * US%C_to_degC
+        MARBL_instances%surface_flux_forcings(CS%sst_ind)%field_0d(1) = prediabatic_T(i,j,1) * US%C_to_degC
       if (CS%ifrac_ind > 0) &
         MARBL_instances%surface_flux_forcings(CS%ifrac_ind)%field_0d(1) = fluxes%ice_fraction(i,j)
 
@@ -1404,7 +1407,7 @@ subroutine MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV,
         call MARBL_instances%StatusLog%log_error_trace("MARBL_instances%surface_flux_compute()", &
             "MARBL_tracers_column_physics")
       endif
-      call print_marbl_log(MARBL_instances%StatusLog)
+      call print_marbl_log(MARBL_instances%StatusLog, G, i, j)
       call MARBL_instances%StatusLog%erase()
 
       ! iv. Copy output that MOM6 needs to hold on to

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -546,8 +546,8 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
     if (CS%use_MARBL_tracers) then
       if ((.not. present(prediabatic_T)) .or. (.not. present(prediabatic_S))) &
         call MOM_error(FATAL, 'Must pass prediabatic_T and prediabatic_S when using MARBL')
-      call MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                        G, GV, US, CS%MARBL_tracers_CSp, tv, &
+      call MARBL_tracers_column_physics(h_old, ea, eb, fluxes, dt, &
+                                        G, GV, US, CS%MARBL_tracers_CSp, &
                                         prediabatic_T, prediabatic_S, &
                                         KPP_CSp=KPP_CSp, &
                                         nonLocalTrans=nonLocalTrans, &
@@ -640,8 +640,8 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
     if (CS%use_MARBL_tracers) then
       if ((.not. present(prediabatic_T)) .or. (.not. present(prediabatic_S))) &
         call MOM_error(FATAL, 'Must pass prediabatic_T and prediabatic_S when using MARBL')
-      call MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-                                        G, GV, US, CS%MARBL_tracers_CSp, tv, &
+      call MARBL_tracers_column_physics(h_old, ea, eb, fluxes, dt, &
+                                        G, GV, US, CS%MARBL_tracers_CSp, &
                                         prediabatic_T, prediabatic_S, &
                                         KPP_CSp=KPP_CSp, &
                                         nonLocalTrans=nonLocalTrans)

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -498,8 +498,10 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
   real,                        optional, intent(in) :: minimum_forcing_depth !< The smallest depth over
                                                               !! which fluxes can be applied [H ~> m or kg m-2]
   real, dimension(:,:),        optional, pointer    :: h_BL   !< Thickness of active mixing layer [H ~> m or kg m-2]
-  real, dimension(:,:,:),      optional, intent(in) :: prediabatic_T   !< Temperature prior to calling diabatic driver [C ~> degC]
-  real, dimension(:,:,:),      optional, intent(in) :: prediabatic_S   !< Salinity prior to calling diabatic driver [S ~> ppt]
+  real, dimension(:,:,:),      optional, intent(in) :: prediabatic_T   !< Temperature prior to calling
+                                                                       !! diabatic driver [C ~> degC]
+  real, dimension(:,:,:),      optional, intent(in) :: prediabatic_S   !< Salinity prior to calling
+                                                                       !! diabatic driver [S ~> ppt]
 
   ! Local variables
   real :: Hbl(SZI_(G),SZJ_(G))    !< Boundary layer thickness [H ~> m or kg m-2]

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -422,7 +422,7 @@ subroutine extract_tracer_flow_member(CS, use_MARBL_tracers)
   ! All output arguments are optional
   logical,                    optional, intent(out) :: use_MARBL_tracers  !< If true, MARBL tracers are active
 
-  ! Constants within diabatic_CS
+  ! Constants within tracer_flow_control_CS
   if (present(use_MARBL_tracers)) use_MARBL_tracers = CS%use_MARBL_tracers
 end subroutine extract_tracer_flow_member
 
@@ -553,7 +553,7 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
                                         nonLocalTrans=nonLocalTrans, &
                                         evap_CFL_limit=evap_CFL_limit, &
                                         minimum_forcing_depth=minimum_forcing_depth)
-    end if
+    endif
     if (CS%use_regional_dyes) &
       call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                      G, GV, US, tv, CS%dye_tracer_CSp, &
@@ -645,7 +645,7 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
                                         prediabatic_T, prediabatic_S, &
                                         KPP_CSp=KPP_CSp, &
                                         nonLocalTrans=nonLocalTrans)
-    end if
+    endif
     if (CS%use_regional_dyes) &
       call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                            G, GV, US, tv, CS%dye_tracer_CSp)

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -81,7 +81,7 @@ implicit none ; private
 public call_tracer_register, tracer_flow_control_init, call_tracer_set_forcing
 public call_tracer_column_fns, call_tracer_surface_state, call_tracer_stocks
 public call_tracer_flux_init, get_chl_from_model, tracer_flow_control_end
-public call_tracer_register_obc_segments
+public call_tracer_register_obc_segments, extract_tracer_flow_member
 
 !> The control structure for orchestrating the calling of tracer packages
 type, public :: tracer_flow_control_CS ; private
@@ -201,7 +201,7 @@ subroutine call_tracer_register(G, GV, US, param_file, CS, tr_Reg, restart_CS)
   call get_param(param_file, mdl, "USE_IDEAL_AGE_TRACER", CS%use_ideal_age, &
                  "If true, use the ideal_age_example tracer package.", &
                  default=.false.)
-  call get_param(param_file, mdl, "USE_MARBL_TRACERS", CS%use_marbl_tracers, &
+  call get_param(param_file, mdl, "USE_MARBL_TRACERS", CS%use_MARBL_tracers, &
                  "If true, use the MARBL tracer package.", &
                  default=.false.)
   call get_param(param_file, mdl, "USE_REGIONAL_DYES", CS%use_regional_dyes, &
@@ -415,6 +415,17 @@ subroutine get_chl_from_model(Chl_array, G, GV, CS)
 
 end subroutine get_chl_from_model
 
+!> Returns pointers or values of members within the tracer_flow_control_CS type. For extensibility,
+!! each returned argument is an optional argument
+subroutine extract_tracer_flow_member(CS, use_MARBL_tracers)
+  type(tracer_flow_control_CS), target, intent(in)  :: CS !< module control structure
+  ! All output arguments are optional
+  logical,                    optional, intent(out) :: use_MARBL_tracers  !< If true, MARBL tracers are active
+
+  ! Constants within diabatic_CS
+  if (present(use_MARBL_tracers)) use_MARBL_tracers = CS%use_MARBL_tracers
+end subroutine extract_tracer_flow_member
+
 !> This subroutine calls the individual tracer modules' subroutines to
 !! specify or read quantities related to their surface forcing.
 subroutine call_tracer_set_forcing(sfc_state, fluxes, day_start, day_interval, G, US, Rho0, CS)
@@ -450,7 +461,8 @@ end subroutine call_tracer_set_forcing
 
 !> This subroutine calls all registered tracer column physics subroutines.
 subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, US, tv, optics, CS, &
-                                  debug, KPP_CSp, nonLocalTrans, evap_CFL_limit, minimum_forcing_depth, h_BL)
+                                  debug, KPP_CSp, nonLocalTrans, evap_CFL_limit, minimum_forcing_depth, &
+                                  h_BL, prediabatic_T, prediabatic_S)
   type(ocean_grid_type),                 intent(in) :: G      !< The ocean's grid structure.
   type(verticalGrid_type),               intent(in) :: GV     !< The ocean's vertical grid structure.
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h_old !< Layer thickness before entrainment
@@ -486,6 +498,8 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
   real,                        optional, intent(in) :: minimum_forcing_depth !< The smallest depth over
                                                               !! which fluxes can be applied [H ~> m or kg m-2]
   real, dimension(:,:),        optional, pointer    :: h_BL   !< Thickness of active mixing layer [H ~> m or kg m-2]
+  real, dimension(:,:,:),      optional, intent(in) :: prediabatic_T   !< Temperature prior to calling diabatic driver [C ~> degC]
+  real, dimension(:,:,:),      optional, intent(in) :: prediabatic_S   !< Salinity prior to calling diabatic driver [S ~> ppt]
 
   ! Local variables
   real :: Hbl(SZI_(G),SZJ_(G))    !< Boundary layer thickness [H ~> m or kg m-2]
@@ -527,13 +541,17 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
                                            evap_CFL_limit=evap_CFL_limit, &
                                            minimum_forcing_depth=minimum_forcing_depth, Hbl=Hbl)
     endif
-    if (CS%use_MARBL_tracers) &
+    if (CS%use_MARBL_tracers) then
+      if ((.not. present(prediabatic_T)) .or. (.not. present(prediabatic_S))) &
+        call MOM_error(FATAL, 'Must pass prediabatic_T and prediabatic_S when using MARBL')
       call MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                         G, GV, US, CS%MARBL_tracers_CSp, tv, &
+                                        prediabatic_T, prediabatic_S, &
                                         KPP_CSp=KPP_CSp, &
                                         nonLocalTrans=nonLocalTrans, &
                                         evap_CFL_limit=evap_CFL_limit, &
                                         minimum_forcing_depth=minimum_forcing_depth)
+    end if
     if (CS%use_regional_dyes) &
       call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                      G, GV, US, tv, CS%dye_tracer_CSp, &
@@ -617,11 +635,15 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
       call ideal_age_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                            G, GV, US, CS%ideal_age_tracer_CSp, Hbl=Hbl)
     endif
-    if (CS%use_MARBL_tracers) &
+    if (CS%use_MARBL_tracers) then
+      if ((.not. present(prediabatic_T)) .or. (.not. present(prediabatic_S))) &
+        call MOM_error(FATAL, 'Must pass prediabatic_T and prediabatic_S when using MARBL')
       call MARBL_tracers_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                         G, GV, US, CS%MARBL_tracers_CSp, tv, &
+                                        prediabatic_T, prediabatic_S, &
                                         KPP_CSp=KPP_CSp, &
                                         nonLocalTrans=nonLocalTrans)
+    end if
     if (CS%use_regional_dyes) &
       call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                            G, GV, US, tv, CS%dye_tracer_CSp)


### PR DESCRIPTION
When computing surface fluxes and interior tendencies for MARBL tracers, we want to use T & S from before they are modified by `tracer_vertdiff()`. We do this by adding `prediabatic_T` and `prediabatic_S` to the diabatic control structure, and then passing these values instead of `tv%T` and `tv%S` to MARBL.