### PR TITLE
Ensure short-circuiting in Lam2 available check in mixedlayer_restart_Bodner

### DIFF
--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -853,6 +853,7 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
   logical :: line_is_empty, keep_going
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
+  logical :: lam2_available = .false.
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -891,7 +892,9 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
 
   ! Wave Enhanced of ustar following Eq. 28 in Bodner23
   if (CS%wave_enhanced_ustar) then
-    if (present(Lam2) .and. associated(Lam2)) then
+    lam2_available = present(Lam2)
+    if (lam2_available) lam2_available = associated(Lam2)
+    if (lam2_available) then
       do j=js-1,je+1 ; do i=is-1,ie+1
         E_ustar   =  sqrt( 1.0 + (Lam2(i,j) * 0.104) + (Lam2(i,j) * Lam2(i,j) * 0.00118))
         U_star_2d(i,j) = E_ustar * U_star_2d(i,j)

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -853,7 +853,7 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
   logical :: line_is_empty, keep_going
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
-  logical :: lam2_available = .false.
+  logical :: Lam2_available
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -890,11 +890,12 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
   ! Extract the friction velocity from the forcing type.
   call find_ustar(forces, tv, U_star_2d, G, GV, US, halo=1)
 
+  Lam2_available = present(Lam2)
+  if (Lam2_available) Lam2_available = associated(Lam2)
+
   ! Wave Enhanced of ustar following Eq. 28 in Bodner23
   if (CS%wave_enhanced_ustar) then
-    lam2_available = present(Lam2)
-    if (lam2_available) lam2_available = associated(Lam2)
-    if (lam2_available) then
+    if (Lam2_available) then
       do j=js-1,je+1 ; do i=is-1,ie+1
         E_ustar   =  sqrt( 1.0 + (Lam2(i,j) * 0.104) + (Lam2(i,j) * Lam2(i,j) * 0.00118))
         U_star_2d(i,j) = E_ustar * U_star_2d(i,j)


### PR DESCRIPTION
Otherwise, `associated(Lam2)` may be checked before `present(Lam2)`, which may lead to sigsegv.

This behavior was discovered while testing https://github.com/ESCOMP/MOM_interface/pull/298

Testing: aux_mom.b4b