### PR TITLE
Apply minOBLdepth when it's set to ERdepth

### DIFF
--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -1439,7 +1439,7 @@ subroutine KPP_compute_BLD(CS, G, GV, US, h, Temp, Salt, u, v, tv, uStar, buoyFl
                      CVMix_kpp_params_user=CS%KPP_params ) ! KPP parameters
 
           if ( ERdepth > -iFaceHeight(2) ) then                          ! deeper than top layer
-            CS%OBLdepth(i,j) = US%m_to_Z * ERdepth         !  min( ERdepth , -zBottomMinusOffset )
+            CS%OBLdepth(i,j) = max(US%m_to_Z * ERdepth, CS%minOBLdepth)  ! min( ERdepth , -zBottomMinusOffset )
             CS%ERdepth(i,j) = 100.  ! check and diagnostic for ER depth calculated
           endif
         endif


### PR DESCRIPTION
- Make sure to apply the `minOBLdepth` constraint when OBLdpth is set to ERdepth in Stokes MOST implementation.
- Also update CVMix hash to fix out-of-bounds access on zk in cvmix_kpp_compute_StokesXi.