### PR TITLE
fix MARBL RIV_FLUX diagnostics

### DIFF
--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -1798,15 +1798,20 @@ subroutine MARBL_tracers_column_physics(h_old, ea, eb, fluxes, dt, G, GV, US, CS
       do k=1,nz ;do j=js,je ; do i=is,ie
         h_work(i,j,k) = h_old(i,j,k)
       enddo ; enddo ; enddo
-      ! CS%RIV_FLUXES is conc m/s, in_flux_optional expects time-integrated flux (conc H)
-      do j=js,je ; do i=is,ie
-        riv_flux_loc(i,j) = (CS%RIV_FLUXES(i,j,m) * (dt*US%T_to_s)) * GV%m_to_H
-      enddo ; enddo
-      if (CS%debug) &
-        call hchksum(riv_flux_loc(:,:), &
-            trim(MARBL_instances%tracer_metadata(m)%short_name)//' riv flux', G%HI, unscale=GV%H_to_m)
-      call applyTracerBoundaryFluxesInOut(G, GV, CS%tracer_data(m)%tr(:,:,:) , dt, fluxes, h_work, &
-          evap_CFL_limit, minimum_forcing_depth, in_flux_optional=riv_flux_loc)
+      if (CS%read_riv_fluxes) then
+        ! CS%RIV_FLUXES is conc m/s, in_flux_optional expects time-integrated flux (conc H)
+        do j=js,je ; do i=is,ie
+          riv_flux_loc(i,j) = (CS%RIV_FLUXES(i,j,m) * (dt*US%T_to_s)) * GV%m_to_H
+        enddo ; enddo
+        if (CS%debug) &
+          call hchksum(riv_flux_loc(:,:), &
+              trim(MARBL_instances%tracer_metadata(m)%short_name)//' riv flux', G%HI, unscale=GV%H_to_m)
+        call applyTracerBoundaryFluxesInOut(G, GV, CS%tracer_data(m)%tr(:,:,:) , dt, fluxes, h_work, &
+            evap_CFL_limit, minimum_forcing_depth, in_flux_optional=riv_flux_loc)
+      else
+        call applyTracerBoundaryFluxesInOut(G, GV, CS%tracer_data(m)%tr(:,:,:) , dt, fluxes, h_work, &
+            evap_CFL_limit, minimum_forcing_depth)
+      endif
       call tracer_vertdiff(h_work, ea, eb, dt, CS%tracer_data(m)%tr(:,:,:), G, GV, &
           sfc_flux=GV%Rho0 * CS%STF(:,:,m))
     enddo
@@ -1893,6 +1898,43 @@ subroutine MARBL_tracers_column_physics(h_old, ea, eb, fluxes, dt, G, GV, US, CS
     enddo
   endif
 
+  if (CS%read_riv_fluxes) then
+    if (CS%no3_riv_flux > 0 .and. CS%tracer_inds%no3_ind > 0) &
+      call post_data(CS%no3_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%no3_ind), CS%diag)
+    if (CS%po4_riv_flux > 0 .and. CS%tracer_inds%po4_ind > 0) &
+      call post_data(CS%po4_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%po4_ind), CS%diag)
+    if (CS%don_riv_flux > 0 .and. CS%tracer_inds%don_ind > 0) &
+      call post_data(CS%don_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%don_ind), CS%diag)
+    if (CS%donr_riv_flux > 0 .and. CS%tracer_inds%donr_ind > 0) &
+      call post_data(CS%donr_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%donr_ind), CS%diag)
+    if (CS%dop_riv_flux > 0 .and. CS%tracer_inds%dop_ind > 0) &
+      call post_data(CS%dop_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%dop_ind), CS%diag)
+    if (CS%dopr_riv_flux > 0 .and. CS%tracer_inds%dopr_ind > 0) &
+      call post_data(CS%dopr_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%dopr_ind), CS%diag)
+    if (CS%sio3_riv_flux > 0 .and. CS%tracer_inds%sio3_ind > 0) &
+      call post_data(CS%sio3_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%sio3_ind), CS%diag)
+    if (CS%fe_riv_flux > 0 .and. CS%tracer_inds%fe_ind > 0) &
+      call post_data(CS%fe_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%fe_ind), CS%diag)
+    if (CS%doc_riv_flux > 0 .and. CS%tracer_inds%doc_ind > 0) &
+      call post_data(CS%doc_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%doc_ind), CS%diag)
+    if (CS%docr_riv_flux > 0 .and. CS%tracer_inds%docr_ind > 0) &
+      call post_data(CS%docr_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%docr_ind), CS%diag)
+    if (CS%alk_riv_flux > 0 .and. CS%tracer_inds%alk_ind > 0) &
+      call post_data(CS%alk_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%alk_ind), CS%diag)
+    if (CS%alk_alt_co2_riv_flux > 0  .and. CS%tracer_inds%alk_alt_co2_ind > 0) &
+      call post_data(CS%alk_alt_co2_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%alk_alt_co2_ind), &
+          CS%diag)
+    if (CS%dic_riv_flux > 0 .and. CS%tracer_inds%dic_ind > 0) &
+      call post_data(CS%dic_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%dic_ind), CS%diag)
+    if (CS%dic_alt_co2_riv_flux > 0 .and. CS%tracer_inds%dic_alt_co2_ind > 0) &
+      call post_data(CS%dic_alt_co2_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%dic_alt_co2_ind), &
+          CS%diag)
+  endif
+
+  if (CS%abio_dic_on) then
+    if (CS%d14c_id > 0) &
+      call post_data(CS%d14c_id, CS%d14c, CS%diag)
+  endif
 
 end subroutine MARBL_tracers_column_physics
 
@@ -2057,44 +2099,6 @@ subroutine MARBL_tracers_set_forcing(day_start, G, CS)
       CS%restoring_in(i,j,k,m) = G%mask2dT(i,j) * CS%restoring_in(i,j,k,m)
     enddo ; enddo ; enddo
   enddo
-
-  ! Post Forcing to Diagnostics
-  if (CS%read_riv_fluxes) then
-    if (CS%no3_riv_flux > 0 .and. CS%tracer_inds%no3_ind > 0) &
-      call post_data(CS%no3_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%no3_ind), CS%diag)
-    if (CS%po4_riv_flux > 0 .and. CS%tracer_inds%po4_ind > 0) &
-      call post_data(CS%po4_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%po4_ind), CS%diag)
-    if (CS%don_riv_flux > 0 .and. CS%tracer_inds%don_ind > 0) &
-      call post_data(CS%don_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%don_ind), CS%diag)
-    if (CS%donr_riv_flux > 0 .and. CS%tracer_inds%donr_ind > 0) &
-      call post_data(CS%donr_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%donr_ind), CS%diag)
-    if (CS%dop_riv_flux > 0 .and. CS%tracer_inds%dop_ind > 0) &
-      call post_data(CS%dop_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%dop_ind), CS%diag)
-    if (CS%dopr_riv_flux > 0 .and. CS%tracer_inds%dopr_ind > 0) &
-      call post_data(CS%dopr_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%dopr_ind), CS%diag)
-    if (CS%sio3_riv_flux > 0 .and. CS%tracer_inds%sio3_ind > 0) &
-      call post_data(CS%sio3_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%sio3_ind), CS%diag)
-    if (CS%fe_riv_flux > 0 .and. CS%tracer_inds%fe_ind > 0) &
-      call post_data(CS%fe_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%fe_ind), CS%diag)
-    if (CS%doc_riv_flux > 0 .and. CS%tracer_inds%doc_ind > 0) &
-      call post_data(CS%doc_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%doc_ind), CS%diag)
-    if (CS%docr_riv_flux > 0 .and. CS%tracer_inds%docr_ind > 0) &
-      call post_data(CS%docr_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%docr_ind), CS%diag)
-    if (CS%alk_riv_flux > 0 .and. CS%tracer_inds%alk_ind > 0) &
-      call post_data(CS%alk_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%alk_ind), CS%diag)
-    if (CS%alk_alt_co2_riv_flux > 0  .and. CS%tracer_inds%alk_alt_co2_ind > 0) &
-      call post_data(CS%alk_alt_co2_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%alk_alt_co2_ind), &
-          CS%diag)
-    if (CS%dic_riv_flux > 0 .and. CS%tracer_inds%dic_ind > 0) &
-      call post_data(CS%dic_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%dic_ind), CS%diag)
-    if (CS%dic_alt_co2_riv_flux > 0 .and. CS%tracer_inds%dic_alt_co2_ind > 0) &
-      call post_data(CS%dic_alt_co2_riv_flux, CS%RIV_FLUXES(:,:,CS%tracer_inds%dic_alt_co2_ind), &
-          CS%diag)
-  endif
-  if (CS%abio_dic_on) then
-    if (CS%d14c_id > 0) &
-      call post_data(CS%d14c_id, CS%d14c, CS%diag)
-  endif
 
 end subroutine MARBL_tracers_set_forcing
 


### PR DESCRIPTION
passes (modified) pr_mom test suite, including baseline comparison to current dev/ncar

Modification to pr_mom test suite is to change the GW_JRA ERS test to a GW1850MARBL_JRA ERS test.

The baseline comparison in the MARBL test passes because the test suite is not checking MARBL output on native vertical grid (https://github.com/ESCOMP/MOM_interface/issues/323).

The fix is implemented by moving RIV_FLIX post_data calls from MARBL_tracers_set_forcing to MARBL_tracers_column_physics.
The post_data call for atmospheric Delta-14C is also moved.
The PR also avoids unneeded computation of riv_flux_loc if read_riv_fluxes=.false.