### PR TITLE
OBC Restarts Failing Fix 

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -469,41 +469,37 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     ! Update OBC ramp value as function of time
     call update_OBC_ramp(Time_local, CS%OBC, US)
 
-    ! === OBC-exterior h fix: rebuild the zero-gradient OBC-exterior h halo, which is ===
-    ! not reconstructed bit-for-bit across an exact restart. vertvisc_coef projects
-    ! thickness outward across OBCs and reads this exterior h/dz, so a stale/inconsistent
-    ! exterior value seeds a last-bit velocity difference that breaks exact restart.
-    ! Two passes (E/W exterior columns, then N/S exterior rows) so diagonal corner cells
-    ! trace back to the bit-perfect interior h rather than a stale exterior cell.
-    ! Pass 1: E/W segments -- fill exterior column from the first interior column.
-    do n=1,CS%OBC%number_of_segments
-      segment => CS%OBC%segment(n)
-      if (.not. segment%on_pe) cycle
-      if (.not. segment%is_E_or_W) cycle
-      I = segment%HI%IsdB
-      do k=1,nz ; do j=segment%HI%jsd,segment%HI%jed
-        if (segment%direction == OBC_DIRECTION_W) then
-          h(I,j,k)   = h(I+1,j,k)
-        elseif (segment%direction == OBC_DIRECTION_E) then
-          h(I+1,j,k) = h(I,j,k)
+    ! === OBC-exterior h fix (minimal): the OBC-exterior h halo is not reconstructed
+    ! bit-for-bit across an exact restart, and vertvisc_coef reads it (zero-gradient
+    ! projection across OBCs), seeding a last-bit velocity divergence. Rebuild it here with a
+    ! single in-place zero-gradient fill over all segments: copy the first interior thickness
+    ! into the exterior ghost cell. u-points (E/W) and v-points (N/S) only read same-row /
+    ! same-column neighbours, never the diagonal corner, so no corner handling is needed.
+    if (associated(CS%OBC)) then
+      do n=1,CS%OBC%number_of_segments
+        segment => CS%OBC%segment(n)
+        if (.not. segment%on_pe) cycle
+        if (segment%is_E_or_W) then
+          I = segment%HI%IsdB
+          do k=1,nz ; do j=segment%HI%jsd,segment%HI%jed
+            if (segment%direction == OBC_DIRECTION_W) then
+              h(I,j,k)   = h(I+1,j,k)
+            elseif (segment%direction == OBC_DIRECTION_E) then
+              h(I+1,j,k) = h(I,j,k)
+            endif
+          enddo ; enddo
+        elseif (segment%is_N_or_S) then
+          J = segment%HI%JsdB
+          do k=1,nz ; do i=segment%HI%isd,segment%HI%ied
+            if (segment%direction == OBC_DIRECTION_S) then
+              h(i,J,k)   = h(i,J+1,k)
+            elseif (segment%direction == OBC_DIRECTION_N) then
+              h(i,J+1,k) = h(i,J,k)
+            endif
+          enddo ; enddo
         endif
-      enddo ; enddo
-    enddo
-    ! Pass 2: N/S segments -- fill exterior row; corner cells pick up the E/W-filled
-    ! (interior-traced) column from pass 1.
-    do n=1,CS%OBC%number_of_segments
-      segment => CS%OBC%segment(n)
-      if (.not. segment%on_pe) cycle
-      if (.not. segment%is_N_or_S) cycle
-      J = segment%HI%JsdB
-      do k=1,nz ; do i=segment%HI%isd,segment%HI%ied
-        if (segment%direction == OBC_DIRECTION_S) then
-          h(i,J,k)   = h(i,J+1,k)
-        elseif (segment%direction == OBC_DIRECTION_N) then
-          h(i,J+1,k) = h(i,J,k)
-        endif
-      enddo ; enddo
-    enddo
+      enddo
+    endif
     ! === end OBC-exterior h fix ===
 
     do k=1,nz ; do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -60,6 +60,8 @@ use MOM_interface_heights,     only : thickness_to_dz, find_col_avg_SpV
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types,            only : MEKE_type
 use MOM_open_boundary,         only : ocean_OBC_type, radiation_open_bdry_conds
+use MOM_open_boundary,         only : OBC_segment_type, OBC_DIRECTION_E, OBC_DIRECTION_W
+use MOM_open_boundary,         only : OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_open_boundary,         only : open_boundary_zero_normal_flow, open_boundary_query
 use MOM_open_boundary,         only : open_boundary_test_extern_h, update_OBC_ramp
 use MOM_open_boundary,         only : copy_thickness_reservoirs
@@ -419,6 +421,8 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: cont_stencil, obc_stencil, vel_stencil
   integer :: cor_stencil
+  integer :: n                                         ! OBC segment loop index (OBC-exterior h fix)
+  type(OBC_segment_type), pointer :: segment => NULL() ! OBC segment (OBC-exterior h fix)
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -464,6 +468,43 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
     ! Update OBC ramp value as function of time
     call update_OBC_ramp(Time_local, CS%OBC, US)
+
+    ! === OBC-exterior h fix: rebuild the zero-gradient OBC-exterior h halo, which is ===
+    ! not reconstructed bit-for-bit across an exact restart. vertvisc_coef projects
+    ! thickness outward across OBCs and reads this exterior h/dz, so a stale/inconsistent
+    ! exterior value seeds a last-bit velocity difference that breaks exact restart.
+    ! Two passes (E/W exterior columns, then N/S exterior rows) so diagonal corner cells
+    ! trace back to the bit-perfect interior h rather than a stale exterior cell.
+    ! Pass 1: E/W segments -- fill exterior column from the first interior column.
+    do n=1,CS%OBC%number_of_segments
+      segment => CS%OBC%segment(n)
+      if (.not. segment%on_pe) cycle
+      if (.not. segment%is_E_or_W) cycle
+      I = segment%HI%IsdB
+      do k=1,nz ; do j=segment%HI%jsd,segment%HI%jed
+        if (segment%direction == OBC_DIRECTION_W) then
+          h(I,j,k)   = h(I+1,j,k)
+        elseif (segment%direction == OBC_DIRECTION_E) then
+          h(I+1,j,k) = h(I,j,k)
+        endif
+      enddo ; enddo
+    enddo
+    ! Pass 2: N/S segments -- fill exterior row; corner cells pick up the E/W-filled
+    ! (interior-traced) column from pass 1.
+    do n=1,CS%OBC%number_of_segments
+      segment => CS%OBC%segment(n)
+      if (.not. segment%on_pe) cycle
+      if (.not. segment%is_N_or_S) cycle
+      J = segment%HI%JsdB
+      do k=1,nz ; do i=segment%HI%isd,segment%HI%ied
+        if (segment%direction == OBC_DIRECTION_S) then
+          h(i,J,k)   = h(i,J+1,k)
+        elseif (segment%direction == OBC_DIRECTION_N) then
+          h(i,J+1,k) = h(i,J,k)
+        endif
+      enddo ; enddo
+    enddo
+    ! === end OBC-exterior h fix ===
 
     do k=1,nz ; do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB
       u_old_rad_OBC(I,j,k) = u_av(I,j,k)


### PR DESCRIPTION
**Details:**

When OBCs are on, we are failing restart tests (Tests here: https://github.com/ESCOMP/MOM_interface/pull/315). When OBCs are OFF (OBC number of segments are zero) it passes.

**Reproduce:**

1. I'm using a hodgepodge of branches and checkouts required to run regional MOM6 inside the CESM, which is mostly captured here: https://github.com/CROCODILE-CESM/CESM/tree/full_regional_cesm

2. Run a simple ERS test: 
```
qcmd -A NCGD0011 -- /glade/work/manishrv/installs/cesm3_maddd_new/cime/scripts/create_test --test-root /glade/derecho/scratch/manishrv/tests/regional/reg_ers --generate /glade/derecho/scratch/manishrv/baselines/regional ERS_Ld9.USER_RES.CR_JRA.derecho_intel.mom-regional-base -o --no-run
```

**Root Cause:**

With Claude's help and a lot of iteration, the issue seems to be that across an exact restart, the OBC-exterior h halo (the ghost ring just outside open-boundary segments) is not reconstructed bit-for-bit. The interior thickness restarts perfectly, but the exterior ghost cells come back different: the restart file stores only the computational domain, and the existing thickness-reservoir restart path (h_res_x/h_res_y, gated by use_h_res) does not restore the value the friction solve needs.

That stale ghost h is consumed by vertvisc's DIRECT_STRESS body force (MOM_vert_friction.F90, h_a = 0.5*(h(i,j,k)+h(i+1,j,k)), ~L698 u / L918 v), which spreads wind stress over the top HMIX_STRESS of fluid and reads the ghost cell with no OBC projection — perturbing the surface velocity and breaking restart. (vertvisc_coef reads the ghost too but already projects it away with a zero-gradient condition, so its coefficients stay bit-perfect; the .z. remapped diagnostics also read it.)

**The fix:**
There are three, the first of which is a workaround.

1. DIRECT_STRESS = False. This is the only consumer that was using the halo ghost ring without shielding, restarts still fail because the z-remapped diagnostics (the ".z." files) seem to use it as well, but the model itself restarts perfectly.
2. This PR! We set the halo to be the exact same thickness as the first thickness within computation domain. This is not without merit, in vertvisc_coef, there is a similar protection but it's only for that routine
3. Same as 1), a fix in direct stress: https://github.com/ACCESS-NRI/MOM6/issues/54, so you still get the minor z file differences.
