### PR TITLE
MARBL OBC Segments w/ Generic Tracers

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -1799,15 +1799,14 @@ subroutine ModelAdvance(gcomp, rc)
     endif
   endif
 
+  call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
+  if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  Ice_ocean_boundary => ocean_internalstate%ptr%ice_ocean_boundary_type_ptr
+  ocean_public       => ocean_internalstate%ptr%ocean_public_type_ptr
+  ocean_state        => ocean_internalstate%ptr%ocean_state_type_ptr
+
   if (do_advance) then
-
-    call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    Ice_ocean_boundary => ocean_internalstate%ptr%ice_ocean_boundary_type_ptr
-    ocean_public       => ocean_internalstate%ptr%ocean_public_type_ptr
-    ocean_state        => ocean_internalstate%ptr%ocean_state_type_ptr
-
     !---------------
     ! Write diagnostics for import
     !---------------

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2929,7 +2929,13 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
   CS%HFrz = (US%Z_to_m * GV%m_to_H) * HFrz_z
 
-
+  if (associated(OBC_in)) then
+    ! This call allocates the arrays on the segments for open boundary data and initializes the
+    ! relevant vertical remapping structures.   It can only occur after the vertical grid has been
+    ! initialized.
+    call initialize_segment_data(G_in, GV, US, OBC_in, param_file)
+  endif
+  
   !   Shift from using the temporary dynamic grid type to using the final (potentially static)
   ! and properly rotated ocean-specific grid type and horizontal index type.
   if (CS%rotate_index) then
@@ -3146,12 +3152,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
     if (CS%debug_OBCs) call write_OBC_info(CS%OBC, G, GV, US)
   endif
-  if (associated(OBC_in)) then
-    ! This call allocates the arrays on the segments for open boundary data and initializes the
-    ! relevant vertical remapping structures.   It can only occur after the vertical grid has been
-    ! initialized.
-    call initialize_segment_data(G_in, GV, US, OBC_in, param_file)
-  endif
+
 
 
   if (present(waves_CSp)) then

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2929,12 +2929,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
   endif
   CS%HFrz = (US%Z_to_m * GV%m_to_H) * HFrz_z
 
-  if (associated(OBC_in)) then
-    ! This call allocates the arrays on the segments for open boundary data and initializes the
-    ! relevant vertical remapping structures.   It can only occur after the vertical grid has been
-    ! initialized.
-    call initialize_segment_data(G_in, GV, US, OBC_in, param_file)
-  endif
 
   !   Shift from using the temporary dynamic grid type to using the final (potentially static)
   ! and properly rotated ocean-specific grid type and horizontal index type.
@@ -3151,6 +3145,12 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
                           param_file, restart_CSp, use_temperature)
 
     if (CS%debug_OBCs) call write_OBC_info(CS%OBC, G, GV, US)
+  endif
+  if (associated(OBC_in)) then
+    ! This call allocates the arrays on the segments for open boundary data and initializes the
+    ! relevant vertical remapping structures.   It can only occur after the vertical grid has been
+    ! initialized.
+    call initialize_segment_data(G_in, GV, US, OBC_in, param_file)
   endif
 
 

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -2935,7 +2935,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
     ! initialized.
     call initialize_segment_data(G_in, GV, US, OBC_in, param_file)
   endif
-  
+
   !   Shift from using the temporary dynamic grid type to using the final (potentially static)
   ! and properly rotated ocean-specific grid type and horizontal index type.
   if (CS%rotate_index) then
@@ -3152,7 +3152,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, &
 
     if (CS%debug_OBCs) call write_OBC_info(CS%OBC, G, GV, US)
   endif
-
 
 
   if (present(waves_CSp)) then

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -47,7 +47,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public register_MARBL_tracers, initialize_MARBL_tracers, register_MARBL_tracer_segments, get_marbl_tracer_props
+public register_MARBL_tracers, initialize_MARBL_tracers, register_MARBL_tracer_segments, get_marbl_obc_params
 public MARBL_tracers_column_physics, MARBL_tracers_surface_state
 public MARBL_tracers_set_forcing
 public MARBL_tracers_stock, MARBL_tracers_get, MARBL_tracers_end
@@ -849,7 +849,7 @@ end function register_MARBL_tracers
 
 !> Register MARBL tracer file and field names.
 !! Each tracer segment must be contained in one file per tracer.
-subroutine get_marbl_tracer_props(varname, param_file, obc_src_file_name, obc_src_field_name)
+subroutine get_marbl_obc_params(varname, param_file, obc_src_file_name, obc_src_field_name)
   character(len=32),  intent(in)  :: varname              !< Tracer variable name used in MARBL parameter file
   type(param_file_type), intent(in) :: param_file         !< Run-time parameter file object
   character(len=256), intent(out) :: obc_src_file_name    !< Parsed file name containing tracer OBC data
@@ -857,7 +857,7 @@ subroutine get_marbl_tracer_props(varname, param_file, obc_src_file_name, obc_sr
 
 # include "version_variable.h"
 
-  character(len=128), parameter :: sub_name = 'get_marbl_tracer_props'
+  character(len=128), parameter :: sub_name = 'get_marbl_obc_params'
   character(len=512)            :: varstr    !< Full string from parameter file (e.g., "file.nc(tracer)")
   integer                       :: i1, i2    !< Indices for locating parentheses
 
@@ -883,7 +883,7 @@ subroutine get_marbl_tracer_props(varname, param_file, obc_src_file_name, obc_sr
   obc_src_file_name  = trim(varstr(1:i1-1))
   obc_src_field_name = trim(varstr(i1+1:i2-1))
 
-end subroutine get_marbl_tracer_props
+end subroutine get_marbl_obc_params
 
 !> Register OBC segments for MARBL tracers.
 !! Each MARBL tracer can have OBC data specified in a parameter file, and this
@@ -909,7 +909,7 @@ subroutine register_MARBL_tracer_segments(CS, GV, tr_Reg, param_file, OBC)
   do m = 1, CS%ntr
 
     ! Extract file and field names for this tracer from the MARBL parameter file.
-    call get_marbl_tracer_props( CS%tracer_data(m)%var_name, &
+    call get_marbl_obc_params( CS%tracer_data(m)%var_name, &
                                  param_file, &
                                  obc_src_file_name, &
                                  obc_src_field_name )

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -875,7 +875,7 @@ subroutine get_marbl_obc_params(varname, param_file, obc_src_file_name, obc_src_
   !   - filename.nc  → obc_src_file_name
   !   - fieldname    → obc_src_field_name
   !
-  ! Use INDEX for reliability instead of extract_word().
+  ! Using index instead of extract_word().
   !-----------------------------------------------------------------------
   i1 = index(varstr, '(')
   i2 = index(varstr, ')')

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -847,63 +847,96 @@ function register_MARBL_tracers(HI, GV, US, param_file, CS, tr_Reg, restart_CS, 
 
 end function register_MARBL_tracers
 
-!> Register MARBL tracer file and field names. Each segment must be in one file per tracer
-subroutine get_marbl_tracer_props(varname, ntr, param_file, obc_src_file_name, obc_src_field_name)
-  character(len=32), intent(in) :: varname            !< Control structure pointer
-  integer,               intent(in)  :: ntr        !< Index of the tracer
-  type(param_file_type), intent(in)  :: param_file !< Run-time parameter file
-  character(len=256),    intent(out) :: obc_src_file_name 
-  character(len=256),    intent(out) :: obc_src_field_name
-  character(len=512)                :: varstr
-  integer :: i1, i2
+!> Register MARBL tracer file and field names.
+!! Each tracer segment must be contained in one file per tracer.
+subroutine get_marbl_tracer_props(varname, param_file, obc_src_file_name, obc_src_field_name)
+  character(len=32),  intent(in)  :: varname              !< Tracer variable name used in MARBL parameter file
+  type(param_file_type), intent(in) :: param_file         !< Run-time parameter file object
+  character(len=256), intent(out) :: obc_src_file_name    !< Parsed file name containing tracer OBC data
+  character(len=256), intent(out) :: obc_src_field_name   !< Parsed field name inside that file
 
-! Get the param with OBC_DATA first
+# include "version_variable.h"
+
+  character(len=128), parameter :: sub_name = 'get_marbl_tracer_props'
+  character(len=512)            :: varstr    !< Full string from parameter file (e.g., "file.nc(tracer)")
+  integer                       :: i1, i2    !< Indices for locating parentheses
+
+  !-----------------------------------------------------------------------
+  ! Retrieve the OBC_DATA entry for this MARBL tracer.
+  ! Example entry format:
+  !     OBC_DATA_<varname> = file.nc(tracer_name)
+  !-----------------------------------------------------------------------
   call get_param(param_file, 'MARBL_tracers', 'OBC_DATA_' // varname, varstr)
 
-  ! varstr should of form filename.nc(varname), we need to get the filename.nc part to obc_src_file_name and varname part to the obc_src_field_name
-  ! Find parentheses manually (more reliable than extract_word)
+  !-----------------------------------------------------------------------
+  ! Parse the returned string:
+  !   varstr = "filename.nc(fieldname)"
+  ! Extract:
+  !   - filename.nc  → obc_src_file_name
+  !   - fieldname    → obc_src_field_name
+  !
+  ! Use INDEX for reliability instead of extract_word().
+  !-----------------------------------------------------------------------
   i1 = index(varstr, '(')
   i2 = index(varstr, ')')
-  ! obc_src_file_name = trim(extract_word(varstr, '(', 1))
-  ! obc_src_field_name = trim(extract_word(varstr, '(', 2))
-  ! obc_src_field_name = trim(extract_word(obc_src_field_name, ')', 1))
+
   obc_src_file_name  = trim(varstr(1:i1-1))
   obc_src_field_name = trim(varstr(i1+1:i2-1))
 
-
-
-
 end subroutine get_marbl_tracer_props
 
-!> Register OBC segments for MARBL tracers
-subroutine register_MARBL_tracer_segments(CS,GV, tr_Reg, param_file, OBC)
-  type(MARBL_tracers_CS), pointer    :: CS         !< Pointer to the control structure for this module.
-  type(verticalGrid_type),     intent(in) :: GV         !< The ocean's vertical grid structure
-                                                        !! where, and what open boundary conditions are used.
-  type(tracer_registry_type),  pointer    :: tr_Reg     !< Pointer to the control structure for the tracer
-                                                        !! advection and diffusion module.
-  type(param_file_type),       intent(in) :: param_file !< A structure to parse for run-time parameters
-  type(ocean_OBC_type),                  pointer       :: OBC     !< This open boundary condition
-  character(len=256)      :: obc_src_file_name, obc_src_field_name
-  integer :: n,m, ntr_id
-  real :: lfac_in   ! Multiplicative factor used in setting the tracer-specific inverse length
-                    ! scales associated with inflowing tracer reservoirs at OBCs [nondim]
-  real :: lfac_out  ! Multiplicative factor used in setting the tracer-specific inverse length
-                    ! scales associated with outflowing tracer reservoirs at OBCs [nondim]
+!> Register OBC segments for MARBL tracers.
+!! Each MARBL tracer can have OBC data specified in a parameter file, and this
+!! routine reads that mapping and registers the segments with the OBC system (using generic tracers).
+subroutine register_MARBL_tracer_segments(CS, GV, tr_Reg, param_file, OBC)
+  type(MARBL_tracers_CS),   pointer    :: CS         !< Control structure for MARBL tracer configuration
+  type(verticalGrid_type),  intent(in) :: GV         !< Ocean vertical grid structure
+  type(tracer_registry_type), pointer :: tr_Reg      !< Tracer advection/diffusion registry
+  type(param_file_type),    intent(in) :: param_file !< Runtime parameter file accessor
+  type(ocean_OBC_type),     pointer    :: OBC        !< Open boundary condition structure
 
-  ! This include declares and sets the variable "version".
-#   include "version_variable.h"
+  character(len=256) :: obc_src_file_name            !< Extracted filename for this tracer's OBC data
+  character(len=256) :: obc_src_field_name           !< Extracted field name within the file
+  integer            :: m                            !< Loop index over MARBL tracers
+
+# include "version_variable.h"
+
   character(len=128), parameter :: sub_name = 'register_MARBL_tracer_segments'
+
   if (.NOT. associated(OBC)) return
-  do m=1,CS%ntr
-      call get_marbl_tracer_props(CS%tracer_data(m)%var_name, m, param_file,obc_src_file_name,obc_src_field_name )
-      ! I don't like this, you have to have all boundaries of each tracer on one file. >:(  Who thought hardcoding this was the right way to do it? so like O2_obc_segment.nc has 02_segment_001 O2_segment_002
-      ! I can't even override these functions because get_obgc_tracers isn't flexible enough for this?? So the file reading can only be done from the file?
-      call set_obgc_segments_props(OBC,CS%tracer_data(m)%var_name,obc_src_file_name,obc_src_field_name,1.0,1.0) ! The last two vars are lfac_in and lfac_out
-      call register_obgc_segments(GV, OBC, tr_Reg, param_file, CS%tracer_data(m)%var_name)
-  enddo
+
+  ! Loop over all MARBL tracers and register the corresponding OBC segments.
+  do m = 1, CS%ntr
+
+    ! Extract file and field names for this tracer from the MARBL parameter file.
+    call get_marbl_tracer_props( CS%tracer_data(m)%var_name, &
+                                 param_file, &
+                                 obc_src_file_name, &
+                                 obc_src_field_name )
+
+    ! NOTE:
+    !   MARBL currently requires all OBC segments for a tracer to live in one file.
+    !   This is limiting, since files like "O2_obc_segment.nc" must contain
+    !   O2_segment_001, O2_segment_002, etc. There is no flexible override path for per-segment files
+    !   because get_obgc_props assumes this fixed structure.
+    !   Improving this would require extending the OBC file-reading layer.
+
+
+    ! Set properties that describe the OBC segments for this tracer.
+    ! lfac_in and lfac_out are scaling factors (set to default 1.0).
+    call set_obgc_segments_props( OBC, &
+                                  CS%tracer_data(m)%var_name, &
+                                  obc_src_file_name, &
+                                  obc_src_field_name, &
+                                  1.0, 1.0 )
+
+    ! Register the segments with the generic tracers system.
+    call register_obgc_segments( GV, OBC, tr_Reg, param_file, &
+                                 CS%tracer_data(m)%var_name )
+  end do
 
 end subroutine register_MARBL_tracer_segments
+
 
 !> This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
 !! and it sets up the tracer output.

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -47,7 +47,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public register_MARBL_tracers, initialize_MARBL_tracers, register_MARBL_tracer_segments, get_marbl_obc_params
+public register_MARBL_tracers, initialize_MARBL_tracers, register_MARBL_tracer_segments
 public MARBL_tracers_column_physics, MARBL_tracers_surface_state
 public MARBL_tracers_set_forcing
 public MARBL_tracers_stock, MARBL_tracers_get, MARBL_tracers_end
@@ -897,7 +897,7 @@ subroutine register_MARBL_tracer_segments(CS, GV, tr_Reg, param_file, OBC)
 
   character(len=256) :: obc_src_file_name            !< Extracted filename for this tracer's OBC data
   character(len=256) :: obc_src_field_name           !< Extracted field name within the file
-  integer            :: m                            !< Loop index over MARBL tracers
+  integer            :: m                             !< Loop index over MARBL tracers
 
 # include "version_variable.h"
 
@@ -919,7 +919,7 @@ subroutine register_MARBL_tracer_segments(CS, GV, tr_Reg, param_file, OBC)
     !   This is limiting, since files like "O2_obc_segment.nc" must contain
     !   O2_segment_001, O2_segment_002, etc. There is no flexible override path for per-segment files
     !   because get_obgc_props assumes this fixed structure.
-    !   Improving this would require extending the three functions below in MOM_open_boundary
+    !   Improving this would require extending the obgc functions in MOM_open_boundary
 
 
     ! Set properties that describe the OBC segments for this tracer.
@@ -932,7 +932,7 @@ subroutine register_MARBL_tracer_segments(CS, GV, tr_Reg, param_file, OBC)
 
     ! Register the segments with the generic tracers system.
     call register_obgc_segments( GV, OBC, tr_Reg, param_file, &
-                                 CS%tracer_data(m)%var_name )
+                                 CS%tracer_data(m)%var_name )     
   end do
 
 end subroutine register_MARBL_tracer_segments
@@ -1254,9 +1254,11 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
     end select
   endif
 
-  do m=1,CS%ntr
-      call fill_obgc_segments(G, GV, OBC, CS%tracer_data(m)%tr, CS%tracer_data(m)%var_name)
-  enddo
+  if (associated(OBC) .and. .NOT. restart) then
+    do m=1,CS%ntr
+        call fill_obgc_segments(G, GV, OBC, CS%tracer_data(m)%tr, CS%tracer_data(m)%var_name)
+    enddo
+  endif
 
 end subroutine initialize_MARBL_tracers
 

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -915,11 +915,11 @@ subroutine register_MARBL_tracer_segments(CS, GV, tr_Reg, param_file, OBC)
                                  obc_src_field_name )
 
     ! NOTE:
-    !   MARBL currently requires all OBC segments for a tracer to live in one file.
+    !   Generic tracers currently requires all OBC segments for a tracer to live in one file.
     !   This is limiting, since files like "O2_obc_segment.nc" must contain
     !   O2_segment_001, O2_segment_002, etc. There is no flexible override path for per-segment files
     !   because get_obgc_props assumes this fixed structure.
-    !   Improving this would require extending the OBC file-reading layer.
+    !   Improving this would require extending the three functions below in MOM_open_boundary
 
 
     ! Set properties that describe the OBC segments for this tracer.

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -47,7 +47,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public register_MARBL_tracers, initialize_MARBL_tracers
+public register_MARBL_tracers, initialize_MARBL_tracers, register_MARBL_tracer_segments
 public MARBL_tracers_column_physics, MARBL_tracers_surface_state
 public MARBL_tracers_set_forcing
 public MARBL_tracers_stock, MARBL_tracers_get, MARBL_tracers_end
@@ -846,6 +846,24 @@ function register_MARBL_tracers(HI, GV, US, param_file, CS, tr_Reg, restart_CS, 
 
 end function register_MARBL_tracers
 
+!> Register OBC segments for MARBL tracers
+subroutine register_MARBL_tracer_segments(CS,GV, tr_Reg, param_file, OBC)
+  type(MARBL_tracers_CS), pointer    :: CS         !< Pointer to the control structure for this module.
+  type(verticalGrid_type),     intent(in) :: GV         !< The ocean's vertical grid structure
+                                                        !! where, and what open boundary conditions are used.
+  type(tracer_registry_type),  pointer    :: tr_Reg     !< Pointer to the control structure for the tracer
+                                                        !! advection and diffusion module.
+  type(param_file_type),       intent(in) :: param_file !< A structure to parse for run-time parameters
+  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
+  type(ocean_OBC_type),                  pointer       :: OBC     !< This open boundary condition
+
+  ! This include declares and sets the variable "version".
+#   include "version_variable.h"
+  character(len=128), parameter :: sub_name = 'register_MARBL_tracer_segments'
+
+  
+end subroutine register_MARBL_tracer_segments
+
 !> This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)
 !! and it sets up the tracer output.
 subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag, OBC, CS, sponge_CSp)
@@ -865,7 +883,7 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
                                                                        !! call to register_MARBL_tracers.
   type(sponge_CS),                       pointer       :: sponge_CSp   !< A pointer to the control structure
                                                                        !! for the sponges, if they are in use.
-
+          
   ! Local variables
   character(len=200) :: log_message
   character(len=48) :: name       ! A variable's name in a NetCDF file.
@@ -1161,6 +1179,10 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
         call MOM_read_data(CS%restoring_I_tau_file, "RTAU", CS%I_tau(:,:,:), G%Domain)
     end select
   endif
+
+  do m=1,CS%ntr
+      call fill_obgc_segments(G, GV, OBC, CS%tracer_data(m)%tr, CS%tracer_data(m)%var_name)
+  enddo
 
 end subroutine initialize_MARBL_tracers
 

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -21,7 +21,7 @@ use MOM_interpolate,     only : forcing_timeseries_dataset
 use MOM_interpolate,     only : forcing_timeseries_set_time_type_vars
 use MOM_interpolate,     only : map_model_time_to_forcing_time
 use MOM_io,              only : file_exists, MOM_read_data, slasher, vardesc, var_desc, query_vardesc
-use MOM_open_boundary,   only : ocean_OBC_type
+use MOM_open_boundary,   only : ocean_OBC_type, fill_obgc_segments, register_obgc_segments, set_obgc_segments_props
 use MOM_remapping,       only : reintegrate_column
 use MOM_remapping,       only : remapping_CS, initialize_remapping, remapping_core_h
 use MOM_restart,         only : query_initialized, MOM_restart_CS, register_restart_field
@@ -47,7 +47,7 @@ implicit none ; private
 
 #include <MOM_memory.h>
 
-public register_MARBL_tracers, initialize_MARBL_tracers, register_MARBL_tracer_segments
+public register_MARBL_tracers, initialize_MARBL_tracers, register_MARBL_tracer_segments, get_marbl_tracer_props
 public MARBL_tracers_column_physics, MARBL_tracers_surface_state
 public MARBL_tracers_set_forcing
 public MARBL_tracers_stock, MARBL_tracers_get, MARBL_tracers_end
@@ -100,6 +100,7 @@ type(MARBL_interface_class) :: MARBL_instances
 
 !> Pointer to tracer concentration and to tracer_type in tracer registry
 type, private :: MARBL_tracer_data
+  character(len=32)          :: var_name             !< The name of the tracer in the tracer registry
   real, pointer              :: tr(:,:,:) => NULL() !< Array of tracers used in this subroutine [CU ~> conc]
                                                     !! (ALK tracers use meq m-3 instead of mmol m-3)
   type(tracer_type), pointer :: tr_ptr    => NULL() !< pointer to tracer inside Tr_reg
@@ -790,15 +791,15 @@ function register_MARBL_tracers(HI, GV, US, param_file, CS, tr_Reg, restart_CS, 
 
   do m=1,CS%ntr
     allocate(CS%tracer_data(m)%tr(isd:ied,jsd:jed,nz), source=0.0)
-    write(var_name(:),'(A)') trim(MARBL_instances%tracer_metadata(m)%short_name)
+    write(CS%tracer_data(m)%var_name(:),'(A)') trim(MARBL_instances%tracer_metadata(m)%short_name)
     write(desc_name(:),'(A)') trim(MARBL_instances%tracer_metadata(m)%long_name)
     write(units(:),'(A)') trim(MARBL_instances%tracer_metadata(m)%units)
-    CS%tr_desc(m) = var_desc(trim(var_name), trim(units), trim(desc_name), caller=mdl)
+    CS%tr_desc(m) = var_desc(trim(CS%tracer_data(m)%var_name), trim(units), trim(desc_name), caller=mdl)
 
     ! This is needed to force the compiler not to do a copy in the registration
     ! calls.  Curses on the designers and implementers of Fortran90.
     tr_ptr => CS%tracer_data(m)%tr(:,:,:)
-    call query_vardesc(CS%tr_desc(m), name=var_name, &
+    call query_vardesc(CS%tr_desc(m), name=CS%tracer_data(m)%var_name, &
                        caller="register_MARBL_tracers")
     ! Register the tracer for horizontal advection, diffusion, and restarts.
     call register_tracer(tr_ptr, tr_Reg, param_file, HI, GV, units = units, &
@@ -810,7 +811,7 @@ function register_MARBL_tracers(HI, GV, US, param_file, CS, tr_Reg, restart_CS, 
     ! values to the coupler (if any).  This is meta-code and its arguments will
     ! currently (deliberately) give fatal errors if it is used.
     if (CS%coupled_tracers) &
-      CS%ind_tr(m) = aof_set_coupler_flux(trim(var_name)//'_flux', &
+      CS%ind_tr(m) = aof_set_coupler_flux(trim(CS%tracer_data(m)%var_name)//'_flux', &
           flux_type=' ', implementation=' ', caller="register_MARBL_tracers")
   enddo
 
@@ -846,6 +847,34 @@ function register_MARBL_tracers(HI, GV, US, param_file, CS, tr_Reg, restart_CS, 
 
 end function register_MARBL_tracers
 
+!> Register MARBL tracer file and field names. Each segment must be in one file per tracer
+subroutine get_marbl_tracer_props(varname, ntr, param_file, obc_src_file_name, obc_src_field_name)
+  character(len=32), intent(in) :: varname            !< Control structure pointer
+  integer,               intent(in)  :: ntr        !< Index of the tracer
+  type(param_file_type), intent(in)  :: param_file !< Run-time parameter file
+  character(len=256),    intent(out) :: obc_src_file_name 
+  character(len=256),    intent(out) :: obc_src_field_name
+  character(len=512)                :: varstr
+  integer :: i1, i2
+
+! Get the param with OBC_DATA first
+  call get_param(param_file, 'MARBL_tracers', 'OBC_DATA_' // varname, varstr)
+
+  ! varstr should of form filename.nc(varname), we need to get the filename.nc part to obc_src_file_name and varname part to the obc_src_field_name
+  ! Find parentheses manually (more reliable than extract_word)
+  i1 = index(varstr, '(')
+  i2 = index(varstr, ')')
+  ! obc_src_file_name = trim(extract_word(varstr, '(', 1))
+  ! obc_src_field_name = trim(extract_word(varstr, '(', 2))
+  ! obc_src_field_name = trim(extract_word(obc_src_field_name, ')', 1))
+  obc_src_file_name  = trim(varstr(1:i1-1))
+  obc_src_field_name = trim(varstr(i1+1:i2-1))
+
+
+
+
+end subroutine get_marbl_tracer_props
+
 !> Register OBC segments for MARBL tracers
 subroutine register_MARBL_tracer_segments(CS,GV, tr_Reg, param_file, OBC)
   type(MARBL_tracers_CS), pointer    :: CS         !< Pointer to the control structure for this module.
@@ -854,14 +883,26 @@ subroutine register_MARBL_tracer_segments(CS,GV, tr_Reg, param_file, OBC)
   type(tracer_registry_type),  pointer    :: tr_Reg     !< Pointer to the control structure for the tracer
                                                         !! advection and diffusion module.
   type(param_file_type),       intent(in) :: param_file !< A structure to parse for run-time parameters
-  type(OBC_segment_type), pointer :: segment => NULL() ! pointer to segment type list
   type(ocean_OBC_type),                  pointer       :: OBC     !< This open boundary condition
+  character(len=256)      :: obc_src_file_name, obc_src_field_name
+  integer :: n,m, ntr_id
+  real :: lfac_in   ! Multiplicative factor used in setting the tracer-specific inverse length
+                    ! scales associated with inflowing tracer reservoirs at OBCs [nondim]
+  real :: lfac_out  ! Multiplicative factor used in setting the tracer-specific inverse length
+                    ! scales associated with outflowing tracer reservoirs at OBCs [nondim]
 
   ! This include declares and sets the variable "version".
 #   include "version_variable.h"
   character(len=128), parameter :: sub_name = 'register_MARBL_tracer_segments'
+  if (.NOT. associated(OBC)) return
+  do m=1,CS%ntr
+      call get_marbl_tracer_props(CS%tracer_data(m)%var_name, m, param_file,obc_src_file_name,obc_src_field_name )
+      ! I don't like this, you have to have all boundaries of each tracer on one file. >:(  Who thought hardcoding this was the right way to do it? so like O2_obc_segment.nc has 02_segment_001 O2_segment_002
+      ! I can't even override these functions because get_obgc_tracers isn't flexible enough for this?? So the file reading can only be done from the file?
+      call set_obgc_segments_props(OBC,CS%tracer_data(m)%var_name,obc_src_file_name,obc_src_field_name,1.0,1.0) ! The last two vars are lfac_in and lfac_out
+      call register_obgc_segments(GV, OBC, tr_Reg, param_file, CS%tracer_data(m)%var_name)
+  enddo
 
-  
 end subroutine register_MARBL_tracer_segments
 
 !> This subroutine initializes the CS%ntr tracer fields in tr(:,:,:,:)

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -957,7 +957,7 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
                                                                        !! call to register_MARBL_tracers.
   type(sponge_CS),                       pointer       :: sponge_CSp   !< A pointer to the control structure
                                                                        !! for the sponges, if they are in use.
-          
+
   ! Local variables
   character(len=200) :: log_message
   character(len=48) :: name       ! A variable's name in a NetCDF file.

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -876,7 +876,7 @@ subroutine get_marbl_obc_params(varname, param_file, obc_src_file_name, obc_src_
 
 # include "version_variable.h"
 
-  character(len=128), parameter :: sub_name = 'get_marbl_obc_params'
+  character(len=*), parameter :: sub_name = 'get_marbl_obc_params'
   character(len=512)            :: varstr    !< Full string from parameter file (e.g., "file.nc(tracer)")
   integer                       :: i1, i2    !< Indices for locating parentheses
 

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -951,7 +951,7 @@ subroutine register_MARBL_tracer_segments(CS, GV, tr_Reg, param_file, OBC)
 
     ! Register the segments with the generic tracers system.
     call register_obgc_segments( GV, OBC, tr_Reg, param_file, &
-                                 CS%tracer_data(m)%var_name )     
+                                 CS%tracer_data(m)%var_name )
   end do
 
 end subroutine register_MARBL_tracer_segments

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -39,7 +39,7 @@ use RGC_tracer, only : RGC_tracer_end, RGC_tracer_CS
 use ideal_age_example, only : register_ideal_age_tracer, initialize_ideal_age_tracer
 use ideal_age_example, only : ideal_age_tracer_column_physics, ideal_age_tracer_surface_state
 use ideal_age_example, only : ideal_age_stock, ideal_age_example_end, ideal_age_tracer_CS
-use MARBL_tracers, only : register_MARBL_tracers, initialize_MARBL_tracers
+use MARBL_tracers, only : register_MARBL_tracers, initialize_MARBL_tracers, register_MARBL_tracer_segments
 use MARBL_tracers, only : MARBL_tracers_column_physics, MARBL_tracers_set_forcing
 use MARBL_tracers, only : MARBL_tracers_surface_state, MARBL_tracers_get
 use MARBL_tracers, only : MARBL_tracers_stock, MARBL_tracers_end, MARBL_tracers_CS
@@ -390,6 +390,8 @@ subroutine call_tracer_register_obc_segments(GV, param_file, CS, tr_Reg, OBC)
 
   if (CS%use_MOM_generic_tracer) &
       call register_MOM_generic_tracer_segments(CS%MOM_generic_tracer_CSp, GV, OBC, tr_Reg, param_file)
+  if (CS%use_MARBL_tracers) &
+      call register_MARBL_tracer_segments(CS%MARBL_tracers_CSp, GV,tr_Reg, param_file, OBC)
 
 end subroutine call_tracer_register_obc_segments
 


### PR DESCRIPTION
Description:
Changes required for MARBL regionally & Alper's change so that GLOFAS runoff will work.

Changes:
1. A function called `register_MARBL_tracer_segments` that reads the parameter file and registers the correct MOM_open_boundary functions to read from files.
2. A function called `get_marbl_obc_params` to read MARBL OBC tracers from the parameter file. Parameters need to be of the form `OBC_DATA_{tracer}={filename}({variablename})`
3. Alper's change to noupc cap so GLOFAS works
4. A change to `initialize_marbl_tracers` to properly initialize the OBC reservoirs
5. A change to MOM_tracer_flow_control to call the new register_MARBL_tracer_segments function.