### PR TITLE
Increased file name size

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -362,7 +362,7 @@ type, public :: MOM_control_struct ; private
 
   ! Variables needed to reach between start and finish phases of initialization
   logical :: write_IC           !< If true, then the initial conditions will be written to file
-  character(len=120) :: IC_file !< A file into which the initial conditions are
+  character(len=512) :: IC_file !< A file into which the initial conditions are
                                 !! written in a new run if SAVE_INITIAL_CONDS is true.
 
   logical :: calc_rho_for_sea_lev !< If true, calculate rho to convert pressure to sea level

--- a/src/framework/MOM_restart.F90
+++ b/src/framework/MOM_restart.F90
@@ -1590,7 +1590,7 @@ subroutine save_restart(directory, time, G, CS, time_stamped, filename, GV, num_
   type(MOM_field) :: fields(CS%max_fields) ! Opaque types containing metadata describing
                                         ! each variable that will be written.
   character(len=512) :: restartpath     ! The restart file path (dir/file).
-  character(len=256) :: restartname     ! The restart file name (no dir).
+  character(len=512) :: restartname     ! The restart file name (no dir).
   character(len=8)   :: suffix          ! A suffix (like _2) that is appended
                                         ! to the name of files after the first.
   integer(kind=int64) :: var_sz, size_in_file ! The size in bytes of each variable


### PR DESCRIPTION
src/core/MOM.F90
src/framework/MOM_restart.F90
  Handle CESM test names with multiple test_mods.
  Was needed during low-res MOM6 and CESM3 low-res tests.
  It seems plausible that it will be needed in other testing scenarios.