### PR TITLE
Fix scaling of pRef_MLD

### DIFF
--- a/src/diagnostics/MOM_diagnose_MLD.F90
+++ b/src/diagnostics/MOM_diagnose_MLD.F90
@@ -101,7 +101,7 @@ subroutine diagnoseMLDbyDensityDifference(id_MLD, h, tv, densityDiff, G, GV, US,
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
   hRef_MLD(:) = ref_h_mld
-  pRef_MLD(:) = GV%H_to_RZ*GV%g_Earth*ref_h_mld
+  pRef_MLD(:) = GV%H_to_RZ * GV%Z_to_H * GV%g_Earth * ref_h_mld
   z_ref_diag(:,:) = 0.
 
   EOSdom(:) = EOS_domain(G%HI)
@@ -335,6 +335,7 @@ subroutine diagnoseMLDbyEnergy(id_MLD, h, tv, G, GV, US, Mixing_Energy, k_bounds
 
   is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
+  use_OM4_iteration = .false.
   if (present(OM4_iteration)) then
     use_OM4_iteration = OM4_iteration
   endif


### PR DESCRIPTION
This scaling issue was discovered while evaluating https://github.com/ESCOMP/MOM_interface/pull/298, which updates `HREF_FOR_MLD` to 10.0 (previously 0.0)

Also initialize use_OM4_iteration in case OM4_iteration is not present.

testing: aux_mom.derecho. b4b