### PR TITLE
*Cap Lam2 to avoid excessive Langmuir enhancement

### DIFF
--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1185,7 +1185,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   !$OMP                           BEdE_ER_1d, ERdepth, BEdE_ER, PU_TKE, PS_TKE, PB_TKE, kbl), &
   !$OMP                           shared(G, GV, CS, US, uStar, h, dz, buoy_scale, buoyFlux, &
   !$OMP                           Temp, Salt, waves, tv, GoRho, GoRho_Z_L2, u, v, lamult,   &
-  !$OMP                           Vt_layer)
+  !$OMP                           Vt_layer, Lam2_max)
 
   do j = G%jsc, G%jec
     do i = G%isc, G%iec ; if (G%mask2dT(i,j) > 0.0) then

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1166,7 +1166,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   endif
   buoy_scale = US%L_to_m**2*US%s_to_T**3
 
-  Lam2_max = CS%La_min**-2
+  Lam2_max = CS%La_min**(-2)
 
   ! Find the vertical distances across layers.
   call thickness_to_dz(h, tv, dz, G, GV, US)

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -86,7 +86,8 @@ type, public :: KPP_CS ; private
   real    :: vonKarman                 !< von Karman constant (dimensionless) [nondim]
   real    :: cs                        !< Parameter for computing velocity scale function (dimensionless) [nondim]
   real    :: cs2                       !< Parameter for multiplying by non-local term [nondim]
-                                       !   This is active for NLT_SHAPE_CUBIC_LMD only
+                                       !! This is active for NLT_SHAPE_CUBIC_LMD only
+  real    :: La_min                    !< An arbitrary lower-bound on the Langmuir number [nondim].
   logical :: enhance_diffusion         !< If True, add enhanced diffusivity at base of boundary layer.
   character(len=32) :: interpType      !< Type of interpolation to compute bulk Richardson number
   character(len=32) :: interpType2     !< Type of interpolation to compute diff and visc at OBL_depth
@@ -556,6 +557,12 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive)
   call closeParameterBlock(paramFile)
 
   call get_param(paramFile, mdl, 'DEBUG', CS%debug, default=.False., do_not_log=.True.)
+
+  call get_param(paramFile, mdl, "MIN_LANGMUIR", CS%La_min,    &
+         "A minimum value for all Langmuir numbers that is not physical, "//&
+         "but is likely only encountered when the wind is very small and "//&
+         "therefore its effects should be mostly benign.", &
+         units="nondim", default=0.05, do_not_log=.true.)
 
   call CVMix_init_kpp( Ri_crit=CS%Ri_crit,                 &
                        minOBLdepth=US%Z_to_m*CS%minOBLdepth, &
@@ -1136,7 +1143,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   real :: check ! Entrainment Rule Boundary layer depth  CVMix_kpp_compute_ER_depth in MKS units [m]
   real :: Llimit  ! Stable boundary Layer Limit =  vonk Lstar [Z ~> m]
   integer :: kbl  ! index of cell containing boundary layer depth [nondim]
-  real, parameter :: Lam2_max = 20.0 ! Upper bound for Lam2 [nondim]
+  real    :: Lam2_max ! Upper bound for Lam2 [nondim]
 
   if (CS%Stokes_Mixing .and. .not.associated(Waves)) call MOM_error(FATAL, &
       "KPP_compute_BLD: The Waves control structure must be associated if STOKES_MIXING is True.")
@@ -1158,6 +1165,8 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
     GoRho_Z_L2 = US%L_to_Z**2 * GV%g_Earth * GV%RZ_to_H
   endif
   buoy_scale = US%L_to_m**2*US%s_to_T**3
+
+  Lam2_max = CS%La_min**-2
 
   ! Find the vertical distances across layers.
   call thickness_to_dz(h, tv, dz, G, GV, US)

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1136,6 +1136,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
   real :: check ! Entrainment Rule Boundary layer depth  CVMix_kpp_compute_ER_depth in MKS units [m]
   real :: Llimit  ! Stable boundary Layer Limit =  vonk Lstar [Z ~> m]
   integer :: kbl  ! index of cell containing boundary layer depth [nondim]
+  real, parameter :: Lam2_max = 20.0 ! Upper bound for Lam2 [nondim]
 
   if (CS%Stokes_Mixing .and. .not.associated(Waves)) call MOM_error(FATAL, &
       "KPP_compute_BLD: The Waves control structure must be associated if STOKES_MIXING is True.")
@@ -1527,6 +1528,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
                 StokesXI,BEdE_ER,PU_TKE,PS_TKE,PB_TKE,CVMix_kpp_params_user=CS%KPP_params )
 
         CS%Lam2(i,j)   = sqrt(US_Hi(1)**2+VS_Hi(1)**2) / surfFricVel
+        CS%Lam2(i,j)   = MIN(CS%Lam2(i,j), Lam2_max)
         CS%PU_TKE(i,j) = PU_TKE
         CS%PS_TKE(i,j) = PS_TKE
         CS%PB_TKE(i,j) = PB_TKE


### PR DESCRIPTION
Use an existing parameter (`MIN_LANGMUIR`, default is 0.05) to define the maximum value for the inverse turbulent Langmuir number squared (`Lam2_max = MIN_LANGMUIR**-2 `, default is 400) in `KPP_compute_BLD`.

In non-equilibrium conditions (e.g., swell-dominated or weak winds), `Lam2 = Us/u*` can become unrealistically large due to a small friction velocity. This can lead to excessive Langmuir-driven mixing. Capping `Lam2` prevents these pathological values while remaining consistent with expected physical ranges (equilibrium values are ~11). Below is a daily mean comparison between a case with a limiter introduced in this PR (top panel) versus without the limiter (middle panel):

<img width="775" height="804" alt="image" src="https://github.com/user-attachments/assets/dce461df-c591-4c48-9da4-e126fdcaebd0" />


This PR changes answers.