### PR TITLE
Enforce tracer diffusivity minimum (KHTR_MIN) at all depths

### DIFF
--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -505,21 +505,43 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
         enddo
       enddo
     enddo
+
     if (CS%KhTr_use_vert_struct) then
-      do K=2,nz+1
-        do J=js-1,je
-          do i=is,ie
-            Coef_y(i,J,K) = Coef_y(i,J,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i,j+1,k-1) )
+      if (CS%full_depth_khtr_min) then
+        do K=2,nz+1
+          do J=js-1,je
+            do i=is,ie
+              Coef_y(i,J,K) = Coef_y(i,J,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i,j+1,k-1) )
+              Coef_min = I_numitts * dt * (CS%KhTr_min*(G%dx_Cv(i,J)*G%IdyCv(i,J)))
+              Coef_y(i,J,K) = max(Coef_y(i,J,K), Coef_min)
+            enddo
           enddo
         enddo
-      enddo
-      do k=2,nz+1
-        do j=js,je
-          do I=is-1,ie
-            Coef_x(I,j,K) = Coef_x(I,j,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i+1,j,k-1) )
+        do k=2,nz+1
+          do j=js,je
+            do I=is-1,ie
+              Coef_x(I,j,K) = Coef_x(I,j,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i+1,j,k-1) )
+              Coef_min = I_numitts * dt * (CS%KhTr_min*(G%dy_Cu(I,j)*G%IdxCu(I,j)))
+              Coef_x(I,j,K) = max(Coef_x(I,j,K), Coef_min)
+            enddo
           enddo
         enddo
-      enddo
+      else
+        do K=2,nz+1
+          do J=js-1,je
+            do i=is,ie
+              Coef_y(i,J,K) = Coef_y(i,J,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i,j+1,k-1) )
+            enddo
+          enddo
+        enddo
+        do k=2,nz+1
+          do j=js,je
+            do I=is-1,ie
+              Coef_x(I,j,K) = Coef_x(I,j,1) * 0.5 * ( VarMix%ebt_struct(i,j,k-1) + VarMix%ebt_struct(i+1,j,k-1) )
+            enddo
+          enddo
+        enddo
+      endif
     endif
 
     do itt=1,num_itts
@@ -633,13 +655,24 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
       Kh_u(I,j,:) = G%mask2dCu(I,j)*Kh_u(I,j,1)
     enddo ; enddo
     if (CS%KhTr_use_vert_struct) then
-      do K=2,nz+1
-        do j=js,je
-          do I=is-1,ie
-            Kh_u(I,j,K) = Kh_u(I,j,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i+1,j,k-1) )
+      if (CS%full_depth_khtr_min) then
+        do K=2,nz+1
+          do j=js,je
+            do I=is-1,ie
+              Kh_u(I,j,K) = Kh_u(I,j,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i+1,j,k-1) )
+              Kh_u(I,j,K) = max(Kh_u(I,j,K), CS%KhTr_min)
+            enddo
           enddo
         enddo
-      enddo
+      else
+        do K=2,nz+1
+          do j=js,je
+            do I=is-1,ie
+              Kh_u(I,j,K) = Kh_u(I,j,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i+1,j,k-1) )
+            enddo
+          enddo
+        enddo
+      endif
     endif
     !call post_data(CS%id_KhTr_u, Kh_u, CS%diag, is_static=.false., mask=G%mask2dCu)
     call post_data(CS%id_KhTr_u, Kh_u, CS%diag)
@@ -649,13 +682,24 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
       Kh_v(i,J,:) = G%mask2dCv(i,J)*Kh_v(i,J,1)
     enddo ; enddo
     if (CS%KhTr_use_vert_struct) then
-      do K=2,nz+1
-        do J=js-1,je
-          do i=is,ie
-            Kh_v(i,J,K) = Kh_v(i,J,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i,j+1,k-1) )
+      if (CS%full_depth_khtr_min) then
+        do K=2,nz+1
+          do J=js-1,je
+            do i=is,ie
+              Kh_v(i,J,K) = Kh_v(i,J,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i,j+1,k-1) )
+              Kh_v(i,J,K) = max(Kh_v(i,J,K), CS%KhTr_min)
+            enddo
           enddo
         enddo
-      enddo
+      else
+        do K=2,nz+1
+          do J=js-1,je
+            do i=is,ie
+              Kh_v(i,J,K) = Kh_v(i,J,1) * 0.5 * ( VarMix%khtr_struct(i,j,k-1) + VarMix%khtr_struct(i,j+1,k-1) )
+            enddo
+          enddo
+        enddo
+      endif
     endif
     !call post_data(CS%id_KhTr_v, Kh_v, CS%diag, is_static=.false., mask=G%mask2dCv)
     call post_data(CS%id_KhTr_v, Kh_v, CS%diag)
@@ -675,10 +719,19 @@ subroutine tracer_hordiff(h, dt, MEKE, VarMix, visc, G, GV, US, CS, Reg, tv, do_
       Kh_h(i,j,:) = normalize*G%mask2dT(i,j)*((Kh_u(I-1,j,1)+Kh_u(I,j,1)) + &
                                              (Kh_v(i,J-1,1)+Kh_v(i,J,1)))
       if (CS%KhTr_use_vert_struct) then
-        do K=2,nz+1
-          Kh_h(i,j,K) = normalize*G%mask2dT(i,j)*VarMix%khtr_struct(i,j,k-1)*((Kh_u(I-1,j,1)+Kh_u(I,j,1)) + &
-                                                                            (Kh_v(i,J-1,1)+Kh_v(i,J,1)))
-        enddo
+        if (CS%full_depth_khtr_min) then
+          do K=2,nz+1
+            Kh_h(i,j,K) = normalize*G%mask2dT(i,j)*VarMix%khtr_struct(i,j,k-1)*((Kh_u(I-1,j,1)+Kh_u(I,j,1)) + &
+                                                                              (Kh_v(i,J-1,1)+Kh_v(i,J,1)))
+            Kh_h(i,j,K) = max(Kh_h(i,j,K), CS%KhTr_min)
+          enddo
+
+        else
+          do K=2,nz+1
+            Kh_h(i,j,K) = normalize*G%mask2dT(i,j)*VarMix%khtr_struct(i,j,k-1)*((Kh_u(I-1,j,1)+Kh_u(I,j,1)) + &
+                                                                              (Kh_v(i,J-1,1)+Kh_v(i,J,1)))
+          enddo
+        endif
       endif
     enddo ; enddo
     !call post_data(CS%id_KhTr_h, Kh_h, CS%diag, is_static=.false., mask=G%mask2dT)


### PR DESCRIPTION
This PR enforces the minimum tracer diffusivity throughout the entire water column when using a vertically varying diffusivity structure (`KHTR_USE_EBT_STRUCT=True`). The previous implementation missed updating the neutral diffusion part and the diagnostics `KhTr_u` and `KhTr_v`.

Parameter `FULL_DEPTH_KHTR_MIN` (default = False) controls whether `KHTR_MIN` is applied as a lower bound at all depths. When `FULL_DEPTH_KHTR_MIN=True`, `KHTR_MIN` is enforced at every depth level for `Coef_x`, `Coef_y`, `Kh_u`, `Kh_v`, and `Kh_h`. When `FULL_DEPTH_KHTR_MIN=False` (default), the previous behavior is retained: the vertical structure uses VarMix%ebt_struct instead of VarMix%khtr_struct for Coef_x/Coef_y, and `KHTR_MIN` is only enforced at the surface.

**Motivation:**
When using vertically varying tracer diffusivity (`KHTR_USE_EBT_STRUCT=True`), `KHTR_MIN` was previously enforced only in the surface layer. This could result in very weak or near-zero diffusivity in the ocean interior. The new option allows users to enforce a minimum diffusivity throughout the water column.

`FULL_DEPTH_KHTR_MIN` is only read and applied when both `KHTR_USE_EBT_STRUCT=True` and` KHTR_MIN > 0`.

Changes answer for **pr_mom**, but passes other tests:
/glade/derecho/scratch/gmarques/cesm.tests/pr_mom/cesm3_0_alpha08g--khtr_min.intel/cs.status.20260312_154108_figy5w