### PR TITLE
Get stoch_restfile right with multiple restarts

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -285,10 +285,16 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
 
   OS%Time = Time_in
   if(present(input_restart_file)) then
-      k = len_trim(input_restart_file)
+      k = index(input_restart_file, ' ')
+      if (k==0) k = len_trim(input_restart_file)
       i = index(input_restart_file, '.r.')
       if (i>0) then
          stoch_restfile = input_restart_file(1:i)//'r_stoch'//input_restart_file(i+2:k)
+
+         if (is_root_pe()) then
+           write(stdout,*) 'input_restart_file =', input_restart_file
+           write(stdout,*) 'stoch_restfile =', stoch_restfile
+         endif
       endif
   endif
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &


### PR DESCRIPTION
If MOM6 is writing so many restart fields to disk that FMS splits them across multiple restart files, the logic for determining the name of the restart for the stochastic_physics package needs to be applied to the first file listed (the one without "_N" between the datestamp and the .nc suffix)

Notes:
1. @gustavo-marques provided the modified code from a testcase he ran back in September
1. With this update, `ERS.TL319_t232.GW1850MARBL_JRA.derecho_intel` test passes; it had been failing because the additional tracers from MARBL generated 3 `mom6.r.` restart files instead of just one